### PR TITLE
Add get_default_configuration and defaults yaml

### DIFF
--- a/src/pseudopeople/default_configuration.yaml
+++ b/src/pseudopeople/default_configuration.yaml
@@ -1,0 +1,200 @@
+# Default noising configuration
+# structure follows:
+#   Row noise: `form.noise_type`
+#   Column-wise parameters: `form.noise_type.column.noise_parameter`
+
+decennial_census:
+    omission: 0.0145
+    duplication: 0.05
+    nickname:
+        first_name:
+            row_noise_level: 0.01
+    fake_names:
+        first_name:
+            row_noise_level: 0.01
+    missing_data:
+        first_name:
+            row_noise_level: 0.01
+        age:
+            row_noise_level: 0.01
+        zipcode:
+            row_noise_level: 0.01
+    phonetic:
+        first_name:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+    ocr:
+        first_name:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        age:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+    typographic:
+        first_name:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        age:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        zipcode:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+    zipcode_miswriting:
+        zipcode:
+            row_noise_level: 0.01
+            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
+    age_miswriting:
+        age:
+            row_noise_level: 0.01
+            age_miswriting: [1, -1]
+
+
+
+
+
+american_communities_survey:
+    omission: 0.0145
+    duplication: 0.05
+    nickname:
+        first_name:
+            row_noise_level: 0.01
+    fake_names:
+        first_name:
+            row_noise_level: 0.01
+    missing_data:
+        first_name:
+            row_noise_level: 0.01
+        age:
+            row_noise_level: 0.01
+        zipcode:
+            row_noise_level: 0.01
+    phonetic:
+        first_name:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+    ocr:
+        first_name:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        age:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+    typographic:
+        first_name:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        age:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        zipcode:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+    zipcode_miswriting:
+        zipcode:
+            row_noise_level: 0.01
+            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
+    age_miswriting:
+        age:
+            row_noise_level: 0.01
+            age_miswriting: [1, -1]
+
+current_population_survey:
+    omission: 0.2905
+    duplication: 0.05
+    nickname:
+        first_name:
+            row_noise_level: 0.01
+    fake_names:
+        first_name:
+            row_noise_level: 0.01
+    missing_data:
+        first_name:
+            row_noise_level: 0.01
+        age:
+            row_noise_level: 0.01
+        zipcode:
+            row_noise_level: 0.01
+    phonetic:
+        first_name:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+    ocr:
+        first_name:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        age:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+    typographic:
+        first_name:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        age:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        zipcode:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+    zipcode_miswriting:
+        zipcode:
+            row_noise_level: 0.01
+            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
+    age_miswriting:
+        age:
+            row_noise_level: 0.01
+            age_miswriting: [1, -1]
+
+
+women_infants_and_children:
+    omission: 0.0
+    duplication: 0.05
+    nickname:
+        first_name:
+            row_noise_level: 0.01
+    fake_names:
+        first_name:
+            row_noise_level: 0.01
+    missing_data:
+        first_name:
+            row_noise_level: 0.01
+        age:
+            row_noise_level: 0.01
+        zipcode:
+            row_noise_level: 0.01
+    phonetic:
+        first_name:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+    ocr:
+        first_name:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        age:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+    typographic:
+        first_name:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        age:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        zipcode:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+    zipcode_miswriting:
+        zipcode:
+            row_noise_level: 0.01
+            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
+    age_miswriting:
+        age:
+            row_noise_level: 0.01
+            age_miswriting: [1, -1]
+
+# TODO: add the rest of observers/forms with RT input
+#social_security:
+#
+#taxes_w2_and_1099:
+#
+#taxes_1040:

--- a/src/pseudopeople/default_configuration.yaml
+++ b/src/pseudopeople/default_configuration.yaml
@@ -1,196 +1,171 @@
 # Default noising configuration
 # structure follows:
 #   Row noise: `form.noise_type`
-#   Column-wise parameters: `form.noise_type.column.noise_parameter`
+#   Column-wise parameters: `form.column.noise_type.noise_parameter`
 
 decennial_census:
     omission: 0.0145
     duplication: 0.05
-    nickname:
-        first_name:
+    first_name:
+        nickname:
             row_noise_level: 0.01
-    fake_names:
-        first_name:
+        fake_names:
             row_noise_level: 0.01
-    missing_data:
-        first_name:
+        missing_data:
             row_noise_level: 0.01
-        age:
-            row_noise_level: 0.01
-        zipcode:
-            row_noise_level: 0.01
-    phonetic:
-        first_name:
+        phonetic:
             row_noise_level: 0.01
             token_noise_level: 0.1
-    ocr:
-        first_name:
+        ocr:
             row_noise_level: 0.01
             token_noise_level: 0.1
-        age:
+        typographic:
             row_noise_level: 0.01
             token_noise_level: 0.1
-    typographic:
-        first_name:
+    age:
+        missing_data:
+            row_noise_level: 0.01
+        ocr:
             row_noise_level: 0.01
             token_noise_level: 0.1
-        age:
+        typographic:
             row_noise_level: 0.01
             token_noise_level: 0.1
-        zipcode:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-    zipcode_miswriting:
-        zipcode:
-            row_noise_level: 0.01
-            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
-    age_miswriting:
-        age:
+        age_miswriting:
             row_noise_level: 0.01
             age_miswriting: [1, -1]
-
-
-
-
+    zipcode:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        zipcode_miswriting:
+            row_noise_level: 0.01
+            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
 
 american_communities_survey:
     omission: 0.0145
     duplication: 0.05
-    nickname:
-        first_name:
+    first_name:
+        nickname:
             row_noise_level: 0.01
-    fake_names:
-        first_name:
+        fake_names:
             row_noise_level: 0.01
-    missing_data:
-        first_name:
+        missing_data:
             row_noise_level: 0.01
-        age:
-            row_noise_level: 0.01
-        zipcode:
-            row_noise_level: 0.01
-    phonetic:
-        first_name:
+        phonetic:
             row_noise_level: 0.01
             token_noise_level: 0.1
-    ocr:
-        first_name:
+        ocr:
             row_noise_level: 0.01
             token_noise_level: 0.1
-        age:
+        typographic:
             row_noise_level: 0.01
             token_noise_level: 0.1
-    typographic:
-        first_name:
+    age:
+        missing_data:
+            row_noise_level: 0.01
+        ocr:
             row_noise_level: 0.01
             token_noise_level: 0.1
-        age:
+        typographic:
             row_noise_level: 0.01
             token_noise_level: 0.1
-        zipcode:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-    zipcode_miswriting:
-        zipcode:
-            row_noise_level: 0.01
-            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
-    age_miswriting:
-        age:
+        age_miswriting:
             row_noise_level: 0.01
             age_miswriting: [1, -1]
+    zipcode:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        zipcode_miswriting:
+            row_noise_level: 0.01
+            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
 
 current_population_survey:
     omission: 0.2905
     duplication: 0.05
-    nickname:
-        first_name:
+    first_name:
+        nickname:
             row_noise_level: 0.01
-    fake_names:
-        first_name:
+        fake_names:
             row_noise_level: 0.01
-    missing_data:
-        first_name:
+        missing_data:
             row_noise_level: 0.01
-        age:
-            row_noise_level: 0.01
-        zipcode:
-            row_noise_level: 0.01
-    phonetic:
-        first_name:
+        phonetic:
             row_noise_level: 0.01
             token_noise_level: 0.1
-    ocr:
-        first_name:
+        ocr:
             row_noise_level: 0.01
             token_noise_level: 0.1
-        age:
+        typographic:
             row_noise_level: 0.01
             token_noise_level: 0.1
-    typographic:
-        first_name:
+    age:
+        missing_data:
+            row_noise_level: 0.01
+        ocr:
             row_noise_level: 0.01
             token_noise_level: 0.1
-        age:
+        typographic:
             row_noise_level: 0.01
             token_noise_level: 0.1
-        zipcode:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-    zipcode_miswriting:
-        zipcode:
-            row_noise_level: 0.01
-            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
-    age_miswriting:
-        age:
+        age_miswriting:
             row_noise_level: 0.01
             age_miswriting: [1, -1]
-
+    zipcode:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        zipcode_miswriting:
+            row_noise_level: 0.01
+            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
 
 women_infants_and_children:
     omission: 0.0
     duplication: 0.05
-    nickname:
-        first_name:
+    first_name:
+        nickname:
             row_noise_level: 0.01
-    fake_names:
-        first_name:
+        fake_names:
             row_noise_level: 0.01
-    missing_data:
-        first_name:
+        missing_data:
             row_noise_level: 0.01
-        age:
-            row_noise_level: 0.01
-        zipcode:
-            row_noise_level: 0.01
-    phonetic:
-        first_name:
+        phonetic:
             row_noise_level: 0.01
             token_noise_level: 0.1
-    ocr:
-        first_name:
+        ocr:
             row_noise_level: 0.01
             token_noise_level: 0.1
-        age:
+        typographic:
             row_noise_level: 0.01
             token_noise_level: 0.1
-    typographic:
-        first_name:
+    age:
+        missing_data:
+            row_noise_level: 0.01
+        ocr:
             row_noise_level: 0.01
             token_noise_level: 0.1
-        age:
+        typographic:
             row_noise_level: 0.01
             token_noise_level: 0.1
-        zipcode:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-    zipcode_miswriting:
-        zipcode:
-            row_noise_level: 0.01
-            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
-    age_miswriting:
-        age:
+        age_miswriting:
             row_noise_level: 0.01
             age_miswriting: [1, -1]
+    zipcode:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+        zipcode_miswriting:
+            row_noise_level: 0.01
+            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
 
 # TODO: add the rest of observers/forms with RT input
 #social_security:

--- a/src/pseudopeople/entities.py
+++ b/src/pseudopeople/entities.py
@@ -5,6 +5,7 @@ from pseudopeople import noise_functions
 from pseudopeople.entity_types import ColumnNoiseType, RowNoiseType
 
 
+# todo: is "form" the right word? Ask RT
 class Form(Enum):
     CENSUS = "decennial_census"
     ACS = "american_communities_survey"
@@ -20,7 +21,9 @@ class __Columns(NamedTuple):
     MIDDLE_INITIAL: str = "middle_initial"
     LAST_NAME: str = "last_name"
     STREET_NAME: str = "street_name"
+    ZIP_CODE: str = "zipcode"
     CITY: str = "city"
+    AGE: str = "age"
     # todo finish filling in columns
 
 
@@ -43,6 +46,21 @@ class __NoiseTypes(NamedTuple):
     )
     PHONETIC: ColumnNoiseType = ColumnNoiseType(
         "phonetic", noise_functions.generate_phonetic_errors
+    )
+    MISSING_DATA: ColumnNoiseType = ColumnNoiseType(
+        # todo: implement the noise fn
+        "missing_data",
+        lambda: (_ for _ in ()).throw(NotImplemented("TBD!")),
+    )
+    TYPOGRAPHIC: ColumnNoiseType = ColumnNoiseType(
+        # todo: implement the noise fn
+        "typographic",
+        lambda: (_ for _ in ()).throw(NotImplemented("TBD!")),
+    )
+    OCR: ColumnNoiseType = ColumnNoiseType(
+        # todo: implement the noise fn
+        "ocr",
+        lambda: (_ for _ in ()).throw(NotImplemented("TBD!")),
     )
 
 

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -12,10 +12,13 @@ def get_randomness_stream(form: Form, seed: int) -> RandomnessStream:
 
 
 def get_default_configuration() -> ConfigTree:
+    import pseudopeople
+
     default_config_layers = [
         "base",
     ]
     noising_configuration = ConfigTree(layers=default_config_layers)
-    yaml_path = Path("default_configuration.yaml")
+    BASE_DIR = Path(pseudopeople.__file__).resolve().parent
+    yaml_path = BASE_DIR / "default_configuration.yaml"
     noising_configuration.update(yaml_path, layer="base")
     return noising_configuration

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -1,4 +1,7 @@
+from pathlib import Path
+
 import pandas as pd
+from vivarium.framework.configuration import ConfigTree, ConfigurationError
 from vivarium.framework.randomness import RandomnessStream
 
 from pseudopeople.entities import Form
@@ -6,3 +9,13 @@ from pseudopeople.entities import Form
 
 def get_randomness_stream(form: Form, seed: int) -> RandomnessStream:
     return RandomnessStream(form.value, lambda: pd.Timestamp("2020-04-01"), seed)
+
+
+def get_default_configuration() -> ConfigTree:
+    default_config_layers = [
+        "base",
+    ]
+    noising_configuration = ConfigTree(layers=default_config_layers)
+    yaml_path = Path("default_configuration.yaml")
+    noising_configuration.update(yaml_path, layer="base")
+    return noising_configuration


### PR DESCRIPTION
## Add get_default_configuration and defaults yaml

### Description
- *Category*: feature
- *JIRA issue*: [MIC-3860](https://jira.ihme.washington.edu/browse/MIC-3860)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#noise-functions

#### Changes
- Adds a `get_default_configuration` utility function that returns a ConfigTree object
- Adds a yaml for holding defaults. It is partially complete and will be updated with RT feedback and additional development.

### Testing
Imported the utility, executed, and got an expected ConfigTree:

```
import pandas as pd
from pathlib import Path
from pseudopeople import utilities

utilities.get_default_configuration().to_dict()
```

gave output:
```
{'decennial_census': {'omission': 0.0145,
  'duplication': 0.05,
  'first_name': {'nickname': {'row_noise_level': 0.01},
   'fake_names': {'row_noise_level': 0.01},
   'missing_data': {'row_noise_level': 0.01},
   'phonetic': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'ocr': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'typographic': {'row_noise_level': 0.01, 'token_noise_level': 0.1}},
  'age': {'missing_data': {'row_noise_level': 0.01},
   'ocr': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'typographic': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'age_miswriting': {'row_noise_level': 0.01, 'age_miswriting': [1, -1]}},
  'zipcode': {'missing_data': {'row_noise_level': 0.01},
   'typographic': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'zipcode_miswriting': {'row_noise_level': 0.01,
    'zipcode_miswriting': [0.04, 0.04, 0.2, 0.36, 0.36]}}},
 'american_communities_survey': {'omission': 0.0145,
  'duplication': 0.05,
  'first_name': {'nickname': {'row_noise_level': 0.01},
   'fake_names': {'row_noise_level': 0.01},
   'missing_data': {'row_noise_level': 0.01},
   'phonetic': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'ocr': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'typographic': {'row_noise_level': 0.01, 'token_noise_level': 0.1}},
  'age': {'missing_data': {'row_noise_level': 0.01},
   'ocr': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'typographic': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'age_miswriting': {'row_noise_level': 0.01, 'age_miswriting': [1, -1]}},
  'zipcode': {'missing_data': {'row_noise_level': 0.01},
   'typographic': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'zipcode_miswriting': {'row_noise_level': 0.01,
    'zipcode_miswriting': [0.04, 0.04, 0.2, 0.36, 0.36]}}},
 'current_population_survey': {'omission': 0.2905,
  'duplication': 0.05,
  'first_name': {'nickname': {'row_noise_level': 0.01},
   'fake_names': {'row_noise_level': 0.01},
   'missing_data': {'row_noise_level': 0.01},
   'phonetic': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'ocr': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'typographic': {'row_noise_level': 0.01, 'token_noise_level': 0.1}},
  'age': {'missing_data': {'row_noise_level': 0.01},
   'ocr': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'typographic': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'age_miswriting': {'row_noise_level': 0.01, 'age_miswriting': [1, -1]}},
  'zipcode': {'missing_data': {'row_noise_level': 0.01},
   'typographic': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'zipcode_miswriting': {'row_noise_level': 0.01,
    'zipcode_miswriting': [0.04, 0.04, 0.2, 0.36, 0.36]}}},
 'women_infants_and_children': {'omission': 0.0,
  'duplication': 0.05,
  'first_name': {'nickname': {'row_noise_level': 0.01},
   'fake_names': {'row_noise_level': 0.01},
   'missing_data': {'row_noise_level': 0.01},
   'phonetic': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'ocr': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'typographic': {'row_noise_level': 0.01, 'token_noise_level': 0.1}},
  'age': {'missing_data': {'row_noise_level': 0.01},
   'ocr': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'typographic': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'age_miswriting': {'row_noise_level': 0.01, 'age_miswriting': [1, -1]}},
  'zipcode': {'missing_data': {'row_noise_level': 0.01},
   'typographic': {'row_noise_level': 0.01, 'token_noise_level': 0.1},
   'zipcode_miswriting': {'row_noise_level': 0.01,
    'zipcode_miswriting': [0.04, 0.04, 0.2, 0.36, 0.36]}}}}
```

