### PR TITLE
Missing data noise function

### DIFF
--- a/src/pseudopeople/entities.py
+++ b/src/pseudopeople/entities.py
@@ -50,7 +50,7 @@ class __NoiseTypes(NamedTuple):
     MISSING_DATA: ColumnNoiseType = ColumnNoiseType(
         # todo: implement the noise fn
         "missing_data",
-        lambda: (_ for _ in ()).throw(NotImplemented("TBD!")),
+        noise_functions.missing_data,
     )
     TYPOGRAPHIC: ColumnNoiseType = ColumnNoiseType(
         # todo: implement the noise fn

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable
+from typing import Any, Callable
 
 import pandas as pd
 from vivarium import ConfigTree
@@ -41,17 +41,19 @@ class ColumnNoiseType:
     "phonetic").
 
     The noise function takes as input a Series, the ConfigTree object for this
-    ColumnNoise operation, and a RandomnessStream for controlling randomness. It
-    applies the noising operation to the Series and returns the modified Series.
+    ColumnNoise operation, a RandomnessStream for controlling randomness, and
+    an additional key for the RandomnessStream. It applies the noising operation
+    to the Series and returns the modified Series.
     """
 
     name: str
-    noise_function: Callable[[pd.Series, ConfigTree, RandomnessStream], pd.Series]
+    noise_function: Callable[[pd.Series, ConfigTree, RandomnessStream, Any], pd.Series]
 
     def __call__(
         self,
         column: pd.Series,
         configuration: ConfigTree,
         randomness_stream: RandomnessStream,
+        additional_key: Any,
     ) -> pd.Series:
-        return self.noise_function(column, configuration, randomness_stream)
+        return self.noise_function(column, configuration, randomness_stream, additional_key)

--- a/src/pseudopeople/noise.py
+++ b/src/pseudopeople/noise.py
@@ -46,7 +46,7 @@ def noise_form(
 
                 column_configuration = noise_configuration[column]
                 form_data[column] = noise_type(
-                    form_data[column], column_configuration, randomness
+                    form_data[column], column_configuration, randomness, column
                 )
         else:
             raise TypeError(

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pandas as pd
 from vivarium import ConfigTree
 from vivarium.framework.randomness import RandomnessStream
@@ -70,6 +72,36 @@ def generate_phonetic_errors(
     :return:
     """
     # todo actually generate fake names
+    return column
+
+
+def missing_data(
+    column: pd.Series,
+    configuration: ConfigTree,
+    randomness_stream: RandomnessStream,
+    additional_key: Any,
+) -> pd.Series:
+    """
+    Function that takes a column and blanks out a configurable portion of it's data to be missing.
+
+    :param column:  pd.Series of data
+    :param configuration: ConfigTree with rate at which to blank the data in column.
+    :param randomness_stream:  RandomnessStream to utilize Vivarium CRN.
+    :param additional_key: Key for RandomnessStream
+    :returns: pd.Series of column with configured amount of data missing as an empty string.
+    """
+
+    # Avoid SettingWithCopyWarning
+    column = column.copy()
+    noise_level = configuration.row_noise_level
+    # Get rows to noise
+    to_noise_idx = randomness_stream.filter_for_probability(
+        column.index,
+        probability=noise_level,
+        additional_key=f"{additional_key}_missing_data_filter",
+    )
+    column.loc[to_noise_idx] = ""
+
     return column
 
 


### PR DESCRIPTION
Missing data noise function

## Missing data noise function.

### Adds missing data noise function to blank data for a provided pandas series.
- *Category*: Implementation
- *JIRA issue*: [MIC-3872](https://jira.ihme.washington.edu/browse/MIC-3872)

<!-- 
-Added missing data noise function
-Added passing of an additional key for randomness stream for column noise types which will be the column name being noised.
--> 

### Testing
<!--
Tested function and saw blanked rows matching input value for missingness.
-->

