### PR TITLE
Add census generation interface and implementation

### DIFF
--- a/src/pseudopeople/__init__.py
+++ b/src/pseudopeople/__init__.py
@@ -8,3 +8,4 @@ from pseudopeople.__about__ import (
     __uri__,
     __version__,
 )
+from pseudopeople.interface import generate_decennial_census

--- a/src/pseudopeople/entities.py
+++ b/src/pseudopeople/entities.py
@@ -48,19 +48,17 @@ class __NoiseTypes(NamedTuple):
         "phonetic", noise_functions.generate_phonetic_errors
     )
     MISSING_DATA: ColumnNoiseType = ColumnNoiseType(
-        # todo: implement the noise fn
         "missing_data",
         noise_functions.missing_data,
     )
     TYPOGRAPHIC: ColumnNoiseType = ColumnNoiseType(
-        # todo: implement the noise fn
         "typographic",
-        lambda: (_ for _ in ()).throw(NotImplemented("TBD!")),
+        noise_functions.generate_typographical_errors,
     )
     OCR: ColumnNoiseType = ColumnNoiseType(
         # todo: implement the noise fn
         "ocr",
-        lambda: (_ for _ in ()).throw(NotImplemented("TBD!")),
+        noise_functions.generate_ocr_errors,
     )
 
 

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -21,15 +21,18 @@ class RowNoiseType:
     """
 
     name: str
-    noise_function: Callable[[pd.DataFrame, float, RandomnessStream], pd.DataFrame]
+    noise_function: Callable[[pd.DataFrame, float, RandomnessStream, str], pd.DataFrame]
 
     def __call__(
         self,
         form_data: pd.DataFrame,
         configuration: float,
         randomness_stream: RandomnessStream,
+        additional_key: str,
     ) -> pd.DataFrame:
-        return self.noise_function(form_data, configuration, randomness_stream)
+        return self.noise_function(
+            form_data, configuration, randomness_stream, additional_key
+        )
 
 
 @dataclass

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -21,10 +21,15 @@ def generate_decennial_census(path: Union[Path, str]):
     return noise_form(Form.CENSUS, data, configuration, seed=0)  # XXX: what is seed here?
 
 
-# Testing
+# Manual testing helper
 if __name__ == "__main__":
     args = sys.argv[1:]
     if len(args) == 1:
         my_path = Path(args[0])
+        src = pd.read_csv(my_path)
         out = generate_decennial_census(my_path)
+        diff = src[
+            ~src.astype(str).apply(tuple, 1).isin(out.astype(str).apply(tuple, 1))
+        ]  # get all changed rows
         print(out.head())
+        print(diff)

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+from typing import Union
+
+import pandas as pd
+
+from pseudopeople.entities import Form
+from pseudopeople.noise import noise_form
+from pseudopeople.utilities import get_default_configuration
+
+
+def generate_decennial_census(path: Union[Path, str]):
+    """
+    Generates a noised decennial census data from un-noised data.
+
+    :param path: A path to the un-noised source census data
+    :return: A pd.DataFrame of noised census data
+    """
+    configuration = get_default_configuration()
+    data = pd.read_csv(path)
+    return noise_form(Form.CENSUS, data, configuration, seed=0)  # XXX: what is seed here?
+
+
+# Testing
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if len(args) == 1:
+        my_path = Path(args[0])
+        out = generate_decennial_census(my_path)
+        print(out.head())

--- a/src/pseudopeople/noise.py
+++ b/src/pseudopeople/noise.py
@@ -33,20 +33,28 @@ def noise_form(
     randomness = get_randomness_stream(form, seed)
 
     for noise_type in NOISE_TYPES:
-        noise_configuration = configuration[form][noise_type]
+        noise_configuration = configuration[form.value]
         if isinstance(noise_type, RowNoiseType):
             # Apply row noise
-            form_data = noise_type(form_data, noise_configuration, randomness)
+            print(noise_type.name)
+            form_data = noise_type(
+                form_data, noise_configuration, randomness, noise_type.name
+            )
 
         elif isinstance(noise_type, ColumnNoiseType):
+            columns_to_noise = [
+                col
+                for col in configuration[form.value].keys()
+                if col in form_data.columns
+                and noise_type.name in configuration[form.value][col].to_dict().keys()
+            ]
             # Apply column noise to each column as appropriate
-            for column in form_data.columns:
-                if column not in noise_configuration:
-                    continue
-
-                column_configuration = noise_configuration[column]
+            for column in columns_to_noise:
                 form_data[column] = noise_type(
-                    form_data[column], column_configuration, randomness, column
+                    form_data[column],
+                    noise_configuration[column][noise_type.name],
+                    randomness,
+                    column,
                 )
         else:
             raise TypeError(

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -6,13 +6,17 @@ from vivarium.framework.randomness import RandomnessStream
 
 
 def omit_rows(
-    form_data: pd.DataFrame, configuration: float, randomness_stream: RandomnessStream
+    form_data: pd.DataFrame,
+    configuration: ConfigTree,
+    randomness_stream: RandomnessStream,
+    additional_key: Any,
 ) -> pd.DataFrame:
     """
 
     :param form_data:
     :param configuration:
     :param randomness_stream:
+    :param additional_key: Key for RandomnessStream
     :return:
     """
     # todo actually omit rows
@@ -20,13 +24,17 @@ def omit_rows(
 
 
 def duplicate_rows(
-    form_data: pd.DataFrame, configuration: float, randomness_stream: RandomnessStream
+    form_data: pd.DataFrame,
+    configuration: ConfigTree,
+    randomness_stream: RandomnessStream,
+    additional_key: Any,
 ) -> pd.DataFrame:
     """
 
     :param form_data:
     :param configuration:
     :param randomness_stream:
+    :param additional_key: Key for RandomnessStream
     :return:
     """
     # todo actually duplicate rows
@@ -34,13 +42,17 @@ def duplicate_rows(
 
 
 def generate_nicknames(
-    column: pd.Series, configuration: ConfigTree, randomness_stream: RandomnessStream
+    column: pd.Series,
+    configuration: ConfigTree,
+    randomness_stream: RandomnessStream,
+    additional_key: Any,
 ) -> pd.Series:
     """
 
     :param column:
     :param configuration:
     :param randomness_stream:
+    :param additional_key: Key for RandomnessStream
     :return:
     """
     # todo actually generate nicknames
@@ -48,13 +60,17 @@ def generate_nicknames(
 
 
 def generate_fake_names(
-    column: pd.Series, configuration: ConfigTree, randomness_stream: RandomnessStream
+    column: pd.Series,
+    configuration: ConfigTree,
+    randomness_stream: RandomnessStream,
+    additional_key: Any,
 ) -> pd.Series:
     """
 
     :param column:
     :param configuration:
     :param randomness_stream:
+    :param additional_key: Key for RandomnessStream
     :return:
     """
     # todo actually generate fake names
@@ -62,13 +78,17 @@ def generate_fake_names(
 
 
 def generate_phonetic_errors(
-    column: pd.Series, configuration: ConfigTree, randomness_stream: RandomnessStream
+    column: pd.Series,
+    configuration: ConfigTree,
+    randomness_stream: RandomnessStream,
+    additional_key: Any,
 ) -> pd.Series:
     """
 
     :param column:
     :param configuration:
     :param randomness_stream:
+    :param additional_key: Key for RandomnessStream
     :return:
     """
     # todo actually generate fake names
@@ -82,7 +102,7 @@ def missing_data(
     additional_key: Any,
 ) -> pd.Series:
     """
-    Function that takes a column and blanks out a configurable portion of it's data to be missing.
+    Function that takes a column and blanks out a configurable portion of its data to be missing.
 
     :param column:  pd.Series of data
     :param configuration: ConfigTree with rate at which to blank the data in column.
@@ -102,6 +122,42 @@ def missing_data(
     )
     column.loc[to_noise_idx] = ""
 
+    return column
+
+
+def generate_typographical_errors(
+    column: pd.Series,
+    configuration: ConfigTree,
+    randomness_stream: RandomnessStream,
+    additional_key: Any,
+) -> pd.Series:
+    """
+
+    :param column:
+    :param configuration:
+    :param randomness_stream:
+    :param additional_key: Key for RandomnessStream
+    :return:
+    """
+    # todo actually generate typographical errors
+    return column
+
+
+def generate_ocr_errors(
+    column: pd.Series,
+    configuration: ConfigTree,
+    randomness_stream: RandomnessStream,
+    additional_key: Any,
+) -> pd.Series:
+    """
+
+    :param column:
+    :param configuration:
+    :param randomness_stream:
+    :param additional_key: Key for RandomnessStream
+    :return:
+    """
+    # todo actually generate OCR errors
     return column
 
 


### PR DESCRIPTION
## Add census generation interface

### Description
- *Category*: feature
- *JIRA issue*: [MIC-3856](https://jira.ihme.washington.edu/browse/MIC-3856)

#### Changes
- Adds the generate_decennial_census function as an interface
- Adds interface.py and a "test" main for debugging/testing purposes
- Standardizes noise function parameters to use additional_key
- Adds stubs for noise functions needed for testing

### Testing
Ran interface.py against an existing census csv. Got noised results from missing_data as expected.
