### PR TITLE
Support loading a yaml configuration file for overriding default configurations

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -6,22 +6,30 @@ import pandas as pd
 
 from pseudopeople.entities import Form
 from pseudopeople.noise import noise_form
-from pseudopeople.utilities import get_default_configuration
+from pseudopeople.utilities import (
+    get_default_configuration,
+    update_configuration_with_yaml,
+)
 
 
 # TODO: add year as parameter to select the year of the decennial census to generate (MIC-3909)
 # TODO: add default path: have the package install the small data in a known location and then
 #  to make this parameter optional, with the default being the location of the small data that
 #  is installed with the package (MIC-3884)
-def generate_decennial_census(path: Union[Path, str], seed: int = 0):
+def generate_decennial_census(
+    path: Union[Path, str], seed: int = 0, override: Union[Path, str] = None
+):
     """
     Generates a noised decennial census data from un-noised data.
 
     :param path: A path to the un-noised source census data
     :param seed: An integer seed for randomness
+    :param override: A path to a configuration YAML file to override default configuration
     :return: A pd.DataFrame of noised census data
     """
     configuration = get_default_configuration()
+    if override:
+        configuration = update_configuration_with_yaml(configuration, override)
     data = pd.read_csv(path)
     return noise_form(Form.CENSUS, data, configuration, seed)
 

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -14,19 +14,19 @@ from pseudopeople.utilities import get_configuration
 #  to make this parameter optional, with the default being the location of the small data that
 #  is installed with the package (MIC-3884)
 def generate_decennial_census(
-    path: Union[Path, str], seed: int = 0, override: Union[Path, str] = None
+    path: Union[Path, str], seed: int = 0, configuration: Union[Path, str] = None
 ):
     """
     Generates a noised decennial census data from un-noised data.
 
     :param path: A path to the un-noised source census data
     :param seed: An integer seed for randomness
-    :param override: (optional) A path to a configuration YAML file to override default configuration
+    :param configuration: (optional) A path to a configuration YAML file to modify default values
     :return: A pd.DataFrame of noised census data
     """
-    configuration = get_configuration(override)
+    configuration_tree = get_configuration(configuration)
     data = pd.read_csv(path)
-    return noise_form(Form.CENSUS, data, configuration, seed)
+    return noise_form(Form.CENSUS, data, configuration_tree, seed)
 
 
 # Manual testing helper

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -6,10 +6,7 @@ import pandas as pd
 
 from pseudopeople.entities import Form
 from pseudopeople.noise import noise_form
-from pseudopeople.utilities import (
-    get_default_configuration,
-    update_configuration_with_yaml,
-)
+from pseudopeople.utilities import get_configuration
 
 
 # TODO: add year as parameter to select the year of the decennial census to generate (MIC-3909)
@@ -24,12 +21,10 @@ def generate_decennial_census(
 
     :param path: A path to the un-noised source census data
     :param seed: An integer seed for randomness
-    :param override: A path to a configuration YAML file to override default configuration
+    :param override: (optional) A path to a configuration YAML file to override default configuration
     :return: A pd.DataFrame of noised census data
     """
-    configuration = get_default_configuration()
-    if override:
-        configuration = update_configuration_with_yaml(configuration, override)
+    configuration = get_configuration(override)
     data = pd.read_csv(path)
     return noise_form(Form.CENSUS, data, configuration, seed)
 

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Union
 
 import pandas as pd
-from vivarium.framework.configuration import ConfigTree, ConfigurationError
+from vivarium.framework.configuration import ConfigTree
 from vivarium.framework.randomness import RandomnessStream
 
 from pseudopeople.entities import Form
@@ -12,28 +12,23 @@ def get_randomness_stream(form: Form, seed: int) -> RandomnessStream:
     return RandomnessStream(form.value, lambda: pd.Timestamp("2020-04-01"), seed)
 
 
-def get_default_configuration() -> ConfigTree:
+def get_configuration(user_yaml_path: Union[Path, str] = None) -> ConfigTree:
+    """
+    Gets a noising configuration ConfigTree, optionally overridden by a user-provided YAML.
+
+    :param user_yaml_path: A path to the YAML file defining user overrides for the defaults
+    :return: a ConfigTree object of the noising configuration
+    """
     import pseudopeople
 
     default_config_layers = [
         "base",
         "user",
     ]
-    noising_configuration = ConfigTree(layers=default_config_layers)
-    BASE_DIR = Path(pseudopeople.__file__).resolve().parent
-    yaml_path = BASE_DIR / "default_configuration.yaml"
-    noising_configuration.update(yaml_path, layer="base")
+    noising_configuration = ConfigTree(
+        data=Path(pseudopeople.__file__).resolve().parent / "default_configuration.yaml",
+        layers=default_config_layers,
+    )
+    if user_yaml_path:
+        noising_configuration.update(user_yaml_path, layer="user")
     return noising_configuration
-
-
-def update_configuration_with_yaml(
-    configuration: ConfigTree, yaml_path: Union[Path, str]
-) -> ConfigTree:
-    """
-    Updates a configuration ConfigTree with overrides from a provided YAML file.
-
-    :param configuration: A ConfigTree configuration to override with a given YAML file
-    :param yaml_path: A path to the YAML file defining overrides for configuration
-    :return: a ConfigTree object updated with the configuration from the YAML
-    """
-    return configuration.update(yaml_path, layer="user")

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Union
 
 import pandas as pd
 from vivarium.framework.configuration import ConfigTree, ConfigurationError
@@ -16,9 +17,23 @@ def get_default_configuration() -> ConfigTree:
 
     default_config_layers = [
         "base",
+        "user",
     ]
     noising_configuration = ConfigTree(layers=default_config_layers)
     BASE_DIR = Path(pseudopeople.__file__).resolve().parent
     yaml_path = BASE_DIR / "default_configuration.yaml"
     noising_configuration.update(yaml_path, layer="base")
     return noising_configuration
+
+
+def update_configuration_with_yaml(
+    configuration: ConfigTree, yaml_path: Union[Path, str]
+) -> ConfigTree:
+    """
+    Updates a configuration ConfigTree with overrides from a provided YAML file.
+
+    :param configuration: A ConfigTree configuration to override with a given YAML file
+    :param yaml_path: A path to the YAML file defining overrides for configuration
+    :return: a ConfigTree object updated with the configuration from the YAML
+    """
+    return configuration.update(yaml_path, layer="user")

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -9,7 +9,7 @@ from pseudopeople.noise_functions import (
     generate_phonetic_errors,
     missing_data,
 )
-from pseudopeople.utilities import get_default_configuration
+from pseudopeople.utilities import get_configuration
 
 RANDOMNESS = RandomnessStream(
     key="test_column_noise", clock=lambda: pd.Timestamp("2020-09-01"), seed=0
@@ -24,7 +24,7 @@ def string_series():
 
 @pytest.fixture(scope="module")
 def default_configuration():
-    return get_default_configuration()
+    return get_configuration()
 
 
 def test_missing_data(string_series, default_configuration):

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,8 +1,26 @@
+from pathlib import Path
+
 import pytest
 from vivarium.config_tree import ConfigTree
 
 from pseudopeople.entities import Form
-from pseudopeople.utilities import get_default_configuration
+from pseudopeople.utilities import (
+    get_default_configuration,
+    update_configuration_with_yaml,
+)
+
+
+@pytest.fixture
+def user_configuration_yaml(tmp_path):
+    text = """decennial_census:
+    omission: 0.05
+    first_name:
+        nickname:
+            row_noise_level: 0.05"""
+    user_config_path = Path(f"{tmp_path}/test_configuration.yaml")
+    with open(user_config_path, "w") as file:
+        file.write(text)
+    return user_config_path
 
 
 def test_default_configuration():
@@ -10,12 +28,17 @@ def test_default_configuration():
     assert config
     assert isinstance(config, ConfigTree)
     # TODO: From Rajan: We should test that this configuration actually matches
-    # what we'd expect it to be. We can do this either by comparing it to the
-    # values in the yaml file, or by just confirming that the correct call to
-    # config_tree.update() was made in the function. The latter seems preferable
-    # to me as a unit test.
+    #  what we'd expect it to be. We can do this either by comparing it to the
+    #  values in the yaml file, or by just confirming that the correct call to
+    #  config_tree.update() was made in the function. The latter seems preferable
+    #  to me as a unit test.
 
 
-@pytest.mark.skip(reason="TODO")
-def test_user_configuration_file():
-    pass
+def test_user_configuration_file(user_configuration_yaml):
+    """Test that a user config yaml will override the default configuration."""
+    config = get_default_configuration()
+    config = update_configuration_with_yaml(config, user_configuration_yaml)
+    assert (
+        config["decennial_census"]["omission"]
+        == config["decennial_census"]["first_name"]["nickname"]["row_noise_level"]
+    )

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,44 +1,30 @@
 from pathlib import Path
 
 import pytest
+import yaml
 from vivarium.config_tree import ConfigTree
 
-from pseudopeople.entities import Form
-from pseudopeople.utilities import (
-    get_default_configuration,
-    update_configuration_with_yaml,
-)
+from pseudopeople.utilities import get_configuration
 
 
 @pytest.fixture
 def user_configuration_yaml(tmp_path):
-    text = """decennial_census:
-    omission: 0.05
-    first_name:
-        nickname:
-            row_noise_level: 0.05"""
     user_config_path = Path(f"{tmp_path}/test_configuration.yaml")
+    config = {
+        "decennial_census": {
+            "omission": 0.05,
+            "first_name": {"nickname": {"row_noise_level": 0.05}},
+        }
+    }
     with open(user_config_path, "w") as file:
-        file.write(text)
+        yaml.dump(config, file)
     return user_config_path
 
 
-def test_default_configuration():
-    config = get_default_configuration()
+def test_get_configuration(user_configuration_yaml):
+    config = get_configuration()
     assert config
     assert isinstance(config, ConfigTree)
-    # TODO: From Rajan: We should test that this configuration actually matches
-    #  what we'd expect it to be. We can do this either by comparing it to the
-    #  values in the yaml file, or by just confirming that the correct call to
-    #  config_tree.update() was made in the function. The latter seems preferable
-    #  to me as a unit test.
 
-
-def test_user_configuration_file(user_configuration_yaml):
-    """Test that a user config yaml will override the default configuration."""
-    config = get_default_configuration()
-    config = update_configuration_with_yaml(config, user_configuration_yaml)
-    assert (
-        config["decennial_census"]["omission"]
-        == config["decennial_census"]["first_name"]["nickname"]["row_noise_level"]
-    )
+    overridden_config = get_configuration(user_configuration_yaml)
+    assert config != overridden_config


### PR DESCRIPTION
## Support loading a yaml configuration file for overriding default configurations

### Description
- *Category*: feature
- *JIRA issue*: [MIC-3866](https://jira.ihme.washington.edu/browse/MIC-3866)

#### Changes
- Refactors get_default_configuration to get_configuration, optionally taking a YAML as argument
- Adds configuration parameter to existing census generation function
- Adds test for getting the default configuration and for getting a configuration of defaults overridden by supplied YAML.
- Adds a "user" layer alongside "base" for the ConfigTree noising configuration object

### Testing
New tests work.
