### PR TITLE
census integration test

### DIFF
--- a/src/pseudopeople/default_configuration.yaml
+++ b/src/pseudopeople/default_configuration.yaml
@@ -7,169 +7,48 @@ decennial_census:
     omission: 0.0145
     duplication: 0.05
     first_name:
-        nickname:
-            row_noise_level: 0.01
-        fake_names:
-            row_noise_level: 0.01
         missing_data:
             row_noise_level: 0.01
-        phonetic:
+    middle_initial:
+        missing_data:
             row_noise_level: 0.01
-            token_noise_level: 0.1
-        ocr:
+    last_name:
+        missing_data:
             row_noise_level: 0.01
-            token_noise_level: 0.1
-        typographic:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
     age:
         missing_data:
             row_noise_level: 0.01
-        ocr:
+    date_of_birth:
+        missing_data:
             row_noise_level: 0.01
-            token_noise_level: 0.1
-        typographic:
+    street_number:
+        missing_data:
             row_noise_level: 0.01
-            token_noise_level: 0.1
-        age_miswriting:
+    street_name:
+        missing_data:
             row_noise_level: 0.01
-            age_miswriting: [1, -1]
+    unit_number:
+        missing_data:
+            row_noise_level: 0.01
+    city:
+        missing_data:
+            row_noise_level: 0.01
+    state:
+        missing_data:
+            row_noise_level: 0.01
     zipcode:
         missing_data:
             row_noise_level: 0.01
-        typographic:
+    relation_to_household_head:
+        missing_data:
             row_noise_level: 0.01
-            token_noise_level: 0.1
-        zipcode_miswriting:
+    sex:
+        missing_data:
             row_noise_level: 0.01
-            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
+    race_ethnicity:
+        missing_data:
+            row_noise_level: 0.01
+    housing_type:
+        missing_data:
+            row_noise_level: 0.01
 
-american_communities_survey:
-    omission: 0.0145
-    duplication: 0.05
-    first_name:
-        nickname:
-            row_noise_level: 0.01
-        fake_names:
-            row_noise_level: 0.01
-        missing_data:
-            row_noise_level: 0.01
-        phonetic:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        ocr:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        typographic:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-    age:
-        missing_data:
-            row_noise_level: 0.01
-        ocr:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        typographic:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        age_miswriting:
-            row_noise_level: 0.01
-            age_miswriting: [1, -1]
-    zipcode:
-        missing_data:
-            row_noise_level: 0.01
-        typographic:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        zipcode_miswriting:
-            row_noise_level: 0.01
-            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
-
-current_population_survey:
-    omission: 0.2905
-    duplication: 0.05
-    first_name:
-        nickname:
-            row_noise_level: 0.01
-        fake_names:
-            row_noise_level: 0.01
-        missing_data:
-            row_noise_level: 0.01
-        phonetic:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        ocr:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        typographic:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-    age:
-        missing_data:
-            row_noise_level: 0.01
-        ocr:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        typographic:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        age_miswriting:
-            row_noise_level: 0.01
-            age_miswriting: [1, -1]
-    zipcode:
-        missing_data:
-            row_noise_level: 0.01
-        typographic:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        zipcode_miswriting:
-            row_noise_level: 0.01
-            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
-
-women_infants_and_children:
-    omission: 0.0
-    duplication: 0.05
-    first_name:
-        nickname:
-            row_noise_level: 0.01
-        fake_names:
-            row_noise_level: 0.01
-        missing_data:
-            row_noise_level: 0.01
-        phonetic:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        ocr:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        typographic:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-    age:
-        missing_data:
-            row_noise_level: 0.01
-        ocr:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        typographic:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        age_miswriting:
-            row_noise_level: 0.01
-            age_miswriting: [1, -1]
-    zipcode:
-        missing_data:
-            row_noise_level: 0.01
-        typographic:
-            row_noise_level: 0.01
-            token_noise_level: 0.1
-        zipcode_miswriting:
-            row_noise_level: 0.01
-            zipcode_miswriting: [0.04, 0.04, 0.2, 0.36, 0.36]
-
-# TODO: add the rest of observers/forms with RT input
-#social_security:
-#
-#taxes_w2_and_1099:
-#
-#taxes_1040:

--- a/src/pseudopeople/entities.py
+++ b/src/pseudopeople/entities.py
@@ -31,13 +31,37 @@ COLUMNS = __Columns()
 
 
 class __NoiseTypes(NamedTuple):
-    """
-    Container for all noise types in the order in which they should be applied.
+    """Container for all noise types in the order in which they should be applied:
+    omissions, duplications, missing data, incorrect selection, copy from w/in
+    household, month and day swaps, zip code miswriting, age miswriting,
+    numeric miswriting, nicknames, fake names, phonetic, OCR, typographic"
     """
 
     # todo finish filling in noise types in the correct order per the docs
     OMISSION: RowNoiseType = RowNoiseType("omission", noise_functions.omit_rows)
     DUPLICATION: RowNoiseType = RowNoiseType("duplication", noise_functions.duplicate_rows)
+    MISSING_DATA: ColumnNoiseType = ColumnNoiseType(
+        "missing_data",
+        noise_functions.generate_missing_data,
+    )
+    INCORRECT_SELECTION: ColumnNoiseType = ColumnNoiseType(
+        "incorrect_selection", noise_functions.generate_incorrect_selections
+    )
+    COPY_FROM_WITHIN_HOUSEHOLD: ColumnNoiseType = ColumnNoiseType(
+        "copy_from_within_household", noise_functions.generate_within_household_copies
+    )
+    MONTH_DAY_SWAP: ColumnNoiseType = ColumnNoiseType(
+        "month_day_swap", noise_functions.swap_months_and_days
+    )
+    ZIP_CODE_MISWRITING: ColumnNoiseType = ColumnNoiseType(
+        "zipcode_miswriting", noise_functions.miswrite_zip_codes
+    )
+    AGE_MISWRITING: ColumnNoiseType = ColumnNoiseType(
+        "age_miswriting", noise_functions.miswrite_ages
+    )
+    NUMERIC_MISWRITING: ColumnNoiseType = ColumnNoiseType(
+        "numeric_miswriting", noise_functions.miswrite_numerics
+    )
     NICKNAME: ColumnNoiseType = ColumnNoiseType(
         "nickname", noise_functions.generate_nicknames
     )
@@ -47,18 +71,14 @@ class __NoiseTypes(NamedTuple):
     PHONETIC: ColumnNoiseType = ColumnNoiseType(
         "phonetic", noise_functions.generate_phonetic_errors
     )
-    MISSING_DATA: ColumnNoiseType = ColumnNoiseType(
-        "missing_data",
-        noise_functions.missing_data,
-    )
-    TYPOGRAPHIC: ColumnNoiseType = ColumnNoiseType(
-        "typographic",
-        noise_functions.generate_typographical_errors,
-    )
     OCR: ColumnNoiseType = ColumnNoiseType(
         # todo: implement the noise fn
         "ocr",
         noise_functions.generate_ocr_errors,
+    )
+    TYPOGRAPHIC: ColumnNoiseType = ColumnNoiseType(
+        "typographic",
+        noise_functions.generate_typographical_errors,
     )
 
 

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -37,6 +37,114 @@ def duplicate_rows(
     return form_data
 
 
+def generate_incorrect_selections(
+    form_data: pd.DataFrame,
+    configuration: float,
+    randomness_stream: RandomnessStream,
+    additional_key: Any,
+) -> pd.DataFrame:
+    """
+
+    :param form_data:
+    :param configuration:
+    :param randomness_stream:
+    :param additional_key: Key for RandomnessStream
+    :return:
+    """
+    # todo actually duplicate rows
+    return form_data
+
+
+def generate_within_household_copies(
+    form_data: pd.DataFrame,
+    configuration: float,
+    randomness_stream: RandomnessStream,
+    additional_key: Any,
+) -> pd.DataFrame:
+    """
+
+    :param form_data:
+    :param configuration:
+    :param randomness_stream:
+    :param additional_key: Key for RandomnessStream
+    :return:
+    """
+    # todo actually duplicate rows
+    return form_data
+
+
+def swap_months_and_days(
+    form_data: pd.DataFrame,
+    configuration: float,
+    randomness_stream: RandomnessStream,
+    additional_key: Any,
+) -> pd.DataFrame:
+    """
+
+    :param form_data:
+    :param configuration:
+    :param randomness_stream:
+    :param additional_key: Key for RandomnessStream
+    :return:
+    """
+    # todo actually duplicate rows
+    return form_data
+
+
+def miswrite_zip_codes(
+    form_data: pd.DataFrame,
+    configuration: float,
+    randomness_stream: RandomnessStream,
+    additional_key: Any,
+) -> pd.DataFrame:
+    """
+
+    :param form_data:
+    :param configuration:
+    :param randomness_stream:
+    :param additional_key: Key for RandomnessStream
+    :return:
+    """
+    # todo actually duplicate rows
+    return form_data
+
+
+def miswrite_ages(
+    form_data: pd.DataFrame,
+    configuration: float,
+    randomness_stream: RandomnessStream,
+    additional_key: Any,
+) -> pd.DataFrame:
+    """
+
+    :param form_data:
+    :param configuration:
+    :param randomness_stream:
+    :param additional_key: Key for RandomnessStream
+    :return:
+    """
+    # todo actually duplicate rows
+    return form_data
+
+
+def miswrite_numerics(
+    form_data: pd.DataFrame,
+    configuration: float,
+    randomness_stream: RandomnessStream,
+    additional_key: Any,
+) -> pd.DataFrame:
+    """
+
+    :param form_data:
+    :param configuration:
+    :param randomness_stream:
+    :param additional_key: Key for RandomnessStream
+    :return:
+    """
+    # todo actually duplicate rows
+    return form_data
+
+
 def generate_nicknames(
     column: pd.Series,
     configuration: ConfigTree,
@@ -91,7 +199,7 @@ def generate_phonetic_errors(
     return column
 
 
-def missing_data(
+def generate_missing_data(
     column: pd.Series,
     configuration: ConfigTree,
     randomness_stream: RandomnessStream,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,185 @@
+import random
+import time
+from string import ascii_lowercase, ascii_uppercase
+
+import pandas as pd
+import pytest
+import yaml
+
+from pseudopeople.utilities import get_configuration
+
+HOUSING_TYPES = [
+    "Carceral",
+    "College",
+    "Military",
+    "Nursing home",
+    "Other institutional",
+    "Other non-institutional",
+    "Standard",
+]
+
+RACE_ETHNICITIES = [
+    "AIAN",
+    "Asian",
+    "Black",
+    "Latino",
+    "Multiracial or Other",
+    "NHOPI",
+    "White",
+]
+
+RELATIONS_TO_HOUSEHOLD_HEAD = [
+    "Adopted child",
+    "Biological child",
+    "Child-in-law",
+    "Foster child",
+    "Grandchild",
+    "Institutionalized GQ pop",
+    "Noninstitutionalized GQ pop",
+    "Opp-sex partner",
+    "Opp-sex spouse",
+    "Other nonrelative",
+    "Other relative",
+    "Parent",
+    "Parent-in-law",
+    "Reference person",
+    "Roommate",
+    "Same-sex partner",
+    "Same-sex spouse",
+    "Sibling",
+    "Stepchild",
+]
+
+DOB_START_DATE = time.mktime(time.strptime("1920-1-1", "%Y-%m-%d"))
+DOB_END_DATE = time.mktime(time.strptime("2030-5-1", "%Y-%m-%d"))
+
+STATES = [
+    "AL",
+    "AK",
+    "AZ",
+    "AR",
+    "CA",
+    "CO",
+    "CT",
+    "DC",
+    "DE",
+    "FL",
+    "GA",
+    "HI",
+    "ID",
+    "IL",
+    "IN",
+    "IA",
+    "KS",
+    "KY",
+    "LA",
+    "ME",
+    "MD",
+    "MA",
+    "MI",
+    "MN",
+    "MS",
+    "MO",
+    "MT",
+    "NE",
+    "NV",
+    "NH",
+    "NJ",
+    "NM",
+    "NY",
+    "NC",
+    "ND",
+    "OH",
+    "OK",
+    "OR",
+    "PA",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "UT",
+    "VT",
+    "VA",
+    "WA",
+    "WV",
+    "WI",
+    "WY",
+]
+
+
+@pytest.fixture(scope="session")
+def dummy_census_data(tmp_path_factory):
+    """Generate a dummy decennial census dataframe, save to a tmpdir, and return that path."""
+    random.seed(0)
+    num_rows = 100
+    data = pd.DataFrame(
+        {
+            "housing_type": [random.choice(HOUSING_TYPES) for _ in range(num_rows)],
+            "age": [str(random.random() * 100) for _ in range(num_rows)],
+            "year": [random.choice(["2020", "2030"]) for _ in range(num_rows)],
+            "race_ethnicity": [random.choice(RACE_ETHNICITIES) for _ in range(num_rows)],
+            "guardian_1": [
+                f"100_{random.randint(1,int(num_rows/3))}" for _ in range(num_rows)
+            ],
+            "first_name": [
+                "First" + "".join(random.choice(ascii_lowercase) for _ in range(3))
+                for _ in range(num_rows)
+            ],
+            "street_name": [
+                "Street" + "".join(random.choice(ascii_lowercase) for _ in range(3))
+                for _ in range(num_rows)
+            ],
+            "relation_to_household_head": [
+                random.choice(RELATIONS_TO_HOUSEHOLD_HEAD) for _ in range(num_rows)
+            ],
+            "zipcode": [str(float(random.randint(1, 99999))) for _ in range(num_rows)],
+            "date_of_birth": [
+                time.strftime(
+                    "%Y-%m-%d",
+                    time.localtime(
+                        DOB_START_DATE + random.random() * (DOB_END_DATE - DOB_START_DATE)
+                    ),
+                )
+                for _ in range(num_rows)
+            ],
+            "simulant_id": ["100_" + str(i) for i in range(num_rows)],
+            "middle_initial": [random.choice(ascii_uppercase) for _ in range(num_rows)],
+            "city": [
+                "City" + "".join(random.choice(ascii_lowercase) for _ in range(3))
+                for _ in range(num_rows)
+            ],
+            "street_number": [str(random.randint(1, 15000)) for _ in range(num_rows)],
+            "last_name": [
+                "Last" + "".join(random.choice(ascii_lowercase) for _ in range(3))
+                for _ in range(num_rows)
+            ],
+            "state": [random.choice(STATES) for _ in range(num_rows)],
+            "sex": [random.choice(["Female", "Male"]) for _ in range(num_rows)],
+            "unit_number": [
+                "Unit " + "".join(random.choice(ascii_lowercase) for _ in range(3))
+                for _ in range(num_rows)
+            ],
+            "guardian_2": [
+                f"100_{random.randint(1,int(num_rows)/4)}" for _ in range(num_rows)
+            ],
+        }
+    )
+
+    data_path = tmp_path_factory.getbasetemp() / "dummy_data.csv"
+    data.to_csv(data_path, index=False)
+
+    return data_path
+
+
+@pytest.fixture(scope="module")
+def dummy_config(tmp_path_factory):
+    """This simply copies the default config file to a temp directory
+    to be used as a user-provided config file in integration tests
+    """
+    config = get_configuration().to_dict()  # gets default config
+    config_path = tmp_path_factory.getbasetemp() / "dummy_config.yaml"
+    with open(config_path, "w") as file:
+        yaml.dump(config, file)
+
+    return config_path

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -1,38 +1,99 @@
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+import pandas as pd
 import pytest
 
 from pseudopeople.interface import generate_decennial_census
+from pseudopeople.utilities import get_configuration
+
+
+# TODO: possibly parametrize Forms?
+def test_generate_decennial_census(
+    dummy_census_data: Union[Path, str], dummy_config: Union[Path, str]
+):
+    data = pd.read_csv(dummy_census_data)
+    noised_data = generate_decennial_census(
+        path=dummy_census_data, seed=0, configuration=dummy_config
+    )
+    noised_data_same_seed = generate_decennial_census(
+        path=dummy_census_data, seed=0, configuration=dummy_config
+    )
+    noised_data_different_seed = generate_decennial_census(
+        path=dummy_census_data, seed=1, configuration=dummy_config
+    )
+
+    assert noised_data.equals(noised_data_same_seed)
+    assert not noised_data.equals(noised_data_different_seed)
+    assert not data.equals(noised_data)
+    # TODO: Confirm correct columns exist once the interface functions
+    # modify them
+    # TODO: if we sort out dtype schemas
+    # for col in noised_data.columns:
+    # assert data[col].dtype == noised_data[col].dtype
+    # TODO: Iterate through cols and check that the percentage of errors makes sense
+    # eg, if 25% typographic error and 1% OCR
+    # 1. Use a default config file
+    # 2.
+
+    config = get_configuration(dummy_config)["decennial_census"]
+
+    # Confirm omission and duplication seems reasonable
+    # TODO: when omission function gets implemented.
+    orig_idx = data.index
+    noised_idx = noised_data.index
+    # assert np.isclose(len(set(orig_idx) - set(noised_idx)) / len(data), config.omission)
+    # TODO: when duplication function gets implemented
+    # assert np.isclose(noised_data.duplicated().sum() / len(data), config.duplication)
+
+    # Check that column-level noise seem reasonable
+    # NOTE: this is not perfect because (1) it is only looking at row-level
+    # noise and not token-based noise and (2) it is not accounting for the
+    # fact that noising can occur on duplicated rows which have been removed
+    # for comparison purposes.
+    common_idx = set(orig_idx).intersection(set(noised_idx))
+    common_data = data.loc[common_idx]
+    common_noised_data = noised_data.loc[common_idx].drop_duplicates()
+    assert common_data.shape == common_noised_data.shape
+    for col in noised_data:
+        if col in config:
+            # TODO: when all functions are implemented
+            # actual_noise_rate = (common_data[col] != common_noised_data[col]).mean()
+            # noise_types = [k for k in config[col]]
+            # noise_rates = [config[col][noise_type]["row_noise_level"] for noise_type in noise_types]
+            # expected_noise_rate = 1 - np.prod([1-x for x in noise_rates])
+            # assert np.isclose(actual_noise_rate, expected_noise_rate)
+            pass
+        else:
+            assert (common_data[col] == common_noised_data[col]).all()
 
 
 @pytest.mark.skip(reason="TODO")
-def test_noise_census():
+def test_generate_acs():
     pass
 
 
 @pytest.mark.skip(reason="TODO")
-def test_noise_acs():
+def test_generate_cps():
     pass
 
 
 @pytest.mark.skip(reason="TODO")
-def test_noise_cps():
+def test_generate_wic():
     pass
 
 
 @pytest.mark.skip(reason="TODO")
-def test_noise_wic():
+def test_generate_ssa():
     pass
 
 
 @pytest.mark.skip(reason="TODO")
-def test_noise_ssa():
+def test_generate_tax_w2_1099():
     pass
 
 
 @pytest.mark.skip(reason="TODO")
-def test_noise_tax_w2_1099():
-    pass
-
-
-@pytest.mark.skip(reason="TODO")
-def test_noise_tax_1040():
+def test_generate_tax_1040():
     pass

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -1,14 +1,6 @@
 import pytest
 
-
-@pytest.mark.skip(reason="TODO")
-def test_noise_order():
-    """From docs: "Noising should be applied in the following order: omissions, duplications,
-    missing data, incorrect selection, copy from w/in household, month and day
-    swaps, zip code miswriting, age miswriting, numeric miswriting, nicknames,
-    fake names, phonetic, OCR, typographic"
-    """
-    pass
+from pseudopeople.interface import generate_decennial_census
 
 
 @pytest.mark.skip(reason="TODO")

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -1,0 +1,162 @@
+import random
+from string import ascii_lowercase
+
+import pandas as pd
+import pytest
+from vivarium.config_tree import ConfigTree
+
+from pseudopeople.entities import Form
+from pseudopeople.interface import generate_decennial_census
+from pseudopeople.noise import NOISE_TYPES, noise_form
+
+
+@pytest.fixture(scope="module")
+def dummy_data():
+    """Create a two-column dummy dataset"""
+    random.seed(0)
+    num_rows = 1_000_000
+    return pd.DataFrame(
+        {
+            "numbers": [str(x) for x in range(num_rows)],
+            "words": [
+                "".join(random.choice(ascii_lowercase) for _ in range(4))
+                for _ in range(num_rows)
+            ],
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def dummy_config_noise_numbers():
+    """Create a dummy configuration that applies all noise functions to a single
+    column in the dummy_data fixture. All noise function specs are defined in
+    reverse order here compared to how they are to be applied.
+
+    NOTE: this is not a realistic scenario but allows for certain
+    types of stress testing.
+    """
+    return ConfigTree(
+        {
+            "decennial_census": {
+                "numbers": {
+                    "missing_data": {"row_noise_level": 0.01},
+                    "incorrect_selection": {"row_noise_level": 0.01},
+                    "copy_from_within_household": {"row_noise_level": 0.01},
+                    "month_day_swap": {"row_noise_level": 0.01},
+                    "zipcode_miswriting": {
+                        "row_noise_level": 0.01,
+                        "zipcode_miswriting": [0.04, 0.04, 0.2, 0.36, 0.36],
+                    },
+                    "age_miswriting": {
+                        "row_noise_level": 0.01,
+                        "age_miswriting": [1, -1],
+                    },
+                    "numeric_miswriting": {
+                        "row_noise_level": 0.01,
+                        "numeric_miswriting": [0.1],
+                    },
+                    "nickname": {"row_noise_level": 0.01},
+                    "fake_names": {"row_noise_level": 0.01},
+                    "phonetic": {
+                        "row_noise_level": 0.01,
+                        "token_noise_level": 0.1,
+                    },
+                    "ocr": {
+                        "row_noise_level": 0.01,
+                        "token_noise_level": 0.1,
+                    },
+                    "typographic": {
+                        "row_noise_level": 0.01,
+                        "token_noise_level": 0.1,
+                    },
+                },
+                "duplication": 0.01,
+                "omission": 0.01,
+            },
+        }
+    )
+
+
+def test_noise_order(mocker, dummy_data, dummy_config_noise_numbers):
+    """From docs: "Noising should be applied in the following order: omissions, duplications,
+    missing data, incorrect selection, copy from w/in household, month and day
+    swaps, zip code miswriting, age miswriting, numeric miswriting, nicknames,
+    fake names, phonetic, OCR, typographic"
+    """
+    mock = mocker.MagicMock()
+    # Mock the noise_functions functions so that they are not actually called and
+    # return the original one-column dataframe (so that it doesn't become a mock
+    # object itself after the first mocked function is applied.)
+    for field in NOISE_TYPES._fields:
+        mock.attach_mock(
+            mocker.patch(
+                f"pseudopeople.noise.NOISE_TYPES.{field}.noise_function",
+                return_value=dummy_data[["numbers"]],
+            ),
+            field,
+        )
+    # FIXME: would be better to mock the form instead of using census
+    noise_form(Form.CENSUS, dummy_data, dummy_config_noise_numbers, 0)
+
+    call_order = [call[0] for call in mock.mock_calls]
+    expected_call_order = [
+        "OMISSION",
+        "DUPLICATION",
+        "MISSING_DATA",
+        "INCORRECT_SELECTION",
+        "COPY_FROM_WITHIN_HOUSEHOLD",
+        "MONTH_DAY_SWAP",
+        "ZIP_CODE_MISWRITING",
+        "AGE_MISWRITING",
+        "NUMERIC_MISWRITING",
+        "NICKNAME",
+        "FAKE_NAME",
+        "PHONETIC",
+        "OCR",
+        "TYPOGRAPHIC",
+    ]
+
+    assert expected_call_order == call_order
+
+
+def test_columns_noised(dummy_data):
+    """Test that the noise functions are only applied to the numbers column
+    (as specified in the dummy config)
+    """
+    config = ConfigTree(
+        {
+            "decennial_census": {  # Does not really matter
+                "numbers": {
+                    "missing_data": {"row_noise_level": 0.1},
+                },
+            },
+        },
+    )
+    noised_data = dummy_data.copy()
+    noised_data = noise_form(Form.CENSUS, noised_data, config, 0)
+
+    assert (dummy_data["numbers"] != noised_data["numbers"]).any()
+    assert (dummy_data["words"] == noised_data["words"]).all()
+
+
+@pytest.mark.parametrize(
+    "func, form",
+    [
+        (generate_decennial_census, Form.CENSUS),
+        ("todo", Form.ACS),
+        ("todo", Form.CPS),
+        ("todo", Form.WIC),
+        ("todo", Form.SSA),
+        ("todo", Form.TAX_W2_1099),
+        ("todo", Form.TAX_1040),
+    ],
+)
+def test_correct_forms_are_used(func, form, mocker):
+    """Test that each interface noise function uses the correct form"""
+    if func == "todo":
+        pytest.skip(reason=f"TODO: implement function for {form.value} form")
+    mock = mocker.patch("pseudopeople.interface.noise_form")
+    mocker.patch("pseudopeople.interface.pd")
+    _ = func("dummy/path")
+
+    assert mock.call_args[0][0] == form


### PR DESCRIPTION
## Title: Add basic decennial census integration test

### Description

- *Category*: test
- *JIRA issue*: [MIC-3862](https://jira.ihme.washington.edu/browse/MIC-3862)

This is the final PR for MIC-3862 (pseudopeople testing framework). It adds a
very basic integration test for the `generate_decennial_census` function
as well as several commented out tests to be done as we implement all
of the noising functions.

### Testing
pytests pass as is and I'm lightly tested the commented out portions. These
will undoubtedly need to be fleshed out when implemented b/c I don't know what
to use for tolerance level in `np.isclose()`

