### PR TITLE
add census integration test

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,185 @@
+import random
+import time
+from string import ascii_lowercase, ascii_uppercase
+
+import pandas as pd
+import pytest
+import yaml
+
+from pseudopeople.utilities import get_configuration
+
+HOUSING_TYPES = [
+    "Carceral",
+    "College",
+    "Military",
+    "Nursing home",
+    "Other institutional",
+    "Other non-institutional",
+    "Standard",
+]
+
+RACE_ETHNICITIES = [
+    "AIAN",
+    "Asian",
+    "Black",
+    "Latino",
+    "Multiracial or Other",
+    "NHOPI",
+    "White",
+]
+
+RELATIONS_TO_HOUSEHOLD_HEAD = [
+    "Adopted child",
+    "Biological child",
+    "Child-in-law",
+    "Foster child",
+    "Grandchild",
+    "Institutionalized GQ pop",
+    "Noninstitutionalized GQ pop",
+    "Opp-sex partner",
+    "Opp-sex spouse",
+    "Other nonrelative",
+    "Other relative",
+    "Parent",
+    "Parent-in-law",
+    "Reference person",
+    "Roommate",
+    "Same-sex partner",
+    "Same-sex spouse",
+    "Sibling",
+    "Stepchild",
+]
+
+DOB_START_DATE = time.mktime(time.strptime("1920-1-1", "%Y-%m-%d"))
+DOB_END_DATE = time.mktime(time.strptime("2030-5-1", "%Y-%m-%d"))
+
+STATES = [
+    "AL",
+    "AK",
+    "AZ",
+    "AR",
+    "CA",
+    "CO",
+    "CT",
+    "DC",
+    "DE",
+    "FL",
+    "GA",
+    "HI",
+    "ID",
+    "IL",
+    "IN",
+    "IA",
+    "KS",
+    "KY",
+    "LA",
+    "ME",
+    "MD",
+    "MA",
+    "MI",
+    "MN",
+    "MS",
+    "MO",
+    "MT",
+    "NE",
+    "NV",
+    "NH",
+    "NJ",
+    "NM",
+    "NY",
+    "NC",
+    "ND",
+    "OH",
+    "OK",
+    "OR",
+    "PA",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "UT",
+    "VT",
+    "VA",
+    "WA",
+    "WV",
+    "WI",
+    "WY",
+]
+
+
+@pytest.fixture(scope="session")
+def dummy_census_data(tmp_path_factory):
+    """Generate a dummy decennial census dataframe, save to a tmpdir, and return that path."""
+    random.seed(0)
+    num_rows = 100_000
+    data = pd.DataFrame(
+        {
+            "housing_type": [random.choice(HOUSING_TYPES) for _ in range(num_rows)],
+            "age": [str(random.random() * 100) for _ in range(num_rows)],
+            "year": [random.choice(["2020", "2030"]) for _ in range(num_rows)],
+            "race_ethnicity": [random.choice(RACE_ETHNICITIES) for _ in range(num_rows)],
+            "guardian_1": [
+                f"100_{random.randint(1,int(num_rows/3))}" for _ in range(num_rows)
+            ],
+            "first_name": [
+                "First" + "".join(random.choice(ascii_lowercase) for _ in range(3))
+                for _ in range(num_rows)
+            ],
+            "street_name": [
+                "Street" + "".join(random.choice(ascii_lowercase) for _ in range(3))
+                for _ in range(num_rows)
+            ],
+            "relation_to_household_head": [
+                random.choice(RELATIONS_TO_HOUSEHOLD_HEAD) for _ in range(num_rows)
+            ],
+            "zipcode": [str(float(random.randint(1, 99999))) for _ in range(num_rows)],
+            "date_of_birth": [
+                time.strftime(
+                    "%Y-%m-%d",
+                    time.localtime(
+                        DOB_START_DATE + random.random() * (DOB_END_DATE - DOB_START_DATE)
+                    ),
+                )
+                for _ in range(num_rows)
+            ],
+            "simulant_id": ["100_" + str(i) for i in range(num_rows)],
+            "middle_initial": [random.choice(ascii_uppercase) for _ in range(num_rows)],
+            "city": [
+                "City" + "".join(random.choice(ascii_lowercase) for _ in range(3))
+                for _ in range(num_rows)
+            ],
+            "street_number": [str(random.randint(1, 15000)) for _ in range(num_rows)],
+            "last_name": [
+                "Last" + "".join(random.choice(ascii_lowercase) for _ in range(3))
+                for _ in range(num_rows)
+            ],
+            "state": [random.choice(STATES) for _ in range(num_rows)],
+            "sex": [random.choice(["Female", "Male"]) for _ in range(num_rows)],
+            "unit_number": [
+                "Unit " + "".join(random.choice(ascii_lowercase) for _ in range(3))
+                for _ in range(num_rows)
+            ],
+            "guardian_2": [
+                f"100_{random.randint(1,int(num_rows)/4)}" for _ in range(num_rows)
+            ],
+        }
+    )
+
+    data_path = tmp_path_factory.getbasetemp() / "dummy_data.csv"
+    data.to_csv(data_path, index=False)
+
+    return data_path
+
+
+@pytest.fixture(scope="module")
+def dummy_config(tmp_path_factory):
+    """This simply copies the default config file to a temp directory
+    to be used as a user-provided config file in integration tests
+    """
+    config = get_configuration().to_dict()  # gets default config
+    config_path = tmp_path_factory.getbasetemp() / "dummy_config.yaml"
+    with open(config_path, "w") as file:
+        yaml.dump(config, file)
+
+    return config_path

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -1,38 +1,99 @@
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+import pandas as pd
 import pytest
 
 from pseudopeople.interface import generate_decennial_census
+from pseudopeople.utilities import get_configuration
+
+
+# TODO: possibly parametrize Forms?
+def test_generate_decennial_census(
+    dummy_census_data: Union[Path, str], dummy_config: Union[Path, str]
+):
+    data = pd.read_csv(dummy_census_data)
+    noised_data = generate_decennial_census(
+        path=dummy_census_data, seed=0, configuration=dummy_config
+    )
+    noised_data_same_seed = generate_decennial_census(
+        path=dummy_census_data, seed=0, configuration=dummy_config
+    )
+    noised_data_different_seed = generate_decennial_census(
+        path=dummy_census_data, seed=1, configuration=dummy_config
+    )
+
+    assert noised_data.equals(noised_data_same_seed)
+    assert not noised_data.equals(noised_data_different_seed)
+    assert not data.equals(noised_data)
+    # TODO: Confirm correct columns exist once the interface functions
+    # modify them
+    # TODO: if we sort out dtype schemas
+    # for col in noised_data.columns:
+    # assert data[col].dtype == noised_data[col].dtype
+    # TODO: Iterate through cols and check that the percentage of errors makes sense
+    # eg, if 25% typographic error and 1% OCR
+    # 1. Use a default config file
+    # 2.
+
+    config = get_configuration(dummy_config)["decennial_census"]
+
+    # Confirm omission and duplication seems reasonable
+    # TODO: when omission function gets implemented.
+    orig_idx = data.index
+    noised_idx = noised_data.index
+    # assert np.isclose(len(set(orig_idx) - set(noised_idx)) / len(data), config.omission)
+    # TODO: when duplication function gets implemented
+    # assert np.isclose(noised_data.duplicated().sum() / len(data), config.duplication)
+
+    # Check that column-level noise seem reasonable
+    # NOTE: this is not perfect because (1) it is only looking at row-level
+    # noise and not token-based noise and (2) it is not accounting for the
+    # fact that noising can occur on duplicated rows which have been removed
+    # for comparison purposes.
+    common_idx = set(orig_idx).intersection(set(noised_idx))
+    common_data = data.loc[common_idx]
+    common_noised_data = noised_data.loc[common_idx].drop_duplicates()
+    assert common_data.shape == common_noised_data.shape
+    for col in noised_data:
+        if col in config:
+            actual_noise_rate = (common_data[col] != common_noised_data[col]).mean()
+            noise_types = [k for k in config[col]]
+            noise_rates = [
+                config[col][noise_type]["row_noise_level"] for noise_type in noise_types
+            ]
+            expected_noise_rate = 1 - np.prod([1 - x for x in noise_rates])
+            assert np.isclose(actual_noise_rate, expected_noise_rate, rtol=0.07)
+        else:
+            assert (common_data[col] == common_noised_data[col]).all()
 
 
 @pytest.mark.skip(reason="TODO")
-def test_noise_census():
+def test_generate_acs():
     pass
 
 
 @pytest.mark.skip(reason="TODO")
-def test_noise_acs():
+def test_generate_cps():
     pass
 
 
 @pytest.mark.skip(reason="TODO")
-def test_noise_cps():
+def test_generate_wic():
     pass
 
 
 @pytest.mark.skip(reason="TODO")
-def test_noise_wic():
+def test_generate_ssa():
     pass
 
 
 @pytest.mark.skip(reason="TODO")
-def test_noise_ssa():
+def test_generate_tax_w2_1099():
     pass
 
 
 @pytest.mark.skip(reason="TODO")
-def test_noise_tax_w2_1099():
-    pass
-
-
-@pytest.mark.skip(reason="TODO")
-def test_noise_tax_1040():
+def test_generate_tax_1040():
     pass


### PR DESCRIPTION
## Title: Add basic decennial census integration test

### Description

- *Category*: test
- *JIRA issue*: [MIC-3862](https://jira.ihme.washington.edu/browse/MIC-3862)

This is the final PR for MIC-3862 (pseudopeople testing framework); it adds an
integration test for the `generate_decennial_census` function.

NOTE: there are a few commented out assertions to be implemented as
we continue development. Do please review these commented out
portions even though they are not live to make sure we're not 
missing something.

NOTE: I'm using 100k data length because it seemed like a reasonable
compromise between time to build the data and allowable tolerance.
I'm happy to change if desired. Some basic profiling:
* 1 million rows: 90s runtime, max rtol = 0.02
* 100k rows: 12s runtime, max rtol = 0.07
* 10k rows: 5s runtime, max rtol = 0.15

### Testing
pytests pass 


