### PR TITLE
Add W2 generation interface 

### DIFF
--- a/src/pseudopeople/__init__.py
+++ b/src/pseudopeople/__init__.py
@@ -8,4 +8,4 @@ from pseudopeople.__about__ import (
     __uri__,
     __version__,
 )
-from pseudopeople.interface import generate_decennial_census
+from pseudopeople.interface import generate_decennial_census, generate_w2

--- a/src/pseudopeople/default_configuration.yaml
+++ b/src/pseudopeople/default_configuration.yaml
@@ -51,4 +51,72 @@ decennial_census:
     housing_type:
         missing_data:
             row_noise_level: 0.01
-
+taxes_w2_and_1099:
+    omission: 0.0145
+    duplication: 0.05
+    age:
+        missing_data:
+            row_noise_level: 0.01
+    date_of_birth:
+        missing_data:
+            row_noise_level: 0.01
+    employer_city:
+        missing_data:
+            row_noise_level: 0.01
+    employer_id:
+        missing_data:
+            row_noise_level: 0.01
+    employer_name:
+        missing_data:
+            row_noise_level: 0.01
+    employer_state:
+        missing_data:
+            row_noise_level: 0.01
+    employer_street_name:
+        missing_data:
+            row_noise_level: 0.01
+    employer_street_number:
+        missing_data:
+            row_noise_level: 0.01
+    employer_unit_number:
+        missing_data:
+            row_noise_level: 0.01
+    employer_zipcode:
+        missing_data:
+            row_noise_level: 0.01
+    first_name:
+        missing_data:
+            row_noise_level: 0.01
+    income:
+        missing_data:
+            row_noise_level: 0.01
+    is_w2:
+        missing_data:
+            row_noise_level: 0.01
+    last_name:
+        missing_data:
+            row_noise_level: 0.01
+    mailing_address_city:
+        missing_data:
+            row_noise_level: 0.01
+    mailing_address_state:
+        missing_data:
+            row_noise_level: 0.01
+    mailing_address_street_name:
+        missing_data:
+            row_noise_level: 0.01
+    mailing_address_street_number:
+        missing_data:
+            row_noise_level: 0.01
+    mailing_address_unit_number:
+        missing_data:
+            row_noise_level: 0.01
+    mailing_address_zipcode:
+        missing_data:
+            row_noise_level: 0.01
+    middle_initial:
+        missing_data:
+            row_noise_level: 0.01
+    ssn:
+        missing_data:
+            row_noise_level: 0.01

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -29,13 +29,29 @@ def generate_decennial_census(
     return noise_form(Form.CENSUS, data, configuration_tree, seed)
 
 
+def generate_w2(
+    path: Union[Path, str], seed: int = 0, configuration: Union[Path, str] = None
+):
+    """
+    Generates a noised W2 data from un-noised data.
+
+    :param path: A path to the un-noised source W2 data
+    :param seed: An integer seed for randomness
+    :param configuration: (optional) A path to a configuration YAML file to modify default values
+    :return: A pd.DataFrame of noised W2 data
+    """
+    configuration_tree = get_configuration(configuration)
+    data = pd.read_csv(path)
+    return noise_form(Form.TAX_W2_1099, data, configuration_tree, seed)
+
+
 # Manual testing helper
 if __name__ == "__main__":
     args = sys.argv[1:]
     if len(args) == 1:
         my_path = Path(args[0])
         src = pd.read_csv(my_path)
-        out = generate_decennial_census(my_path)
+        out = generate_w2(my_path)
         diff = src[
             ~src.astype(str).apply(tuple, 1).isin(out.astype(str).apply(tuple, 1))
         ]  # get all changed rows


### PR DESCRIPTION
## Add W2 generation interface 

### Description
- *Category*: feature
- *JIRA issue*: [MIC-3869](https://jira.ihme.washington.edu/browse/MIC-3869)

#### Changes
- Adds `generate_w2` function to interface
- Adds relevant configuration to the defaults yaml
- Addition of a integration test is deferred pending merge of another PR

### Testing
Running the `main` of `interface.py` and calling `generate_w2` resulted in noised data.

