### PR TITLE
Change is_w2 to tax_form

### DIFF
--- a/src/pseudopeople/default_configuration.yaml
+++ b/src/pseudopeople/default_configuration.yaml
@@ -130,7 +130,7 @@ taxes_w2_and_1099:
     income:
         missing_data:
             row_noise_level: 0.01
-    is_w2:
+    tax_form:
         missing_data:
             row_noise_level: 0.01
     last_name:


### PR DESCRIPTION
## Change is_w2 to tax_form

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3933](https://jira.ihme.washington.edu/browse/MIC-3933)

Simply changes is_w2 column to the new tax_form column in the default configuration. No existing tests are impacted.

### Testing
Ran noising against data generated with modified PRL outputs. W2 data were noised as expected.

