### PR TITLE
implement age miswriting

### DIFF
--- a/src/pseudopeople/default_configuration.yaml
+++ b/src/pseudopeople/default_configuration.yaml
@@ -37,8 +37,7 @@ decennial_census:
         age_miswriting:
             row_noise_level: 0.01
             token_noise_level: 0.1
-            possible_perturbations: [1, -1]
-            possible_perturbation_levels: []  # uniform distribution
+            possible_perturbations: {1: 0.5, -1: 0.5}
     date_of_birth:
         missing_data:
             row_noise_level: 0.01
@@ -108,18 +107,42 @@ taxes_w2_and_1099:
     age:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+        age_miswriting:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            possible_perturbations: {1: 0.5, -1: 0.5}
     date_of_birth:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     employer_city:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     employer_id:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     employer_name:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     employer_state:
         missing_data:
             row_noise_level: 0.01
@@ -128,21 +151,45 @@ taxes_w2_and_1099:
     employer_street_name:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     employer_street_number:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     employer_unit_number:
         missing_data:
             row_noise_level: 0.01
-    employer_zipcode:
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    employer_zipcode:   # TODO: CONFIRM WITH RG
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     first_name:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     income:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     tax_form:
         missing_data:
             row_noise_level: 0.01
@@ -151,9 +198,17 @@ taxes_w2_and_1099:
     last_name:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     mailing_address_city:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     mailing_address_state:
         missing_data:
             row_noise_level: 0.01
@@ -162,18 +217,49 @@ taxes_w2_and_1099:
     mailing_address_street_name:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     mailing_address_street_number:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     mailing_address_unit_number:
         missing_data:
             row_noise_level: 0.01
-    mailing_address_zipcode:
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    mailing_address_zipcode:  # TODO: CONFIRM WITH RG
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    mailing_address_po_box:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     middle_initial:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     ssn:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1

--- a/src/pseudopeople/default_configuration.yaml
+++ b/src/pseudopeople/default_configuration.yaml
@@ -34,6 +34,11 @@ decennial_census:
             row_noise_level: 0.01
             token_noise_level: 0.1
             include_original_token_level: 0.1
+        age_miswriting:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            possible_perturbations: [1, -1]
+            possible_perturbation_levels: []  # uniform distribution
     date_of_birth:
         missing_data:
             row_noise_level: 0.01

--- a/src/pseudopeople/default_configuration.yaml
+++ b/src/pseudopeople/default_configuration.yaml
@@ -169,7 +169,7 @@ taxes_w2_and_1099:
             row_noise_level: 0.01
             token_noise_level: 0.1
             include_original_token_level: 0.1
-    employer_zipcode:   # TODO: CONFIRM WITH RG
+    employer_zipcode:
         missing_data:
             row_noise_level: 0.01
         typographic:
@@ -235,7 +235,7 @@ taxes_w2_and_1099:
             row_noise_level: 0.01
             token_noise_level: 0.1
             include_original_token_level: 0.1
-    mailing_address_zipcode:  # TODO: CONFIRM WITH RG
+    mailing_address_zipcode:
         missing_data:
             row_noise_level: 0.01
         typographic:

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -158,7 +158,7 @@ def miswrite_ages(
     )
     new_values = column.astype(float).astype(int) + perturbations
     # Reflect negative values to positive
-    new_values[new_values < 0] = -1 * new_values
+    new_values[new_values < 0] *= -1
     # If new age == original age, subtract 1
     new_values[new_values == column.astype(int)] -= 1
 

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -36,7 +36,9 @@ def get_configuration(user_configuration: Union[Path, str, Dict] = None) -> Conf
             with open(user_configuration, "r") as f:
                 # TODO: Do we need to support other filetypes that yaml?
                 user_configuration = yaml.full_load(f)
-        user_configuration = format_user_configuration(user_configuration, noising_configuration)
+        user_configuration = format_user_configuration(
+            user_configuration, noising_configuration
+        )
         noising_configuration.update(user_configuration, layer="user")
 
     validate_noising_configuration(noising_configuration)

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -34,7 +34,6 @@ def get_configuration(user_configuration: Union[Path, str, Dict] = None) -> Conf
     if user_configuration:
         if isinstance(user_configuration, (Path, str)):
             with open(user_configuration, "r") as f:
-                # TODO: Do we need to support other filetypes that yaml?
                 user_configuration = yaml.full_load(f)
         user_configuration = format_user_configuration(
             user_configuration, noising_configuration

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -18,7 +18,7 @@ def get_configuration(user_configuration: Union[Path, str, Dict] = None) -> Conf
     """
     Gets a noising configuration ConfigTree, optionally overridden by a user-provided YAML.
 
-    :param user_config: A path to the YAML file or a dictionary defining user overrides for the defaults
+    :param user_configuration: A path to the YAML file or a dictionary defining user overrides for the defaults
     :return: a ConfigTree object of the noising configuration
     """
     import pseudopeople

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -63,7 +63,7 @@ def _format_age_miswriting_perturbations(user_dict: Dict, default_config: Config
             .get("possible_perturbations", {})
         )
         if not user_perturbations:
-            break
+            continue
         formatted = {}
         default_perturbations = default_config[form]["age"]["age_miswriting"][
             "possible_perturbations"

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -65,6 +65,8 @@ def vectorized_choice(
     if weights is None:
         n = len(options)
         weights = np.ones(n) / n
+    if isinstance(weights, list):
+        weights = np.array(weights)
     # for each of n_to_choose, sample uniformly between 0 and 1
     index = pd.Index(np.arange(n_to_choose))
     if randomness_stream is None:
@@ -75,7 +77,7 @@ def vectorized_choice(
         probs = randomness_stream.get_draw(index, additional_key=additional_key)
 
     # build cdf based on weights
-    pmf = weights / weights.sum()
+    pmf = weights / sum(weights)
     cdf = np.cumsum(pmf)
 
     # for each p_i in probs, count how many elements of cdf for which p_i >= cdf_i

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -113,11 +113,7 @@ def decennial_census_data_path(tmp_path_factory):
     data = pd.DataFrame(
         {
             "housing_type": [random.choice(HOUSING_TYPES) for _ in range(num_rows)],
-            # TODO: Currently ages are actually floats but a followup pr will ensure ints
-            "age": [
-                str(random.randint(1, 100) + round(random.random(), 6))
-                for _ in range(num_rows)
-            ],
+            "age": [str(random.randint(1, 100)) for _ in range(num_rows)],
             "year": [random.choice(["2020", "2030"]) for _ in range(num_rows)],
             "race_ethnicity": [random.choice(RACE_ETHNICITIES) for _ in range(num_rows)],
             "guardian_1": [
@@ -134,9 +130,7 @@ def decennial_census_data_path(tmp_path_factory):
             "relation_to_household_head": [
                 random.choice(RELATIONS_TO_HOUSEHOLD_HEAD) for _ in range(num_rows)
             ],
-            # TODO: currently zipcodes are floats (and thus not zero-padded);
-            # a followup PR will convert to 5-digit integer strings
-            "zipcode": [str(random.randint(1, 99999)) + ".0" for _ in range(num_rows)],
+            "zipcode": [str(random.randint(1, 99999)).zfill(5) for _ in range(num_rows)],
             "date_of_birth": [
                 time.strftime(
                     "%Y-%m-%d",

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -20,7 +20,7 @@ RANDOMNESS1 = RandomnessStream(
 @pytest.fixture(scope="module")
 def dummy_dataset():
     # Add a column of integer strings
-    num_simulants = 100_000
+    num_simulants = 1_000_000
     dummy_idx = pd.Index(range(num_simulants))
     integer_series = pd.Series([str(x) for x in range(num_simulants)])
     # Add missing data from `generate_missing_data` function
@@ -76,7 +76,7 @@ def test_generate_missing_data(dummy_dataset):
     # Check for expected noise level
     expected_noise = config["row_noise_level"]
     actual_noise = len(newly_missing_idx) / len(orig_non_missing_idx)
-    assert np.isclose(expected_noise, actual_noise, rtol=0.04)
+    assert np.isclose(expected_noise, actual_noise, rtol=0.02)
 
     # Check that un-noised values are unchanged
     not_noised_idx = noised_data.index[noised_data != ""]
@@ -140,7 +140,6 @@ def test_miswrite_ages_default_config(dummy_dataset):
     # Check for expected noise level
     not_missing_idx = data.index[data != ""]
     expected_noise = config["row_noise_level"]
-    # todo: Update when generate_incorrect_selection uses exclusive resampling
     actual_noise = (noised_data[not_missing_idx] != data[not_missing_idx]).mean()
     # NOTE: we increase the relative tolerance a bit here because the expected
     # noise calculated above does not account for the fact that if a perturbed
@@ -243,7 +242,7 @@ def test_miswrite_ages_flips_negative_to_positive():
     """Test that any ages perturbed to <0 are reflected to positive values"""
     num_rows = 100
     age = 3
-    perturbations = [-5]  # This will cause -2 and should flip to +2
+    perturbations = [-7]  # This will cause -4 and should flip to +4
 
     config = get_configuration(
         {
@@ -261,7 +260,7 @@ def test_miswrite_ages_flips_negative_to_positive():
     data = pd.Series([str(age)] * num_rows)
     noised_data = NOISE_TYPES.AGE_MISWRITING(data, config, RANDOMNESS0, "test")
 
-    assert (noised_data == "2").all()
+    assert (noised_data == "4").all()
 
 
 @pytest.mark.skip(reason="TODO")

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -49,7 +49,6 @@ def categorical_series():
     )
 
 
-
 def test_generate_missing_data(dummy_dataset):
     config = get_configuration()["decennial_census"]["zipcode"]["missing_data"]
     config.update(

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,10 +1,17 @@
 from pathlib import Path
 
+import pandas as pd
 import pytest
 import yaml
+from vivarium.config_tree import ConfigTree
+from vivarium.framework.randomness import RandomnessStream
 
 import pseudopeople
 from pseudopeople.utilities import get_configuration
+
+RANDOMNESS0 = RandomnessStream(
+    key="test_column_noise", clock=lambda: pd.Timestamp("2020-09-01"), seed=0
+)
 
 
 @pytest.fixture
@@ -42,8 +49,73 @@ def test_get_configuration_with_user_override(user_configuration_yaml, mocker):
     update_calls = [
         call
         for call in mock.mock_calls
-        if "update" in str(call)
-        and "user" in str(call)
-        and str(user_configuration_yaml) in str(call)
+        if ".update({" in str(call) and "layer='user'" in str(call)
     ]
     assert len(update_calls) == 1
+
+
+def test_validate_miswrite_ages_fails_if_includes_0():
+    """Test that a runtime error is thrown if the user includes 0 as a possible perturbation"""
+    perturbations = [-1, 0, 1]
+    with pytest.raises(ValueError, match="Cannot include 0"):
+        get_configuration(
+            {
+                "decennial_census": {
+                    "age": {
+                        "age_miswriting": {
+                            "row_noise_level": 1,
+                            "possible_perturbations": perturbations,
+                        },
+                    },
+                },
+            },
+        )
+
+
+def test_validate_miswrite_ages_if_probabilities_do_not_add_to_1():
+    """Test that runtimerrors if probs do not add up to 1"""
+    perturbations = {-1: 0.1, 1: 0.8}  # does not sum to 1
+
+    with pytest.raises(ValueError, match="must sum to 1"):
+        get_configuration(
+            {
+                "decennial_census": {
+                    "age": {
+                        "age_miswriting": {
+                            "possible_perturbations": perturbations,
+                        },
+                    },
+                },
+            },
+        )
+
+
+@pytest.mark.parametrize("user_config_type", ["dict", "path"])
+def test_format_miswrite_ages(user_config_type, tmp_path):
+    """Test that user-supplied dictionary properly updates ConfigTree object.
+    This includes zero-ing out default values that don't exist in the user config
+    """
+    user_config = {
+        "decennial_census": {
+            "age": {
+                "age_miswriting": {
+                    "possible_perturbations": [-2, -1, 2],
+                },
+            },
+        },
+    }
+    if user_config_type == "path":
+        filepath = tmp_path / "user_dict.yaml"
+        with open(filepath, "w") as file:
+            yaml.dump(user_config, file)
+        user_config = filepath
+
+    new_dict = get_configuration(user_config).decennial_census.age.age_miswriting.to_dict()
+    default_dict = get_configuration().decennial_census.age.age_miswriting.to_dict()
+    assert default_dict["row_noise_level"] == new_dict["row_noise_level"]
+    assert default_dict["token_noise_level"] == new_dict["token_noise_level"]
+    # check that 1 got replaced with 0 probability
+    assert new_dict["possible_perturbations"][1] == 0
+    # check that others have 1/3 probability
+    for p in [-2, -1, 2]:
+        assert new_dict["possible_perturbations"][p] == 1 / 3

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -176,7 +176,6 @@ def test_correct_forms_are_used(func, form, mocker):
 
 
 def test_two_noise_functions_are_independent(mocker):
-
     # Make simple config tree to test 2 noise functions work together
     config_tree = ConfigTree(
         {

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -18,7 +18,7 @@ from pseudopeople.schema_entities import Form
 def dummy_data():
     """Create a two-column dummy dataset"""
     random.seed(0)
-    num_rows = 1_000_000
+    num_rows = 100_000
     return pd.DataFrame(
         {
             "numbers": [str(x) for x in range(num_rows)],

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -18,7 +18,7 @@ from pseudopeople.schema_entities import Form
 def dummy_data():
     """Create a two-column dummy dataset"""
     random.seed(0)
-    num_rows = 100_000
+    num_rows = 1_000_000
     return pd.DataFrame(
         {
             "numbers": [str(x) for x in range(num_rows)],


### PR DESCRIPTION
## Title: Add miswrite-age function

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-3876](https://jira.ihme.washington.edu/browse/MIC-3876)

Note that I did NOT use the code Abie generated for age miswriting as it looped through everything whereas this takes a vectorized approach.

The current docs describe age miswrites as:

> To implement this, first select the rows for noise according to the row noise probability. For each selected row, the age will be adjusted. The adjustment value will be randomly selected from the configured list of possible perturbations, according to the configured probabilities of selection. If the probabilities of selection are a none/null value (which is the default), the choice is uniform among the list of possible perturbations.
> 
> For example, if the correct age is 28 and the possible perturbations are [-2, -1, 1, 2] with configured probabilities of [0.2, 0.3, 0.3, 0.2] then 28 will be adjusted to either: 26, 27, 29, or 30, with a 0.2 probability for each of 26 and 30 and a 0.3 probability for each of 27 and 29.
> 
> Note
> 
> The probabilities are supplied as a list that must align with the order of the possible perturbations. The first element in the probabilities is the probability of the first element in the perturbations, and so on.
> 
> If the age after adding the chosen perturbation is negative, reflect the sign to be positive (e.g. a -2 becomes 2). If this reflection is performed and the resulting age is equal to the original age value, subtract 1 from the age. (This will never result in a negative value because reflecting a negative value will never result in 0.)

### Testing
pytests added and passed

