### PR TITLE
Implement all non-1040 forms

### DIFF
--- a/src/pseudopeople/__init__.py
+++ b/src/pseudopeople/__init__.py
@@ -8,4 +8,11 @@ from pseudopeople.__about__ import (
     __uri__,
     __version__,
 )
-from pseudopeople.interface import generate_decennial_census, generate_w2
+from pseudopeople.interface import (
+    generate_american_communities_survey,
+    generate_current_population_survey,
+    generate_decennial_census,
+    generate_social_security,
+    generate_taxes_w2_and_1099,
+    generate_women_infants_and_children,
+)

--- a/src/pseudopeople/default_configuration.yaml
+++ b/src/pseudopeople/default_configuration.yaml
@@ -98,23 +98,43 @@ decennial_census:
             row_noise_level: 0.01
 
 taxes_w2_and_1099:
-    omission: 0.0145
+    omission: 0.0
     duplication: 0.05
     age:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     date_of_birth:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     employer_city:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     employer_id:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     employer_name:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     employer_state:
         missing_data:
             row_noise_level: 0.01
@@ -123,21 +143,45 @@ taxes_w2_and_1099:
     employer_street_name:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     employer_street_number:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     employer_unit_number:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     employer_zipcode:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     first_name:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     income:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     tax_form:
         missing_data:
             row_noise_level: 0.01
@@ -146,9 +190,17 @@ taxes_w2_and_1099:
     last_name:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     mailing_address_city:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     mailing_address_state:
         missing_data:
             row_noise_level: 0.01
@@ -157,18 +209,347 @@ taxes_w2_and_1099:
     mailing_address_street_name:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     mailing_address_street_number:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     mailing_address_unit_number:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     mailing_address_zipcode:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     middle_initial:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
     ssn:
         missing_data:
             row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+american_communities_survey:
+    omission: 0.0145
+    duplication: 0.05
+    age:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    city:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    date_of_birth:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    first_name:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    last_name:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    middle_initial:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    sex:
+        missing_data:
+            row_noise_level: 0.01
+        incorrect_selection:
+            row_noise_level: 0.01
+    state:
+        missing_data:
+            row_noise_level: 0.01
+        incorrect_selection:
+            row_noise_level: 0.01
+    street_name:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    street_number:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    unit_number:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    zipcode:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+current_population_survey:
+    omission: 0.2905
+    duplication: 0.05
+    age:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    city:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    date_of_birth:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    first_name:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    last_name:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    middle_initial:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    sex:
+        missing_data:
+            row_noise_level: 0.01
+        incorrect_selection:
+            row_noise_level: 0.01
+    state:
+        missing_data:
+            row_noise_level: 0.01
+        incorrect_selection:
+            row_noise_level: 0.01
+    street_name:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    street_number:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    unit_number:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    zipcode:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+
+women_infants_and_children:
+    omission: 0.0
+    duplication: 0.05
+    age:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    city:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    date_of_birth:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    first_name:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    last_name:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    middle_initial:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    race_ethnicity:
+        missing_data:
+            row_noise_level: 0.01
+        incorrect_selection:
+            row_noise_level: 0.01
+    sex:
+        missing_data:
+            row_noise_level: 0.01
+        incorrect_selection:
+            row_noise_level: 0.01
+    state:
+        missing_data:
+            row_noise_level: 0.01
+        incorrect_selection:
+            row_noise_level: 0.01
+    street_name:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    street_number:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    unit_number:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    zipcode:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+social_security:
+    omission: 0.0
+    duplication: 0.05
+    date_of_birth:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    event_date:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    event_type:
+        missing_data:
+            row_noise_level: 0.01
+        incorrect_selection:
+            row_noise_level: 0.01
+    first_name:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    last_name:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    middle_initial:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1
+    ssn:
+        missing_data:
+            row_noise_level: 0.01
+        typographic:
+            row_noise_level: 0.01
+            token_noise_level: 0.1
+            include_original_token_level: 0.1

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -9,40 +9,119 @@ from pseudopeople.schema_entities import Form
 from pseudopeople.utilities import get_configuration
 
 
+def generate_form(
+    form: Form,
+    source: Union[Path, str, pd.DataFrame],
+    seed: int,
+    configuration: Union[Path, str, dict],
+):
+    """Helper function for noising forms"""
+    configuration_tree = get_configuration(configuration)
+    if isinstance(source, pd.DataFrame):
+        data = source
+    else:
+        data = pd.read_csv(source, dtype=str, keep_default_na=False)
+    return noise_form(form, data, configuration_tree, seed)
+
+
 # TODO: add year as parameter to select the year of the decennial census to generate (MIC-3909)
 # TODO: add default path: have the package install the small data in a known location and then
 #  to make this parameter optional, with the default being the location of the small data that
 #  is installed with the package (MIC-3884)
 def generate_decennial_census(
-    path: Union[Path, str], seed: int = 0, configuration: Union[Path, str] = None
+    source: Union[Path, str, pd.DataFrame],
+    seed: int = 0,
+    configuration: Union[Path, str, dict] = None,
 ):
     """
-    Generates a noised decennial census data from un-noised data.
+    Generates noised decennial census data from un-noised data.
 
-    :param path: A path to the un-noised source census data
+    :param source: A path to or pd.DataFrame of the un-noised source census data
     :param seed: An integer seed for randomness
-    :param configuration: (optional) A path to a configuration YAML file to modify default values
+    :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
     :return: A pd.DataFrame of noised census data
     """
-    configuration_tree = get_configuration(configuration)
-    data = pd.read_csv(path, dtype=str, keep_default_na=False)
-    return noise_form(Form.CENSUS, data, configuration_tree, seed)
+    return generate_form(Form.CENSUS, source, seed, configuration)
 
 
-def generate_w2(
-    path: Union[Path, str], seed: int = 0, configuration: Union[Path, str] = None
+def generate_american_communities_survey(
+    source: Union[Path, str, pd.DataFrame],
+    seed: int = 0,
+    configuration: Union[Path, str, dict] = None,
 ):
     """
-    Generates a noised W2 data from un-noised data.
+    Generates noised American Communities Survey (ACS) data from un-noised data.
 
-    :param path: A path to the un-noised source W2 data
+    :param source: A path to or pd.DataFrame of the un-noised source ACS data
     :param seed: An integer seed for randomness
-    :param configuration: (optional) A path to a configuration YAML file to modify default values
-    :return: A pd.DataFrame of noised W2 data
+    :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
+    :return: A pd.DataFrame of noised ACS data
     """
-    configuration_tree = get_configuration(configuration)
-    data = pd.read_csv(path, dtype=str, keep_default_na=False)
-    return noise_form(Form.TAX_W2_1099, data, configuration_tree, seed)
+    return generate_form(Form.ACS, source, seed, configuration)
+
+
+def generate_current_population_survey(
+    source: Union[Path, str, pd.DataFrame],
+    seed: int = 0,
+    configuration: Union[Path, str, dict] = None,
+):
+    """
+    Generates noised Current Population Survey (CPS) data from un-noised data.
+
+    :param source: A path to or pd.DataFrame of the un-noised source CPS data
+    :param seed: An integer seed for randomness
+    :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
+    :return: A pd.DataFrame of noised CPS data
+    """
+    return generate_form(Form.CPS, source, seed, configuration)
+
+
+def generate_taxes_w2_and_1099(
+    source: Union[Path, str, pd.DataFrame],
+    seed: int = 0,
+    configuration: Union[Path, str, dict] = None,
+):
+    """
+    Generates noised W2 and 1099 data from un-noised data.
+
+    :param source: A path to or pd.DataFrame of the un-noised source W2 and 1099 data
+    :param seed: An integer seed for randomness
+    :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
+    :return: A pd.DataFrame of noised W2 and 1099 data
+    """
+    return generate_form(Form.TAX_W2_1099, source, seed, configuration)
+
+
+def generate_women_infants_and_children(
+    source: Union[Path, str, pd.DataFrame],
+    seed: int = 0,
+    configuration: Union[Path, str, dict] = None,
+):
+    """
+    Generates noised Women Infants and Children (WIC) data from un-noised data.
+
+    :param source: A path to or pd.DataFrame of the un-noised source WIC data
+    :param seed: An integer seed for randomness
+    :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
+    :return: A pd.DataFrame of noised WIC data
+    """
+    return generate_form(Form.WIC, source, seed, configuration)
+
+
+def generate_social_security(
+    source: Union[Path, str, pd.DataFrame],
+    seed: int = 0,
+    configuration: Union[Path, str, dict] = None,
+):
+    """
+    Generates noised Social Security (SSA) data from un-noised data.
+
+    :param source: A path to or pd.DataFrame of the un-noised source SSA data
+    :param seed: An integer seed for randomness
+    :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
+    :return: A pd.DataFrame of noised SSA data
+    """
+    return generate_form(Form.SSA, source, seed, configuration)
 
 
 # Manual testing helper
@@ -51,7 +130,7 @@ if __name__ == "__main__":
     if len(args) == 1:
         my_path = Path(args[0])
         src = pd.read_csv(my_path, dtype=str, keep_default_na=False)
-        out = generate_w2(my_path)
+        out = generate_taxes_w2_and_1099(my_path)
         diff = src[
             ~src.astype(str).apply(tuple, 1).isin(out.astype(str).apply(tuple, 1))
         ]  # get all changed rows

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -9,13 +9,26 @@ from pseudopeople.schema_entities import Form
 from pseudopeople.utilities import get_configuration
 
 
-def generate_form(
+def _generate_form(
     form: Form,
     source: Union[Path, str, pd.DataFrame],
     seed: int,
     configuration: Union[Path, str, dict],
 ):
-    """Helper function for noising forms"""
+    """
+    Helper for generating noised forms from clean data.
+
+    :param form:
+        Form needing to be noised
+    :param source:
+        Clean data input which needs to be noised
+    :param seed:
+        Seed for controlling randomness
+    :param configuration:
+        Object to configure noise levels
+    :return:
+        Noised form data
+    """
     configuration_tree = get_configuration(configuration)
     if isinstance(source, pd.DataFrame):
         data = source
@@ -41,7 +54,7 @@ def generate_decennial_census(
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
     :return: A pd.DataFrame of noised census data
     """
-    return generate_form(Form.CENSUS, source, seed, configuration)
+    return _generate_form(Form.CENSUS, source, seed, configuration)
 
 
 def generate_american_communities_survey(
@@ -57,7 +70,7 @@ def generate_american_communities_survey(
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
     :return: A pd.DataFrame of noised ACS data
     """
-    return generate_form(Form.ACS, source, seed, configuration)
+    return _generate_form(Form.ACS, source, seed, configuration)
 
 
 def generate_current_population_survey(
@@ -73,7 +86,7 @@ def generate_current_population_survey(
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
     :return: A pd.DataFrame of noised CPS data
     """
-    return generate_form(Form.CPS, source, seed, configuration)
+    return _generate_form(Form.CPS, source, seed, configuration)
 
 
 def generate_taxes_w2_and_1099(
@@ -89,7 +102,7 @@ def generate_taxes_w2_and_1099(
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
     :return: A pd.DataFrame of noised W2 and 1099 data
     """
-    return generate_form(Form.TAX_W2_1099, source, seed, configuration)
+    return _generate_form(Form.TAX_W2_1099, source, seed, configuration)
 
 
 def generate_women_infants_and_children(
@@ -105,7 +118,7 @@ def generate_women_infants_and_children(
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
     :return: A pd.DataFrame of noised WIC data
     """
-    return generate_form(Form.WIC, source, seed, configuration)
+    return _generate_form(Form.WIC, source, seed, configuration)
 
 
 def generate_social_security(
@@ -121,7 +134,7 @@ def generate_social_security(
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
     :return: A pd.DataFrame of noised SSA data
     """
-    return generate_form(Form.SSA, source, seed, configuration)
+    return _generate_form(Form.SSA, source, seed, configuration)
 
 
 # Manual testing helper

--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -4,6 +4,9 @@ from typing import NamedTuple
 
 # todo: is "form" the right word? Ask RT
 class Form(Enum):
+    """
+    Enum containing all supported forms.
+    """
     CENSUS = "decennial_census"
     ACS = "american_communities_survey"
     CPS = "current_population_survey"

--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -7,6 +7,7 @@ class Form(Enum):
     """
     Enum containing all supported forms.
     """
+
     CENSUS = "decennial_census"
     ACS = "american_communities_survey"
     CPS = "current_population_survey"

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -17,7 +17,7 @@ def get_configuration(user_configuration: Union[Path, str, dict] = None) -> Conf
     """
     Gets a noising configuration ConfigTree, optionally overridden by a user-provided YAML.
 
-    :param user_configuration: A path to the YAML file defining user overrides for the defaults
+    :param user_configuration: A dictionary or path to the YAML file defining user overrides for the defaults
     :return: a ConfigTree object of the noising configuration
     """
     import pseudopeople
@@ -45,7 +45,7 @@ def vectorized_choice(
 ):
     """
     Function that takes a list of options and uses Vivarium common random numbers framework to make a given number
-    of razndom choice selections.
+    of random choice selections.
 
     :param options: List and series of possible values to choose
     :param n_to_choose: Number of choices to make, the length of the returned array of values

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -13,11 +13,11 @@ def get_randomness_stream(form: Form, seed: int) -> RandomnessStream:
     return RandomnessStream(form.value, lambda: pd.Timestamp("2020-04-01"), seed)
 
 
-def get_configuration(user_yaml_path: Union[Path, str] = None) -> ConfigTree:
+def get_configuration(user_configuration: Union[Path, str, dict] = None) -> ConfigTree:
     """
     Gets a noising configuration ConfigTree, optionally overridden by a user-provided YAML.
 
-    :param user_yaml_path: A path to the YAML file defining user overrides for the defaults
+    :param user_configuration: A path to the YAML file defining user overrides for the defaults
     :return: a ConfigTree object of the noising configuration
     """
     import pseudopeople
@@ -30,8 +30,8 @@ def get_configuration(user_yaml_path: Union[Path, str] = None) -> ConfigTree:
         data=Path(pseudopeople.__file__).resolve().parent / "default_configuration.yaml",
         layers=default_config_layers,
     )
-    if user_yaml_path:
-        noising_configuration.update(user_yaml_path, layer="user")
+    if user_configuration:
+        noising_configuration.update(user_configuration, layer="user")
     return noising_configuration
 
 

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -15,13 +15,13 @@ def test_generate_decennial_census(
 
     # TODO: Refactor this check into a separate test
     noised_data = generate_decennial_census(
-        path=decennial_census_data_path, seed=0, configuration=user_config_path
+        source=decennial_census_data_path, seed=0, configuration=user_config_path
     )
     noised_data_same_seed = generate_decennial_census(
-        path=decennial_census_data_path, seed=0, configuration=user_config_path
+        source=decennial_census_data_path, seed=0, configuration=user_config_path
     )
     noised_data_different_seed = generate_decennial_census(
-        path=decennial_census_data_path, seed=1, configuration=user_config_path
+        source=decennial_census_data_path, seed=1, configuration=user_config_path
     )
 
     assert noised_data.equals(noised_data_same_seed)

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -168,7 +168,7 @@ def test_correct_forms_are_used(func, form, mocker):
     """Test that each interface noise function uses the correct form"""
     if func == "todo":
         pytest.skip(reason=f"TODO: implement function for {form.value} form")
-    mock = mocker.patch("pseudopeople.interface.noise_form")
+    mock = mocker.patch("pseudopeople.interface.generate_form")
     mocker.patch("pseudopeople.interface.pd")
     _ = func("dummy/path")
 

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -168,8 +168,8 @@ def test_correct_forms_are_used(func, form, mocker):
     """Test that each interface noise function uses the correct form"""
     if func == "todo":
         pytest.skip(reason=f"TODO: implement function for {form.value} form")
-    mock = mocker.patch("pseudopeople.interface._generate_form")
-    mocker.patch("pseudopeople.interface.pd")
+    mock = mocker.patch("pseudopeople.interface.noise_form")
+    mocker.patch("pseudopeople.interface.pd.read_csv")
     _ = func("dummy/path")
 
     assert mock.call_args[0][0] == form

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -168,7 +168,7 @@ def test_correct_forms_are_used(func, form, mocker):
     """Test that each interface noise function uses the correct form"""
     if func == "todo":
         pytest.skip(reason=f"TODO: implement function for {form.value} form")
-    mock = mocker.patch("pseudopeople.interface.generate_form")
+    mock = mocker.patch("pseudopeople.interface._generate_form")
     mocker.patch("pseudopeople.interface.pd")
     _ = func("dummy/path")
 


### PR DESCRIPTION
## Implement all non-1040 forms


### Description
- *Category*: feature
- *JIRA issue*: [MIC-3882](https://jira.ihme.washington.edu/browse/MIC-3882)

#### Changes
- Adds ACS, CPS, SSA, and WIC forms interfaces and default configuration
- Adds ability to pass in DataFrame as source data and pass in a dict as configuration


### Testing
Manual testing, ran each noising function against each sample data. Noising succeeded with noising being seen in diffs between source and noising output.
