### PR TITLE
Add year argument to form generation functions

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -75,7 +75,13 @@ def _generate_form(
         if col.dtype_name != data[col.name].dtype.name:
             data[col.name] = data[col.name].astype(col.dtype_name)
     noised_form = noise_form(form, data, configuration_tree, seed)
-    noised_form = noised_form[[c.name for c in columns_to_keep]]
+    noised_form = _extract_columns(columns_to_keep, noised_form)
+    return noised_form
+
+
+def _extract_columns(columns_to_keep, noised_form):
+    if columns_to_keep:
+        noised_form = noised_form[[c.name for c in columns_to_keep]]
     return noised_form
 
 

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -51,8 +51,8 @@ def _generate_form(
         data = source
     elif isinstance(source, Path):
         if source.suffix == ".hdf":
-            hdf_store = pd.HDFStore(source)
-            data = hdf_store.select("data", where=year_filter["hdf"])
+            with pd.HDFStore(str(source), mode="r") as hdf_store:
+                data = hdf_store.select("data", where=year_filter["hdf"])
             hdf_store.close()
         elif source.suffix == ".parquet":
             data = pq.read_table(source, filters=year_filter["parquet"]).to_pandas()
@@ -87,7 +87,7 @@ def generate_decennial_census(
     source: Union[Path, str, pd.DataFrame] = None,
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
-    year: Union[int, str] = 2020,
+    year: int = 2020,
 ) -> pd.DataFrame:
     """
     Generates noised decennial census data from un-noised data.
@@ -109,7 +109,7 @@ def generate_american_communities_survey(
     source: Union[Path, str, pd.DataFrame] = None,
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
-    year: Union[int, str] = 2020,
+    year: int = 2020,
 ) -> pd.DataFrame:
     """
     Generates noised American Communities Survey (ACS) data from un-noised data.
@@ -129,6 +129,7 @@ def generate_american_communities_survey(
             (FORMS.acs.date_column, ">=", pd.Timestamp(f"{year}-01-01")),
             (FORMS.acs.date_column, "<=", pd.Timestamp(f"{year}-12-31")),
         ]
+        seed = seed * 10_000 + year
     return _generate_form(FORMS.acs, source, seed, configuration, year_filter)
 
 
@@ -136,7 +137,7 @@ def generate_current_population_survey(
     source: Union[Path, str, pd.DataFrame] = None,
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
-    year: Union[int, str] = 2020,
+    year: int = 2020,
 ) -> pd.DataFrame:
     """
     Generates noised Current Population Survey (CPS) data from un-noised data.
@@ -156,6 +157,7 @@ def generate_current_population_survey(
             (FORMS.cps.date_column, ">=", pd.Timestamp(f"{year}-01-01")),
             (FORMS.cps.date_column, "<=", pd.Timestamp(f"{year}-12-31")),
         ]
+        seed = seed * 10_000 + year
     return _generate_form(FORMS.cps, source, seed, configuration, year_filter)
 
 
@@ -163,7 +165,7 @@ def generate_taxes_w2_and_1099(
     source: Union[Path, str, pd.DataFrame] = None,
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
-    year: Union[int, str] = 2020,
+    year: int = 2020,
 ) -> pd.DataFrame:
     """
     Generates noised W2 and 1099 data from un-noised data.
@@ -178,6 +180,7 @@ def generate_taxes_w2_and_1099(
     if year:
         year_filter["hdf"] = [f"{FORMS.tax_w2_1099.date_column} == {year}."]
         year_filter["parquet"] = [(FORMS.tax_w2_1099.date_column, "==", year)]
+        seed = seed * 10_000 + year
     return _generate_form(FORMS.tax_w2_1099, source, seed, configuration, year_filter)
 
 
@@ -185,7 +188,7 @@ def generate_women_infants_and_children(
     source: Union[Path, str, pd.DataFrame] = None,
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
-    year: Union[int, str] = 2020,
+    year: int = 2020,
 ) -> pd.DataFrame:
     """
     Generates noised Women Infants and Children (WIC) data from un-noised data.
@@ -200,6 +203,7 @@ def generate_women_infants_and_children(
     if year:
         year_filter["hdf"] = [f"{FORMS.wic.date_column} == {year}."]
         year_filter["parquet"] = [(FORMS.wic.date_column, "==", year)]
+        seed = seed * 10_000 + year
     return _generate_form(FORMS.wic, source, seed, configuration, year_filter)
 
 
@@ -207,7 +211,7 @@ def generate_social_security(
     source: Union[Path, str, pd.DataFrame] = None,
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
-    year: Union[int, str] = 2020,
+    year: int = 2020,
 ) -> pd.DataFrame:
     """
     Generates noised Social Security (SSA) data from un-noised data.
@@ -224,4 +228,5 @@ def generate_social_security(
         year_filter["parquet"] = [
             (FORMS.ssa.date_column, "<=", pd.Timestamp(f"{year}-12-31"))
         ]
+        seed = seed * 10_000 + year
     return _generate_form(FORMS.ssa, source, seed, configuration, year_filter)

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -1,7 +1,8 @@
 from pathlib import Path
-from typing import Union
+from typing import List, Union
 
 import pandas as pd
+import pyarrow.parquet as pq
 
 from pseudopeople.configuration import get_configuration
 from pseudopeople.constants import paths
@@ -14,6 +15,7 @@ def _generate_form(
     source: Union[Path, str, pd.DataFrame],
     seed: int,
     configuration: Union[Path, str, dict],
+    year_filter: dict,
 ) -> pd.DataFrame:
     """
     Helper for generating noised forms from clean data.
@@ -49,9 +51,11 @@ def _generate_form(
         data = source
     elif isinstance(source, Path):
         if source.suffix == ".hdf":
-            data = pd.read_hdf(source)
+            hdf_store = pd.HDFStore(source)
+            data = hdf_store.select("data", where=year_filter["hdf"])
+            hdf_store.close()
         elif source.suffix == ".parquet":
-            data = pd.read_parquet(source)
+            data = pq.read_table(source, filters=year_filter["parquet"]).to_pandas()
         else:
             raise ValueError(
                 "Source path must either be a .hdf or a .parquet file. Provided "
@@ -83,6 +87,7 @@ def generate_decennial_census(
     source: Union[Path, str, pd.DataFrame] = None,
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
+    year: Union[int, str] = 2020,
 ) -> pd.DataFrame:
     """
     Generates noised decennial census data from un-noised data.
@@ -90,15 +95,21 @@ def generate_decennial_census(
     :param source: A path to or pd.DataFrame of the un-noised source census data
     :param seed: An integer seed for randomness
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
+    :param year: The year from the data to noise
     :return: A pd.DataFrame of noised census data
     """
-    return _generate_form(FORMS.census, source, seed, configuration)
+    year_filter = {"hdf": None, "parquet": None}
+    if year:
+        year_filter["hdf"] = [f"{FORMS.census.date_column} == {year}."]
+        year_filter["parquet"] = [(FORMS.census.date_column, "==", year)]
+    return _generate_form(FORMS.census, source, seed, configuration, year_filter)
 
 
 def generate_american_communities_survey(
     source: Union[Path, str, pd.DataFrame] = None,
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
+    year: Union[int, str] = 2020,
 ) -> pd.DataFrame:
     """
     Generates noised American Communities Survey (ACS) data from un-noised data.
@@ -106,15 +117,26 @@ def generate_american_communities_survey(
     :param source: A path to or pd.DataFrame of the un-noised source ACS data
     :param seed: An integer seed for randomness
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
+    :param year: The year from the data to noise
     :return: A pd.DataFrame of noised ACS data
     """
-    return _generate_form(FORMS.acs, source, seed, configuration)
+    year_filter = {"hdf": None, "parquet": None}
+    if year:
+        year_filter["hdf"] = [
+            f"{FORMS.acs.date_column} >= '{year}-01-01' and {FORMS.acs.date_column} <= '{year}-12-31'"
+        ]
+        year_filter["parquet"] = [
+            (FORMS.acs.date_column, ">=", pd.Timestamp(f"{year}-01-01")),
+            (FORMS.acs.date_column, "<=", pd.Timestamp(f"{year}-12-31")),
+        ]
+    return _generate_form(FORMS.acs, source, seed, configuration, year_filter)
 
 
 def generate_current_population_survey(
     source: Union[Path, str, pd.DataFrame] = None,
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
+    year: Union[int, str] = 2020,
 ) -> pd.DataFrame:
     """
     Generates noised Current Population Survey (CPS) data from un-noised data.
@@ -122,15 +144,26 @@ def generate_current_population_survey(
     :param source: A path to or pd.DataFrame of the un-noised source CPS data
     :param seed: An integer seed for randomness
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
+    :param year: The year from the data to noise
     :return: A pd.DataFrame of noised CPS data
     """
-    return _generate_form(FORMS.cps, source, seed, configuration)
+    year_filter = {"hdf": None, "parquet": None}
+    if year:
+        year_filter["hdf"] = [
+            f"{FORMS.cps.date_column} >= '{year}-01-01' and {FORMS.cps.date_column} <= '{year}-12-31'"
+        ]
+        year_filter["parquet"] = [
+            (FORMS.cps.date_column, ">=", pd.Timestamp(f"{year}-01-01")),
+            (FORMS.cps.date_column, "<=", pd.Timestamp(f"{year}-12-31")),
+        ]
+    return _generate_form(FORMS.cps, source, seed, configuration, year_filter)
 
 
 def generate_taxes_w2_and_1099(
     source: Union[Path, str, pd.DataFrame] = None,
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
+    year: Union[int, str] = 2020,
 ) -> pd.DataFrame:
     """
     Generates noised W2 and 1099 data from un-noised data.
@@ -138,15 +171,21 @@ def generate_taxes_w2_and_1099(
     :param source: A path to or pd.DataFrame of the un-noised source W2 and 1099 data
     :param seed: An integer seed for randomness
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
+    :param year: The year from the data to noise
     :return: A pd.DataFrame of noised W2 and 1099 data
     """
-    return _generate_form(FORMS.tax_w2_1099, source, seed, configuration)
+    year_filter = {"hdf": None, "parquet": None}
+    if year:
+        year_filter["hdf"] = [f"{FORMS.tax_w2_1099.date_column} == {year}."]
+        year_filter["parquet"] = [(FORMS.tax_w2_1099.date_column, "==", year)]
+    return _generate_form(FORMS.tax_w2_1099, source, seed, configuration, year_filter)
 
 
 def generate_women_infants_and_children(
     source: Union[Path, str, pd.DataFrame] = None,
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
+    year: Union[int, str] = 2020,
 ) -> pd.DataFrame:
     """
     Generates noised Women Infants and Children (WIC) data from un-noised data.
@@ -154,15 +193,21 @@ def generate_women_infants_and_children(
     :param source: A path to or pd.DataFrame of the un-noised source WIC data
     :param seed: An integer seed for randomness
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
+    :param year: The year from the data to noise
     :return: A pd.DataFrame of noised WIC data
     """
-    return _generate_form(FORMS.wic, source, seed, configuration)
+    year_filter = {"hdf": None, "parquet": None}
+    if year:
+        year_filter["hdf"] = [f"{FORMS.wic.date_column} == {year}."]
+        year_filter["parquet"] = [(FORMS.wic.date_column, "==", year)]
+    return _generate_form(FORMS.wic, source, seed, configuration, year_filter)
 
 
 def generate_social_security(
     source: Union[Path, str, pd.DataFrame] = None,
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
+    year: Union[int, str] = 2020,
 ) -> pd.DataFrame:
     """
     Generates noised Social Security (SSA) data from un-noised data.
@@ -170,6 +215,13 @@ def generate_social_security(
     :param source: A path to or pd.DataFrame of the un-noised source SSA data
     :param seed: An integer seed for randomness
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
+    :param year: The year up to which to noise from the data
     :return: A pd.DataFrame of noised SSA data
     """
-    return _generate_form(FORMS.ssa, source, seed, configuration)
+    year_filter = {"hdf": None, "parquet": None}
+    if year:
+        year_filter["hdf"] = [f"{FORMS.ssa.date_column} <= {year}."]
+        year_filter["parquet"] = [
+            (FORMS.ssa.date_column, "<=", pd.Timestamp(f"{year}-12-31"))
+        ]
+    return _generate_form(FORMS.ssa, source, seed, configuration, year_filter)

--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -356,6 +356,8 @@ COLUMNS = __Columns()
 class Form:
     name: str
     columns: Tuple[Column, ...]  # This defines the output column order
+    date_column: str
+
     row_noise_types: Tuple[RowNoiseType, ...] = (
         NOISE_TYPES.omission,
         # NOISE_TYPES.duplication,
@@ -384,6 +386,7 @@ class __Forms(NamedTuple):
             COLUMNS.sex,
             COLUMNS.race_ethnicity,
         ),
+        date_column="year",
     )
     acs: Form = Form(
         "american_communities_survey",
@@ -405,6 +408,7 @@ class __Forms(NamedTuple):
             COLUMNS.sex,
             COLUMNS.race_ethnicity,
         ),
+        date_column="survey_date",
     )
     cps: Form = Form(
         "current_population_survey",
@@ -426,6 +430,7 @@ class __Forms(NamedTuple):
             COLUMNS.sex,
             COLUMNS.race_ethnicity,
         ),
+        date_column="survey_date",
     )
     wic: Form = Form(
         "women_infants_and_children",
@@ -445,6 +450,7 @@ class __Forms(NamedTuple):
             COLUMNS.sex,
             COLUMNS.race_ethnicity,
         ),
+        date_column="year",
     )
     ssa: Form = Form(
         "social_security",
@@ -458,6 +464,7 @@ class __Forms(NamedTuple):
             COLUMNS.ssa_event_type,
             COLUMNS.ssa_event_date,
         ),
+        date_column="event_date",
     )
     tax_w2_1099: Form = Form(
         "taxes_w2_and_1099",
@@ -487,6 +494,7 @@ class __Forms(NamedTuple):
             COLUMNS.employer_zipcode,
             COLUMNS.tax_form,
         ),
+        date_column="tax_year",
     )
     # tax_1040: Form = Form(
     #     "taxes_1040",

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -56,6 +56,35 @@ def test_generate_form(data_dir_name: str, noising_function: Callable):
 
 
 @pytest.mark.parametrize(
+    "data_dir_name, noising_function",
+    [
+        ("decennial_census_observer", generate_decennial_census),
+        ("household_survey_observer_acs", generate_american_communities_survey),
+        ("household_survey_observer_cps", generate_current_population_survey),
+        ("social_security_observer", generate_social_security),
+        ("tax_w2_observer", generate_taxes_w2_and_1099),
+        ("wic_observer", generate_women_infants_and_children),
+        ("tax 1040", "todo"),
+    ],
+)
+def test_generate_form_with_year(data_dir_name: str, noising_function: Callable):
+    if noising_function == "todo":
+        pytest.skip(reason=f"TODO: implement form {data_dir_name}")
+    # todo fix hard-coding in MIC-3960
+    data_path = paths.SAMPLE_DATA_ROOT / data_dir_name / f"{data_dir_name}.parquet"
+    data = pd.read_parquet(data_path)
+
+    noised_data = noising_function(year=2020, seed=0)
+    noised_data_same_seed = noising_function(year=2020, seed=0)
+    noised_data_different_seed = noising_function(year=2020, seed=1)
+
+    assert not data.equals(noised_data)
+    assert noised_data.equals(noised_data_same_seed)
+    assert not noised_data.equals(noised_data_different_seed)
+    assert set(noised_data.columns) == set(data.columns)
+
+
+@pytest.mark.parametrize(
     "data_dir_name, noising_function, date_column",
     [
         ("decennial_census_observer", generate_decennial_census, FORMS.census.date_column),
@@ -65,11 +94,12 @@ def test_generate_form(data_dir_name: str, noising_function: Callable):
     ],
 )
 def test_form_filter_by_year(
-    data_dir_name: str, noising_function: Callable, date_column: str
+    mocker, data_dir_name: str, noising_function: Callable, date_column: str
 ):
     if noising_function == "todo":
         pytest.skip(reason=f"TODO: implement form {data_dir_name}")
 
+    mocker.patch("pseudopeople.interface.noise_form", side_effect=_mock_noise_form)
     noised_data = noising_function(year=2020)
 
     assert (noised_data[date_column] == 2020).all()

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -96,8 +96,8 @@ def _mock_noise_form(
 def test_form_filter_by_year_with_full_dates(
     mocker, data_dir_name: str, noising_function: Callable, form: FORMS
 ):
-    with mocker.patch("pseudopeople.interface.noise_form", side_effect=_mock_noise_form):
-        noised_data = noising_function(year=2020)
+    mocker.patch("pseudopeople.interface.noise_form", side_effect=_mock_noise_form)
+    noised_data = noising_function(year=2020)
 
     dates = pd.DatetimeIndex(noised_data[form.date_column])
     if form == FORMS.ssa:

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -51,8 +51,8 @@ def test_generate_form(data_dir_name: str, noising_function: Callable):
             expected_dtype = np.dtype(object)
         assert noised_data[col].dtype == expected_dtype
 
+
 # TODO [MIC-4000]: add test that each col to get noised actually does get noised
-    assert set(noised_data.columns) == set(data.columns)
 
 
 @pytest.mark.parametrize(
@@ -81,7 +81,10 @@ def test_generate_form_with_year(data_dir_name: str, noising_function: Callable)
     assert not data.equals(noised_data)
     assert noised_data.equals(noised_data_same_seed)
     assert not noised_data.equals(noised_data_different_seed)
-    assert set(noised_data.columns) == set(data.columns)
+
+
+def _mock_extract_columns(columns_to_keep, noised_form):
+    return noised_form
 
 
 @pytest.mark.parametrize(
@@ -99,6 +102,7 @@ def test_form_filter_by_year(
     if noising_function == "todo":
         pytest.skip(reason=f"TODO: implement form {data_dir_name}")
 
+    mocker.patch("pseudopeople.interface._extract_columns", side_effect=_mock_extract_columns)
     mocker.patch("pseudopeople.interface.noise_form", side_effect=_mock_noise_form)
     noised_data = noising_function(year=2020)
 
@@ -126,6 +130,7 @@ def _mock_noise_form(
 def test_form_filter_by_year_with_full_dates(
     mocker, data_dir_name: str, noising_function: Callable, form: FORMS
 ):
+    mocker.patch("pseudopeople.interface._extract_columns", side_effect=_mock_extract_columns)
     mocker.patch("pseudopeople.interface.noise_form", side_effect=_mock_noise_form)
     noised_data = noising_function(year=2020)
 
@@ -134,4 +139,3 @@ def test_form_filter_by_year_with_full_dates(
         assert (dates.year <= 2020).all()
     else:
         assert (dates.year == 2020).all()
-

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -13,7 +13,7 @@ from pseudopeople.interface import (
     generate_taxes_w2_and_1099,
     generate_women_infants_and_children,
 )
-from pseudopeople.schema_entities import COLUMNS
+from pseudopeople.schema_entities import COLUMNS, FORMS
 
 
 @pytest.mark.parametrize(
@@ -51,5 +51,26 @@ def test_generate_form(data_dir_name: str, noising_function: Callable):
             expected_dtype = np.dtype(object)
         assert noised_data[col].dtype == expected_dtype
 
-
 # TODO [MIC-4000]: add test that each col to get noised actually does get noised
+    assert set(noised_data.columns) == set(data.columns)
+
+
+@pytest.mark.parametrize(
+    "data_dir_name, noising_function, date_column",
+    [
+        ("decennial_census_observer", generate_decennial_census, FORMS.census.date_column),
+        ("tax_w2_observer", generate_taxes_w2_and_1099, FORMS.tax_w2_1099.date_column),
+        ("wic_observer", generate_women_infants_and_children, FORMS.wic.date_column),
+        ("tax 1040", "todo", "todo"),
+    ],
+)
+def test_form_filter_by_year(
+    data_dir_name: str, noising_function: Callable, date_column: str
+):
+    if noising_function == "todo":
+        pytest.skip(reason=f"TODO: implement form {data_dir_name}")
+
+    noised_data = noising_function(year=2020)
+
+    assert (noised_data[date_column] == 2020).all()
+

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -185,7 +185,7 @@ def test_correct_forms_are_used(func, form, mocker):
     """Test that each interface noise function uses the correct form"""
     if func == "todo":
         pytest.skip(reason=f"TODO: implement function for form {form}")
-    mock = mocker.patch("pseudopeople.interface.noise_form")
+    mock = mocker.patch("pseudopeople.interface._generate_form")
     _ = func()
 
     assert mock.call_args[0][0] == form


### PR DESCRIPTION
## Add year argument to form generation functions

### Description

- *Category*: feature
- *JIRA issue*: [MIC-3909](https://jira.ihme.washington.edu/browse/MIC-3909)

#### Changes
- Adds year parameter to all form generation interfaces, defaulting to 2020
- For all forms but SSA, this will limit the noised output to that year
- For SSA forms, this will limit the noised output up to and including that year
- Adds tests for all this
- Adds a date_column attribute to FORMS, as these are the fields to filter by year on

### Testing
Added tests work.
