### PR TITLE
update codeowners so that researchers can approve docs changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 # default owners
-* @albrja @hussain-jafari @mattkappel @ramittal @rmudambi @stevebachmeier
+* @ihmeuw/vivarium-dev
+/docs/* @ihmeuw/vivarium-research @ihmeuw/vivarium-dev
+*.rst @ihmeuw/vivarium-research @ihmeuw/vivarium-dev


### PR DESCRIPTION
## Update codeowners so that research can approve docs changes
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: N/A

Update codeowners so that research can approve docs changes
Avoid hardcoding individuals' github accounts

Link to some information about codeowners: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

### Testing
Will test once it's merged (can't do it until it's on develop)
