### PR TITLE
Switching to np.nan instead of pd.NA

### DIFF
--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -315,7 +315,7 @@ def generate_missing_data(column: pd.Series, *_: Any) -> pd.Series:
     :returns: pd.Series of empty strings with the index of column.
     """
 
-    return pd.Series(pd.NA, index=column.index)
+    return pd.Series(np.nan, index=column.index)
 
 
 def generate_typographical_errors(


### PR DESCRIPTION
## Change pd.NA to np.nan

### Changes missing data noise function to use np.nan instead of pd.NA
- *Category*: Other
- *JIRA issue*: [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-XYZ)

-Changes missing data noise function to use np.nan instead of pd.NA to be consistent with PRL.

### Testing
All tests pass.

