### PR TITLE
validate user configuration keys

### DIFF
--- a/src/pseudopeople/configuration/__init__.py
+++ b/src/pseudopeople/configuration/__init__.py
@@ -1,0 +1,2 @@
+from pseudopeople.configuration.entities import Keys
+from pseudopeople.configuration.generator import get_configuration

--- a/src/pseudopeople/configuration/entities.py
+++ b/src/pseudopeople/configuration/entities.py
@@ -1,0 +1,9 @@
+class Keys:
+    """Container for all non-form standard/repeated key names used in the configuration file"""
+
+    ROW_NOISE = "row_noise"  # second layer, eg <form>: row_noise: {...}
+    COLUMN_NOISE = "column_noise"  # second layer, eg <form>: column_noise: {...}
+    PROBABILITY = "probability"
+    ROW_NOISE_LEVEL = "row_noise_level"
+    TOKEN_NOISE_LEVEL = "token_noise_level"
+    AGE_MISWRITING_PERTURBATIONS = "possible_perturbations"

--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -7,9 +7,11 @@ from pseudopeople.configuration import Keys
 
 
 def validate_user_configuration(user_config: Dict, default_config: ConfigTree) -> None:
-    """Perform various validation checks on the final noising ConfigTree object"""
-    # todo validate that all keys in user config match values in default/baseline
-    #  besides possible permutations of age mis-writing
+    """
+    Validates the user-provided configuration. Confirms that all user-provided
+    keys exist in the default configuration. Confirms that all user-provided
+    values are valid for their respective noise functions.
+    """
     for form, form_config in user_config.items():
         default_form_config = _get_default_config_node(default_config, form, "form")
         for key in form_config:
@@ -47,9 +49,13 @@ def _validate_noise_type_config(
     noise_type: str,
     column: str = None,
 ) -> None:
+    """
+    Validates that all parameters are allowed for this noise function.
+    Additionally, validates that the configuration values are permissible.
+    """
     for parameter, parameter_config in noise_type_config.items():
         parameter_config_validator = {
-            # todo add additional custom validators
+            # todo add additional config value validators
             Keys.AGE_MISWRITING_PERTURBATIONS: _validate_age_miswriting_perturbations_config
         }.get(parameter, lambda *_: _)
 
@@ -77,7 +83,9 @@ def _get_default_config_node(
         form_context = "" if form is None else f" for form '{form}'"
         column_context = "" if column is None else f" for column '{column}'"
         noise_type_context = "" if noise_type is None else f" and noise type '{noise_type}'"
-        error_message = f"Invalid {key_type} '{key}' provided{form_context}{column_context}{noise_type_context}. "
+        context = form_context + column_context + noise_type_context
+
+        error_message = f"Invalid {key_type} '{key}' provided{context}. "
         valid_options_message = f"Valid {key_type}s are {[k for k in default_config]}."
         raise ValueError(error_message + valid_options_message)
 
@@ -85,6 +93,10 @@ def _get_default_config_node(
 def _validate_age_miswriting_perturbations_config(
     noise_type_config: Union[Dict, List], form: str, column: str
 ) -> None:
+    """
+    Validates the user-provided values for the age-miswriting permutations
+    parameter
+    """
     if not isinstance(noise_type_config, (Dict, List)):
         raise TypeError(
             "Invalid configuration type provided for age miswriting for form "

--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -1,0 +1,121 @@
+from typing import Dict, List, Union
+
+import numpy as np
+from vivarium.config_tree import ConfigTree, ConfigurationKeyError
+
+from pseudopeople.configuration import Keys
+
+
+def validate_user_configuration(user_config: Dict, default_config: ConfigTree) -> None:
+    """Perform various validation checks on the final noising ConfigTree object"""
+    # todo validate that all keys in user config match values in default/baseline
+    #  besides possible permutations of age mis-writing
+    for form, form_config in user_config.items():
+        default_form_config = _get_default_config_node(default_config, form, "form")
+        for key in form_config:
+            _get_default_config_node(default_form_config, key, "configuration key", form)
+
+        default_row_noise_config = default_form_config[Keys.ROW_NOISE]
+        default_column_noise_config = default_form_config[Keys.COLUMN_NOISE]
+
+        for noise_type, noise_type_config in form_config.get(Keys.ROW_NOISE, {}).items():
+            default_noise_type_config = _get_default_config_node(
+                default_row_noise_config, noise_type, "noise type", form
+            )
+            _validate_noise_type_config(
+                noise_type_config, default_noise_type_config, form, noise_type
+            )
+            # TODO: validate omissions = [0, 0.5]
+
+        for column, column_config in form_config.get(Keys.COLUMN_NOISE, {}).items():
+            default_column_config = _get_default_config_node(
+                default_column_noise_config, column, "column", form
+            )
+            for noise_type, noise_type_config in column_config.items():
+                default_noise_type_config = _get_default_config_node(
+                    default_column_config, noise_type, "noise type", form, column
+                )
+                _validate_noise_type_config(
+                    noise_type_config, default_noise_type_config, form, noise_type, column
+                )
+
+
+def _validate_noise_type_config(
+    noise_type_config: Union[Dict, List],
+    default_noise_type_config: ConfigTree,
+    form: str,
+    noise_type: str,
+    column: str = None,
+) -> None:
+    for parameter, parameter_config in noise_type_config.items():
+        parameter_config_validator = {
+            # todo add additional custom validators
+            Keys.AGE_MISWRITING_PERTURBATIONS: _validate_age_miswriting_perturbations_config
+        }.get(parameter, lambda *_: _)
+
+        _ = _get_default_config_node(
+            default_noise_type_config, parameter, "parameter", form, column, noise_type
+        )
+        parameter_config_validator(parameter_config, form, column)
+
+
+def _get_default_config_node(
+    default_config: ConfigTree,
+    key: str,
+    key_type: str,
+    form: str = None,
+    column: str = None,
+    noise_type: str = None,
+) -> ConfigTree:
+    """
+    Validate that the node the user is trying to add exists in the default
+    configuration.
+    """
+    try:
+        return default_config[key]
+    except ConfigurationKeyError:
+        form_context = "" if form is None else f" for form '{form}'"
+        column_context = "" if column is None else f" for column '{column}'"
+        noise_type_context = "" if noise_type is None else f" and noise type '{noise_type}'"
+        error_message = f"Invalid {key_type} '{key}' provided{form_context}{column_context}{noise_type_context}. "
+        valid_options_message = f"Valid {key_type}s are {[k for k in default_config]}."
+        raise ValueError(error_message + valid_options_message)
+
+
+def _validate_age_miswriting_perturbations_config(
+    noise_type_config: Union[Dict, List], form: str, column: str
+) -> None:
+    if not isinstance(noise_type_config, (Dict, List)):
+        raise TypeError(
+            "Invalid configuration type provided for age miswriting for form "
+            f"{form} and column {column}."
+        )
+
+    for key in noise_type_config:
+        if not isinstance(key, int):
+            raise TypeError(
+                "All possible age miswriting perturbations must be ints. "
+                f"Provided {key} of type {type(key)} in the configuration "
+                f"for form {form} and column {column}."
+            )
+        if key == 0:
+            raise ValueError(
+                "Cannot include 0 as an age miswriting perturbation. "
+                f"Provided 0 in the configuration for form {form} and "
+                f"column {column}."
+            )
+
+    if isinstance(noise_type_config, Dict):
+        for value in noise_type_config.values():
+            if not isinstance(value, float):
+                raise TypeError(
+                    "All possible age miswriting probabilities must be floats. "
+                    f"Provided {value} of type {type(value)} in the configuration "
+                    f"for form {form} and column {column}."
+                )
+
+        if not np.isclose(sum(noise_type_config.values()), 1.0):
+            raise ValueError(
+                "The provided age miswriting probabilities must sum to 1. "
+                f"Provided values sum to {sum(noise_type_config.values())}."
+            )

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 import pandas as pd
 from loguru import logger
@@ -53,7 +53,7 @@ class ColumnNoiseType:
     name: str
     noise_function: Callable[[pd.Series, ConfigTree, RandomnessStream, Any], pd.Series]
     row_noise_level: float = 0.01
-    token_noise_level: float = 0.1
+    token_noise_level: Optional[float] = 0.1
     noise_level_scaling_function: Callable[[str], float] = lambda x: 1.0
     additional_parameters: Dict[str, Any] = None
 

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -1,6 +1,7 @@
 from typing import NamedTuple
 
 from pseudopeople import noise_functions, utilities
+from pseudopeople.configuration import Keys
 from pseudopeople.entity_types import ColumnNoiseType, RowNoiseType
 
 
@@ -8,7 +9,7 @@ class __NoiseTypes(NamedTuple):
     """Container for all noise types in the order in which they should be applied:
     omissions, duplications, missing data, incorrect selection, copy from w/in
     household, month and day swaps, zip code miswriting, age miswriting,
-    numeric miswriting, nicknames, fake names, phonetic, OCR, typographic"
+    numeric miswriting, nicknames, fake names, phonetic, OCR, typographic
 
     NOTE: Any configuration tree overwrites in these objects are what ends up
     in the "baseline" ConfigTree layer.
@@ -49,7 +50,7 @@ class __NoiseTypes(NamedTuple):
         "age_miswriting",
         noise_functions.miswrite_ages,
         token_noise_level=None,
-        additional_parameters={"possible_perturbations": {-1: 0.5, 1: 0.5}},
+        additional_parameters={Keys.AGE_MISWRITING_PERTURBATIONS: {-1: 0.5, 1: 0.5}},
     )
     numeric_miswriting: ColumnNoiseType = ColumnNoiseType(
         "numeric_miswriting",

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -2,11 +2,11 @@ from pathlib import Path
 
 import pytest
 import yaml
-from vivarium.config_tree import ConfigTree
 
-from pseudopeople.configuration import DEFAULT_NOISE_VALUES, get_configuration
+from pseudopeople.configuration import Keys, get_configuration
+from pseudopeople.configuration.generator import DEFAULT_NOISE_VALUES
 from pseudopeople.noise_entities import NOISE_TYPES
-from pseudopeople.schema_entities import FORMS
+from pseudopeople.schema_entities import COLUMNS, FORMS
 
 
 @pytest.fixture
@@ -25,7 +25,7 @@ def user_configuration_yaml(tmp_path):
 
 def test_get_default_configuration(mocker):
     """Tests that the default configuration can be retrieved."""
-    mock = mocker.patch("pseudopeople.configuration.ConfigTree")
+    mock = mocker.patch("pseudopeople.configuration.generator.ConfigTree")
     _ = get_configuration()
     mock.assert_called_once_with(layers=["baseline", "default", "user"])
 
@@ -54,10 +54,10 @@ def test_default_configuration_structure():
                 config_level = config[form.name].column_noise[col.name][noise_type.name]
                 baseline_level = getattr(NOISE_TYPES, noise_type.name)
                 # FIXME: Is there a way to allow for adding new keys when they
-                # don't exist in baseline? eg the for if loops below depend on their
-                # being row_noise, token_noise, and additional parameters at the
-                # baseline level ('noise_type in col.noise_types')
-                # Would we ever want to allow for adding non-baseline default noise?
+                #  don't exist in baseline? eg the for if loops below depend on their
+                #  being row_noise, token_noise, and additional parameters at the
+                #  baseline level ('noise_type in col.noise_types')
+                #  Would we ever want to allow for adding non-baseline default noise?
                 if noise_type.row_noise_level:
                     config_row_noise_level = config_level.row_noise_level
                     default_row_noise_level = (
@@ -124,7 +124,7 @@ def test_default_configuration_structure():
 
 def test_get_configuration_with_user_override(user_configuration_yaml, mocker):
     """Tests that the default configuration get updated when a user configuration is supplied."""
-    mock = mocker.patch("pseudopeople.configuration.ConfigTree")
+    mock = mocker.patch("pseudopeople.configuration.generator.ConfigTree")
     _ = get_configuration(user_configuration_yaml)
     mock.assert_called_once_with(layers=["baseline", "default", "user"])
     update_calls = [
@@ -135,10 +135,142 @@ def test_get_configuration_with_user_override(user_configuration_yaml, mocker):
     assert len(update_calls) == 1
 
 
-def test_validate_miswrite_ages_fails_if_includes_0():
+def test_loading_from_yaml(tmp_path):
+    user_config = {
+        FORMS.census.name: {
+            Keys.COLUMN_NOISE: {
+                COLUMNS.age.name: {
+                    NOISE_TYPES.age_miswriting.name: {
+                        Keys.ROW_NOISE_LEVEL: 0.5,
+                    },
+                },
+            },
+        },
+    }
+    filepath = tmp_path / "user_dict.yaml"
+    with open(filepath, "w") as file:
+        yaml.dump(user_config, file)
+
+    default_config = get_configuration()[FORMS.census.name][Keys.COLUMN_NOISE][
+        COLUMNS.age.name
+    ][NOISE_TYPES.age_miswriting.name].to_dict()
+    updated_config = get_configuration(filepath)[FORMS.census.name][Keys.COLUMN_NOISE][
+        COLUMNS.age.name
+    ][NOISE_TYPES.age_miswriting.name].to_dict()
+
+    assert (
+        default_config[Keys.AGE_MISWRITING_PERTURBATIONS]
+        == updated_config[Keys.AGE_MISWRITING_PERTURBATIONS]
+    )
+    # check that 1 got replaced with 0 probability
+    assert updated_config[Keys.ROW_NOISE_LEVEL] == 0.5
+
+
+@pytest.mark.parametrize(
+    "user_config, expected",
+    [
+        ([-2, -1, 2], {-2: 1 / 3, -1: 1 / 3, 1: 0, 2: 1 / 3}),
+        ({-2: 0.3, 1: 0.5, 2: 0.2}, {-2: 0.3, -1: 0, 1: 0.5, 2: 0.2}),
+    ],
+    ids=["list", "dict"],
+)
+def test_format_miswrite_ages(user_config, expected):
+    """Test that user-supplied dictionary properly updates ConfigTree object.
+    This includes zero-ing out default values that don't exist in the user config
+    """
+    user_config = {
+        "decennial_census": {
+            "column_noise": {
+                "age": {
+                    "age_miswriting": {
+                        "possible_perturbations": user_config,
+                    },
+                },
+            },
+        },
+    }
+
+    config = get_configuration(user_config)[FORMS.census.name][Keys.COLUMN_NOISE][
+        COLUMNS.age.name
+    ][NOISE_TYPES.age_miswriting.name][Keys.AGE_MISWRITING_PERTURBATIONS].to_dict()
+
+    assert config == expected
+
+
+@pytest.mark.parametrize(
+    "config, match",
+    [
+        ({"fake_form": {}}, "Invalid form '.*' provided. Valid forms are "),
+        (
+            {FORMS.acs.name: {"other_noise": {}}},
+            "Invalid configuration key '.*' provided for form '.*'. ",
+        ),
+        (
+            {FORMS.acs.name: {Keys.ROW_NOISE: {"fake_noise": {}}}},
+            "Invalid noise type '.*' provided for form '.*'. ",
+        ),
+        (
+            {FORMS.acs.name: {Keys.ROW_NOISE: {NOISE_TYPES.omission.name: {"fake": {}}}}},
+            "Invalid parameter '.*' provided for form '.*' and noise type '.*'. ",
+        ),
+        (
+            {FORMS.acs.name: {Keys.COLUMN_NOISE: {"fake_column": {}}}},
+            "Invalid column '.*' provided for form '.*'. ",
+        ),
+        (
+            {FORMS.acs.name: {Keys.COLUMN_NOISE: {COLUMNS.age.name: {"fake_noise": {}}}}},
+            "Invalid noise type '.*' provided for form '.*' for column '.*'. ",
+        ),
+        (
+            {
+                FORMS.acs.name: {
+                    Keys.COLUMN_NOISE: {
+                        COLUMNS.age.name: {NOISE_TYPES.missing_data.name: {"fake": 1}}
+                    }
+                }
+            },
+            "Invalid parameter '.*' provided for form '.*' for column '.*' and noise type '.*'",
+        ),
+    ],
+    ids=[
+        "invalid form",
+        "invalid noise type",
+        "invalid row noise type",
+        "Invalid row noise type parameter",
+        "Invalid column",
+        "Invalid column noise type",
+        "Invalid column noise type parameter",
+    ],
+)
+def test_overriding_nonexistent_keys_fails(config, match):
+    with pytest.raises(ValueError, match=match):
+        get_configuration(config)
+
+
+@pytest.mark.parametrize(
+    "perturbations, error, match",
+    [
+        (-1, TypeError, "Invalid configuration type"),
+        ([-1, 0.4, 1], TypeError, "must be ints"),
+        ({-1: 0.5, 0.4: 0.2, 1: 0.3}, TypeError, "must be ints"),
+        ([-1, 0, 1], ValueError, "Cannot include 0"),
+        ({-1: 0.5, 4: 0.2, 0: 0.3}, ValueError, "Cannot include 0"),
+        ({-1: 0.1, 1: 1}, TypeError, "must be floats"),
+        ({-1: 0.1, 1: 0.8}, ValueError, "must sum to 1"),
+    ],
+    ids=[
+        "bad type",
+        "non-int keys list",
+        "non-int keys dict",
+        "include 0 list",
+        "include 0 dict",
+        "non-float values",
+        "not sum to 1",
+    ],
+)
+def test_validate_miswrite_ages_failures(perturbations, error, match):
     """Test that a runtime error is thrown if the user includes 0 as a possible perturbation"""
-    perturbations = [-1, 0, 1]
-    with pytest.raises(ValueError, match="Cannot include 0"):
+    with pytest.raises(error, match=match):
         get_configuration(
             {
                 "decennial_census": {
@@ -153,59 +285,3 @@ def test_validate_miswrite_ages_fails_if_includes_0():
                 },
             },
         )
-
-
-def test_validate_miswrite_ages_if_probabilities_do_not_add_to_1():
-    """Test that runtimerrors if probs do not add up to 1"""
-    perturbations = {-1: 0.1, 1: 0.8}  # does not sum to 1
-
-    with pytest.raises(ValueError, match="must sum to 1"):
-        get_configuration(
-            {
-                "decennial_census": {
-                    "column_noise": {
-                        "age": {
-                            "age_miswriting": {
-                                "possible_perturbations": perturbations,
-                            },
-                        },
-                    },
-                },
-            },
-        )
-
-
-@pytest.mark.parametrize("user_config_type", ["dict", "path"])
-def test_format_miswrite_ages(user_config_type, tmp_path):
-    """Test that user-supplied dictionary properly updates ConfigTree object.
-    This includes zero-ing out default values that don't exist in the user config
-    """
-    user_config = {
-        "decennial_census": {
-            "column_noise": {
-                "age": {
-                    "age_miswriting": {
-                        "possible_perturbations": [-2, -1, 2],
-                    },
-                },
-            },
-        },
-    }
-    if user_config_type == "path":
-        filepath = tmp_path / "user_dict.yaml"
-        with open(filepath, "w") as file:
-            yaml.dump(user_config, file)
-        user_config = filepath
-
-    new_dict = get_configuration(
-        user_config
-    ).decennial_census.column_noise.age.age_miswriting.to_dict()
-    default_dict = (
-        get_configuration().decennial_census.column_noise.age.age_miswriting.to_dict()
-    )
-    assert default_dict["row_noise_level"] == new_dict["row_noise_level"]
-    # check that 1 got replaced with 0 probability
-    assert new_dict["possible_perturbations"][1] == 0
-    # check that others have 1/3 probability
-    for p in [-2, -1, 2]:
-        assert new_dict["possible_perturbations"][p] == 1 / 3


### PR DESCRIPTION
## Validate user-provided configuration exist in default configuration
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: [MIC-3939](https://jira.ihme.washington.edu/browse/MIC-3939)

Refactored configuration.py into a module
Refactored get_configuration to split up code to generate the default config from the code to parse the user-provided config
Flipped the order of some arguments so we're consistently using default config as the first argument and user config second
Moved an age miswriting validation from the format function to the validation function
Restructured some configuration tests

### Testing
Added automated tests