### PR TITLE
Add logging and progress bar for generation of forms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ if __name__ == "__main__":
         "pyyaml>=5.1",
         "vivarium",
         "pyarrow",
+        "tqdm",
     ]
 
     interactive_requirements = [

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -4,6 +4,7 @@ from typing import Dict, Union
 import pandas as pd
 import pyarrow.parquet as pq
 from loguru import logger
+from tqdm import tqdm
 
 from pseudopeople.configuration import get_configuration
 from pseudopeople.constants import paths
@@ -58,6 +59,7 @@ def _generate_form(
         )
     noised_form = []
     for data_path in data_paths:
+        logger.info(f"Loading data from {data_path}.")
         data = _load_data_from_path(data_path, year_filter)
 
         data = _reformat_dates_for_noising(data, form)

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -4,12 +4,12 @@ from typing import Dict, Union
 import pandas as pd
 import pyarrow.parquet as pq
 from loguru import logger
-from tqdm import tqdm
 
 from pseudopeople.configuration import get_configuration
 from pseudopeople.constants import paths
 from pseudopeople.noise import noise_form
 from pseudopeople.schema_entities import COLUMNS, FORMS, Form
+from pseudopeople.utilities import configure_logging_to_terminal
 
 
 def _generate_form(
@@ -18,6 +18,7 @@ def _generate_form(
     seed: int,
     configuration: Union[Path, str, dict],
     year_filter: Dict,
+    verbose: bool = False,
 ) -> pd.DataFrame:
     """
     Helper for generating noised forms from clean data.
@@ -30,9 +31,14 @@ def _generate_form(
         Seed for controlling randomness
     :param configuration:
         Object to configure noise levels
+    :param year_filter:
+        Dictionary with keys 'hdf' and 'parquet' and values filter lists
+    :param verbose:
+        Log with verbosity if True. Default is False.
     :return:
         Noised form data in a pd.DataFrame
     """
+    configure_logging_to_terminal(verbose)
     configuration_tree = get_configuration(configuration)
     # TODO: we should save outputs of the simulation with filenames that are
     #  consistent with the names of the forms if possible.
@@ -131,6 +137,7 @@ def generate_decennial_census(
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
     year: int = 2020,
+    verbose: bool = False,
 ) -> pd.DataFrame:
     """
     Generates noised decennial census data from un-noised data.
@@ -139,13 +146,14 @@ def generate_decennial_census(
     :param seed: An integer seed for randomness
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
     :param year: The year from the data to noise
+    :param verbose: Log with verbosity if True. Default is False.
     :return: A pd.DataFrame of noised census data
     """
     year_filter = {"hdf": None, "parquet": None}
     if year:
         year_filter["hdf"] = [f"{FORMS.census.date_column} == {year}."]
         year_filter["parquet"] = [(FORMS.census.date_column, "==", year)]
-    return _generate_form(FORMS.census, source, seed, configuration, year_filter)
+    return _generate_form(FORMS.census, source, seed, configuration, year_filter, verbose)
 
 
 def generate_american_communities_survey(
@@ -153,6 +161,7 @@ def generate_american_communities_survey(
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
     year: int = 2020,
+    verbose: bool = False,
 ) -> pd.DataFrame:
     """
     Generates noised American Communities Survey (ACS) data from un-noised data.
@@ -161,6 +170,7 @@ def generate_american_communities_survey(
     :param seed: An integer seed for randomness
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
     :param year: The year from the data to noise
+    :param verbose: Log with verbosity if True. Default is False.
     :return: A pd.DataFrame of noised ACS data
     """
     year_filter = {"hdf": None, "parquet": None}
@@ -173,7 +183,7 @@ def generate_american_communities_survey(
             (FORMS.acs.date_column, "<=", pd.Timestamp(f"{year}-12-31")),
         ]
         seed = seed * 10_000 + year
-    return _generate_form(FORMS.acs, source, seed, configuration, year_filter)
+    return _generate_form(FORMS.acs, source, seed, configuration, year_filter, verbose)
 
 
 def generate_current_population_survey(
@@ -181,6 +191,7 @@ def generate_current_population_survey(
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
     year: int = 2020,
+    verbose: bool = False,
 ) -> pd.DataFrame:
     """
     Generates noised Current Population Survey (CPS) data from un-noised data.
@@ -189,6 +200,7 @@ def generate_current_population_survey(
     :param seed: An integer seed for randomness
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
     :param year: The year from the data to noise
+    :param verbose: Log with verbosity if True. Default is False.
     :return: A pd.DataFrame of noised CPS data
     """
     year_filter = {"hdf": None, "parquet": None}
@@ -201,7 +213,7 @@ def generate_current_population_survey(
             (FORMS.cps.date_column, "<=", pd.Timestamp(f"{year}-12-31")),
         ]
         seed = seed * 10_000 + year
-    return _generate_form(FORMS.cps, source, seed, configuration, year_filter)
+    return _generate_form(FORMS.cps, source, seed, configuration, year_filter, verbose)
 
 
 def generate_taxes_w2_and_1099(
@@ -209,6 +221,7 @@ def generate_taxes_w2_and_1099(
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
     year: int = 2020,
+    verbose: bool = False,
 ) -> pd.DataFrame:
     """
     Generates noised W2 and 1099 data from un-noised data.
@@ -217,6 +230,7 @@ def generate_taxes_w2_and_1099(
     :param seed: An integer seed for randomness
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
     :param year: The year from the data to noise
+    :param verbose: Log with verbosity if True. Default is False.
     :return: A pd.DataFrame of noised W2 and 1099 data
     """
     year_filter = {"hdf": None, "parquet": None}
@@ -224,7 +238,9 @@ def generate_taxes_w2_and_1099(
         year_filter["hdf"] = [f"{FORMS.tax_w2_1099.date_column} == {year}."]
         year_filter["parquet"] = [(FORMS.tax_w2_1099.date_column, "==", year)]
         seed = seed * 10_000 + year
-    return _generate_form(FORMS.tax_w2_1099, source, seed, configuration, year_filter)
+    return _generate_form(
+        FORMS.tax_w2_1099, source, seed, configuration, year_filter, verbose
+    )
 
 
 def generate_women_infants_and_children(
@@ -232,6 +248,7 @@ def generate_women_infants_and_children(
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
     year: int = 2020,
+    verbose: bool = False,
 ) -> pd.DataFrame:
     """
     Generates noised Women Infants and Children (WIC) data from un-noised data.
@@ -240,6 +257,7 @@ def generate_women_infants_and_children(
     :param seed: An integer seed for randomness
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
     :param year: The year from the data to noise
+    :param verbose: Log with verbosity if True. Default is False.
     :return: A pd.DataFrame of noised WIC data
     """
     year_filter = {"hdf": None, "parquet": None}
@@ -247,7 +265,7 @@ def generate_women_infants_and_children(
         year_filter["hdf"] = [f"{FORMS.wic.date_column} == {year}."]
         year_filter["parquet"] = [(FORMS.wic.date_column, "==", year)]
         seed = seed * 10_000 + year
-    return _generate_form(FORMS.wic, source, seed, configuration, year_filter)
+    return _generate_form(FORMS.wic, source, seed, configuration, year_filter, verbose)
 
 
 def generate_social_security(
@@ -255,6 +273,7 @@ def generate_social_security(
     seed: int = 0,
     configuration: Union[Path, str, dict] = None,
     year: int = 2020,
+    verbose: bool = False,
 ) -> pd.DataFrame:
     """
     Generates noised Social Security (SSA) data from un-noised data.
@@ -263,6 +282,7 @@ def generate_social_security(
     :param seed: An integer seed for randomness
     :param configuration: (optional) A path to a configuration YAML file or a dictionary to override the default configuration
     :param year: The year up to which to noise from the data
+    :param verbose: Log with verbosity if True. Default is False.
     :return: A pd.DataFrame of noised SSA data
     """
     year_filter = {"hdf": None, "parquet": None}
@@ -272,4 +292,4 @@ def generate_social_security(
             (FORMS.ssa.date_column, "<=", pd.Timestamp(f"{year}-12-31"))
         ]
         seed = seed * 10_000 + year
-    return _generate_form(FORMS.ssa, source, seed, configuration, year_filter)
+    return _generate_form(FORMS.ssa, source, seed, configuration, year_filter, verbose)

--- a/src/pseudopeople/noise.py
+++ b/src/pseudopeople/noise.py
@@ -12,6 +12,7 @@ rows in each columns changed to null values.  Then, the form data will be noised
 by column and row for each type of additional noise type.
 """
 import pandas as pd
+from tqdm import tqdm
 from vivarium import ConfigTree
 
 from pseudopeople.configuration import Keys
@@ -48,7 +49,7 @@ def noise_form(
     randomness = get_randomness_stream(form.name, seed)
 
     noise_configuration = configuration[form.name]
-    for noise_type in NOISE_TYPES:
+    for noise_type in tqdm(NOISE_TYPES, desc="Applying noise", unit="type"):
         if isinstance(noise_type, RowNoiseType):
             if (
                 Keys.ROW_NOISE in noise_configuration

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -1,7 +1,9 @@
+import sys
 from typing import Any, Union
 
 import numpy as np
 import pandas as pd
+from loguru import logger
 from vivarium.framework.randomness import RandomnessStream, random
 
 from pseudopeople.constants import paths
@@ -103,3 +105,24 @@ def noise_scaling_incorrect_selection(name: str) -> float:
     noise_scaling_value = 1 / (1 - 1 / len(options))
 
     return noise_scaling_value
+
+
+def configure_logging_to_terminal(verbose: bool = False):
+    logger.remove()  # Clear default configuration
+    add_logging_sink(sys.stdout, verbose, colorize=True)
+
+
+def add_logging_sink(sink, verbose, colorize=False, serialize=False):
+    message_format = (
+        "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
+        "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> "
+        "- <level>{message}</level>"
+    )
+    if verbose:
+        logger.add(
+            sink, colorize=colorize, level="DEBUG", format=message_format, serialize=serialize
+        )
+    else:
+        logger.add(
+            sink, colorize=colorize, level="INFO", format=message_format, serialize=serialize
+        )


### PR DESCRIPTION
## Add logging and progress bar for generation of forms

### Description

- *Category*: feature
- *JIRA issue*: [MIC-3987](https://jira.ihme.washington.edu/browse/MIC-3987)

#### Changes
- Adds tqdm to setup requirements
- Adds tqdm progress bar over the main noise_form loop
- Adds a logging message on opening a data file
- Sets default log level to INFO, configurable to DEBUG if verbose=True on an interface

### Testing
Interactive output looks as expected:
```
>>> import pseudopeople as pp
>>> data = pp.generate_decennial_census()
2023-04-14 10:16:37.443 | INFO     | pseudopeople.interface:_generate_form:62 - Loading data from /Users/mkappel/git/pseudopeople/pseudopeople/src/pseudopeople/data/sample_forms/decennial_census_observer/decennial_census_observer.parquet.
Applying noise: 100%|███████████████████████████| 8/8 [00:00<00:00, 53.98type/s]
>>> data2 = pp.generate_taxes_w2_and_1099()
2023-04-14 10:19:22.760 | INFO     | pseudopeople.interface:_generate_form:62 - Loading data from /Users/mkappel/git/pseudopeople/pseudopeople/src/pseudopeople/data/sample_forms/tax_w2_observer/tax_w2_observer.parquet.
Applying noise: 100%|███████████████████████████| 8/8 [00:00<00:00, 25.11type/s]
```
