### PR TITLE
change 'row_noise_level' to 'probability'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
 **0.5.0 - 04/13/23**
- - Bugfix to apply incorrect selection noising at the expected probabilility
+ - Bugfix to apply incorrect selection noising at the expected probability
  - Implement the omission noise function
  - Implement schema for output columns and their dtypes
  - Implement a year filter to the form generation functions

--- a/src/pseudopeople/configuration/entities.py
+++ b/src/pseudopeople/configuration/entities.py
@@ -4,6 +4,5 @@ class Keys:
     ROW_NOISE = "row_noise"  # second layer, eg <form>: row_noise: {...}
     COLUMN_NOISE = "column_noise"  # second layer, eg <form>: column_noise: {...}
     PROBABILITY = "probability"
-    ROW_NOISE_LEVEL = "row_noise_level"
     TOKEN_NOISE_LEVEL = "token_noise_level"
     AGE_MISWRITING_PERTURBATIONS = "possible_perturbations"

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -78,8 +78,8 @@ def _generate_default_configuration() -> ConfigTree:
             column_noise_dict = {}
             for noise_type in column.noise_types:
                 column_noise_type_dict = {}
-                if noise_type[Keys.PROBABILITY] is not None:
-                    column_noise_type_dict[Keys.PROBABILITY] = noise_type[Keys.PROBABILITY]
+                if noise_type.probability is not None:
+                    column_noise_type_dict[Keys.PROBABILITY] = noise_type.probability
                 if noise_type.token_noise_level is not None:
                     column_noise_type_dict[
                         Keys.TOKEN_NOISE_LEVEL

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -78,8 +78,8 @@ def _generate_default_configuration() -> ConfigTree:
             column_noise_dict = {}
             for noise_type in column.noise_types:
                 column_noise_type_dict = {}
-                if noise_type.row_noise_level is not None:
-                    column_noise_type_dict[Keys.ROW_NOISE_LEVEL] = noise_type.row_noise_level
+                if noise_type[Keys.PROBABILITY] is not None:
+                    column_noise_type_dict[Keys.PROBABILITY] = noise_type[Keys.PROBABILITY]
                 if noise_type.token_noise_level is not None:
                     column_noise_type_dict[
                         Keys.TOKEN_NOISE_LEVEL

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -6,6 +6,7 @@ from loguru import logger
 from vivarium import ConfigTree
 from vivarium.framework.randomness import RandomnessStream
 
+from pseudopeople.configuration import Keys
 from pseudopeople.utilities import get_index_to_noise
 
 
@@ -52,10 +53,13 @@ class ColumnNoiseType:
 
     name: str
     noise_function: Callable[[pd.Series, ConfigTree, RandomnessStream, Any], pd.Series]
-    row_noise_level: float = 0.01
+    probability: float = 0.01
     token_noise_level: Optional[float] = 0.1
     noise_level_scaling_function: Callable[[str], float] = lambda x: 1.0
     additional_parameters: Dict[str, Any] = None
+
+    def __getitem__(self, item):
+        return getattr(self, item)
 
     def __call__(
         self,
@@ -65,7 +69,7 @@ class ColumnNoiseType:
         additional_key: Any,
     ) -> pd.Series:
         column = column.copy()
-        noise_level = configuration.row_noise_level * self.noise_level_scaling_function(
+        noise_level = configuration[Keys.PROBABILITY] * self.noise_level_scaling_function(
             column.name
         )
         to_noise_idx = get_index_to_noise(

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -58,9 +58,6 @@ class ColumnNoiseType:
     noise_level_scaling_function: Callable[[str], float] = lambda x: 1.0
     additional_parameters: Dict[str, Any] = None
 
-    def __getitem__(self, item):
-        return getattr(self, item)
-
     def __call__(
         self,
         column: pd.Series,

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -58,7 +58,7 @@ def test_default_configuration_structure():
                 #  being row_noise, token_noise, and additional parameters at the
                 #  baseline level ('noise_type in col.noise_types')
                 #  Would we ever want to allow for adding non-baseline default noise?
-                if noise_type[Keys.PROBABILITY]:
+                if noise_type.probability:
                     config_probability = config_level[Keys.PROBABILITY]
                     default_probability = (
                         DEFAULT_NOISE_VALUES.get(form.name, {})
@@ -68,7 +68,7 @@ def test_default_configuration_structure():
                         .get(Keys.PROBABILITY, "no default")
                     )
                     if default_probability == "no default":
-                        assert config_probability == baseline_level[Keys.PROBABILITY]
+                        assert config_probability == baseline_level.probability
                     else:
                         assert config_probability == default_probability
                 if noise_type.token_noise_level:

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -15,7 +15,7 @@ def user_configuration_yaml(tmp_path):
     config = {
         "decennial_census": {
             "row_noise": {"omission": {"probability": 0.05}},
-            "column_noise": {"first_name": {"nickname": {"row_noise_level": 0.05}}},
+            "column_noise": {"first_name": {"nickname": {Keys.PROBABILITY: 0.05}}},
         }
     }
     with open(user_config_path, "w") as file:
@@ -58,19 +58,19 @@ def test_default_configuration_structure():
                 #  being row_noise, token_noise, and additional parameters at the
                 #  baseline level ('noise_type in col.noise_types')
                 #  Would we ever want to allow for adding non-baseline default noise?
-                if noise_type.row_noise_level:
-                    config_row_noise_level = config_level.row_noise_level
-                    default_row_noise_level = (
+                if noise_type[Keys.PROBABILITY]:
+                    config_probability = config_level[Keys.PROBABILITY]
+                    default_probability = (
                         DEFAULT_NOISE_VALUES.get(form.name, {})
                         .get("column_noise", {})
                         .get(col.name, {})
                         .get(noise_type.name, {})
-                        .get("row_noise_level", "no default")
+                        .get(Keys.PROBABILITY, "no default")
                     )
-                    if default_row_noise_level == "no default":
-                        assert config_row_noise_level == baseline_level.row_noise_level
+                    if default_probability == "no default":
+                        assert config_probability == baseline_level[Keys.PROBABILITY]
                     else:
-                        assert config_row_noise_level == default_row_noise_level
+                        assert config_probability == default_probability
                 if noise_type.token_noise_level:
                     config_token_noise_level = config_level.token_noise_level
                     default_token_noise_level = (
@@ -88,7 +88,7 @@ def test_default_configuration_structure():
                     config_additional_parameters = {
                         k: v
                         for k, v in config_level.to_dict().items()
-                        if k not in ["row_noise_level", "token_noise_level"]
+                        if k not in [Keys.PROBABILITY, "token_noise_level"]
                     }
                     default_additional_parameters = (
                         DEFAULT_NOISE_VALUES.get(form.name, {})
@@ -99,7 +99,7 @@ def test_default_configuration_structure():
                     default_additional_parameters = {
                         k: v
                         for k, v in default_additional_parameters.items()
-                        if k not in ["row_noise_level", "token_noise_level"]
+                        if k not in [Keys.PROBABILITY, "token_noise_level"]
                     }
                     if default_additional_parameters == {}:
                         assert (
@@ -141,7 +141,7 @@ def test_loading_from_yaml(tmp_path):
             Keys.COLUMN_NOISE: {
                 COLUMNS.age.name: {
                     NOISE_TYPES.age_miswriting.name: {
-                        Keys.ROW_NOISE_LEVEL: 0.5,
+                        Keys.PROBABILITY: 0.5,
                     },
                 },
             },
@@ -163,7 +163,7 @@ def test_loading_from_yaml(tmp_path):
         == updated_config[Keys.AGE_MISWRITING_PERTURBATIONS]
     )
     # check that 1 got replaced with 0 probability
-    assert updated_config[Keys.ROW_NOISE_LEVEL] == 0.5
+    assert updated_config[Keys.PROBABILITY] == 0.5
 
 
 @pytest.mark.parametrize(
@@ -277,7 +277,7 @@ def test_validate_miswrite_ages_failures(perturbations, error, match):
                     "column_noise": {
                         "age": {
                             "age_miswriting": {
-                                "row_noise_level": 1,
+                                Keys.PROBABILITY: 1,
                                 "possible_perturbations": perturbations,
                             },
                         },

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 from vivarium.config_tree import ConfigTree
 
+from pseudopeople.configuration import Keys
 from pseudopeople.entity_types import ColumnNoiseType
 from pseudopeople.interface import (
     generate_american_communities_survey,
@@ -51,34 +52,34 @@ def dummy_config_noise_numbers():
             "decennial_census": {
                 "column_noise": {
                     "event_type": {
-                        "missing_data": {"row_noise_level": 0.01},
-                        "incorrect_selection": {"row_noise_level": 0.01},
-                        "copy_from_within_household": {"row_noise_level": 0.01},
-                        "month_day_swap": {"row_noise_level": 0.01},
+                        "missing_data": {Keys.PROBABILITY: 0.01},
+                        "incorrect_selection": {Keys.PROBABILITY: 0.01},
+                        "copy_from_within_household": {Keys.PROBABILITY: 0.01},
+                        "month_day_swap": {Keys.PROBABILITY: 0.01},
                         "zipcode_miswriting": {
-                            "row_noise_level": 0.01,
+                            Keys.PROBABILITY: 0.01,
                             "zipcode_miswriting": [0.04, 0.04, 0.2, 0.36, 0.36],
                         },
                         "age_miswriting": {
-                            "row_noise_level": 0.01,
+                            Keys.PROBABILITY: 0.01,
                             "age_miswriting": [1, -1],
                         },
                         "numeric_miswriting": {
-                            "row_noise_level": 0.01,
+                            Keys.PROBABILITY: 0.01,
                             "numeric_miswriting": [0.1],
                         },
-                        "nickname": {"row_noise_level": 0.01},
-                        "fake_name": {"row_noise_level": 0.01},
+                        "nickname": {Keys.PROBABILITY: 0.01},
+                        "fake_name": {Keys.PROBABILITY: 0.01},
                         "phonetic": {
-                            "row_noise_level": 0.01,
+                            Keys.PROBABILITY: 0.01,
                             "token_noise_level": 0.1,
                         },
                         "ocr": {
-                            "row_noise_level": 0.01,
+                            Keys.PROBABILITY: 0.01,
                             "token_noise_level": 0.1,
                         },
                         "typographic": {
-                            "row_noise_level": 0.01,
+                            Keys.PROBABILITY: 0.01,
                             "token_noise_level": 0.1,
                         },
                     },
@@ -156,7 +157,7 @@ def test_columns_noised(dummy_data):
             "decennial_census": {
                 "column_noise": {
                     "event_type": {
-                        "missing_data": {"row_noise_level": 0.1},
+                        "missing_data": {Keys.PROBABILITY: 0.1},
                     },
                 },
             },
@@ -198,12 +199,12 @@ def test_two_noise_functions_are_independent(mocker):
             "decennial_census": {
                 "column_noise": {
                     "fake_column_one": {
-                        "alpha": {"row_noise_level": 0.20},
-                        "beta": {"row_noise_level": 0.30},
+                        "alpha": {Keys.PROBABILITY: 0.20},
+                        "beta": {Keys.PROBABILITY: 0.30},
                     },
                     "fake_column_two": {
-                        "alpha": {"row_noise_level": 0.40},
-                        "beta": {"row_noise_level": 0.50},
+                        "alpha": {Keys.PROBABILITY: 0.40},
+                        "beta": {Keys.PROBABILITY: 0.50},
                     },
                 },
             }
@@ -239,16 +240,16 @@ def test_two_noise_functions_are_independent(mocker):
 
     # Get config values for testing
     col1_expected_abc_proportion = (
-        config_tree.decennial_census.column_noise.fake_column_one.alpha.row_noise_level
+        config_tree.decennial_census.column_noise.fake_column_one.alpha[Keys.PROBABILITY]
     )
     col2_expected_abc_proportion = (
-        config_tree.decennial_census.column_noise.fake_column_two.alpha.row_noise_level
+        config_tree.decennial_census.column_noise.fake_column_two.alpha[Keys.PROBABILITY]
     )
     col1_expected_123_proportion = (
-        config_tree.decennial_census.column_noise.fake_column_one.beta.row_noise_level
+        config_tree.decennial_census.column_noise.fake_column_one.beta[Keys.PROBABILITY]
     )
     col2_expected_123_proportion = (
-        config_tree.decennial_census.column_noise.fake_column_two.beta.row_noise_level
+        config_tree.decennial_census.column_noise.fake_column_two.beta[Keys.PROBABILITY]
     )
 
     assert np.isclose(


### PR DESCRIPTION
## Title: Change 'row_level_noise' to "probability'

### Description
- *Category*: other
- *JIRA issue*: [MIC-3945](https://jira.ihme.washington.edu/browse/MIC-3945)

This is the first of probably many PRs that are starting to conver the configuration
key names. 

https://uwnetid.sharepoint.com/:x:/r/sites/ihme_simulation_science_team/_layouts/15/Doc.aspx?sourcedoc=%7B52FC5569-29D6-40B1-B240-158C6AB7D043%7D&file=prl-configuration-item-names.xlsx&action=default&mobileredirect=true 

### Testing
pytests pass

