### PR TITLE
Update zipcode miswriting

### DIFF
--- a/src/pseudopeople/configuration/entities.py
+++ b/src/pseudopeople/configuration/entities.py
@@ -7,3 +7,4 @@ class Keys:
     ROW_NOISE_LEVEL = "row_noise_level"
     TOKEN_NOISE_LEVEL = "token_noise_level"
     AGE_MISWRITING_PERTURBATIONS = "possible_perturbations"
+    ZIPCODE_DIGIT_PROBABILITIES = "digit_probabilities"

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -40,11 +40,7 @@ class __NoiseTypes(NamedTuple):
         "zipcode_miswriting",
         noise_functions.miswrite_zipcodes,
         token_noise_level=None,
-        additional_parameters={
-            "first_two_digits_noise_level": 0.04,
-            "middle_digit_noise_level": 0.20,
-            "last_two_digits_noise_level": 0.36,
-        },
+        additional_parameters={Keys.ZIPCODE_DIGIT_PROBABILITIES: [0.04, 0.04, 0.20, 0.36, 0.36]},
     )
     age_miswriting: ColumnNoiseType = ColumnNoiseType(
         "age_miswriting",

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -40,7 +40,9 @@ class __NoiseTypes(NamedTuple):
         "zipcode_miswriting",
         noise_functions.miswrite_zipcodes,
         token_noise_level=None,
-        additional_parameters={Keys.ZIPCODE_DIGIT_PROBABILITIES: [0.04, 0.04, 0.20, 0.36, 0.36]},
+        additional_parameters={
+            Keys.ZIPCODE_DIGIT_PROBABILITIES: [0.04, 0.04, 0.20, 0.36, 0.36]
+        },
     )
     age_miswriting: ColumnNoiseType = ColumnNoiseType(
         "age_miswriting",

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -152,7 +152,9 @@ def miswrite_zipcodes(
     # Scale up noise levels to adjust for inclusive sampling with all numbers
     scaleup_factor = 1 / (1 - (1 / len(possible_replacements)))
     # Get configuration values for each piece of 5 digit zipcode
-    digit_probabilities = scaleup_factor * np.array(configuration[Keys.ZIPCODE_DIGIT_PROBABILITIES])
+    digit_probabilities = scaleup_factor * np.array(
+        configuration[Keys.ZIPCODE_DIGIT_PROBABILITIES]
+    )
     replace = rng.random(shape) < digit_probabilities
     random_digits = rng.choice(possible_replacements, shape)
     digits = []

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -152,10 +152,7 @@ def miswrite_zipcodes(
     # Scale up noise levels to adjust for inclusive sampling with all numbers
     scaleup_factor = 1 / (1 - (1 / len(possible_replacements)))
     # Get configuration values for each piece of 5 digit zipcode
-    scaled_digit_prob = [
-        p * scaleup_factor for p in configuration[Keys.ZIPCODE_DIGIT_PROBABILITIES]
-    ]
-    digit_probabilities = np.array(scaled_digit_prob)
+    digit_probabilities = scaleup_factor * np.array(configuration[Keys.ZIPCODE_DIGIT_PROBABILITIES])
     replace = rng.random(shape) < digit_probabilities
     random_digits = rng.choice(possible_replacements, shape)
     digits = []

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -6,6 +6,7 @@ import yaml
 from vivarium import ConfigTree
 from vivarium.framework.randomness import RandomnessStream
 
+from pseudopeople.configuration import Keys
 from pseudopeople.constants import paths
 from pseudopeople.data.fake_names import fake_first_names, fake_last_names
 from pseudopeople.utilities import get_index_to_noise, vectorized_choice
@@ -151,11 +152,8 @@ def miswrite_zipcodes(
     # Scale up noise levels to adjust for inclusive sampling with all numbers
     scaleup_factor = 1 / (1 - (1 / len(possible_replacements)))
     # Get configuration values for each piece of 5 digit zipcode
-    first2_prob = configuration.first_two_digits_noise_level * scaleup_factor
-    middle_prob = configuration.middle_digit_noise_level * scaleup_factor
-    last2_prob = configuration.last_two_digits_noise_level * scaleup_factor
-    threshold = np.array([2 * [first2_prob] + [middle_prob] + 2 * [last2_prob]])
-    replace = rng.random(shape) < threshold
+    digit_probabilities = np.array(configuration[Keys.ZIPCODE_DIGIT_PROBABILITIES])
+    replace = rng.random(shape) < digit_probabilities
     random_digits = rng.choice(possible_replacements, shape)
     digits = []
     for i in range(5):

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -152,7 +152,10 @@ def miswrite_zipcodes(
     # Scale up noise levels to adjust for inclusive sampling with all numbers
     scaleup_factor = 1 / (1 - (1 / len(possible_replacements)))
     # Get configuration values for each piece of 5 digit zipcode
-    digit_probabilities = np.array(configuration[Keys.ZIPCODE_DIGIT_PROBABILITIES])
+    scaled_digit_prob = [
+        p * scaleup_factor for p in configuration[Keys.ZIPCODE_DIGIT_PROBABILITIES]
+    ]
+    digit_probabilities = np.array(scaled_digit_prob)
     replace = rng.random(shape) < digit_probabilities
     random_digits = rng.choice(possible_replacements, shape)
     digits = []


### PR DESCRIPTION
## Update zipcode miswriting

### Updates zipcode miswriting function and default configuration to take list of probabilities and changes key name.
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: [MIC-4002](https://jira.ihme.washington.edu/browse/MIC-4002)

-Changes additional parameters to a list of probabilities for each of the 5 digits in a zipcode
-Changes key name to digit probabilities for the configuration 

### Testing
All tests pass successfully.

