### PR TITLE
add individuals not in the ihmeuw org to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # default owners
 * @ihmeuw/vivarium-dev
 /docs/* @ihmeuw/vivarium-research @ihmeuw/vivarium-dev
-*.rst @ihmeuw/vivarium-research @ihmeuw/vivarium-dev
+*.rst @ihmeuw/vivarium-research @ihmeuw/vivarium-dev @zmbc @pletale


### PR DESCRIPTION
## Add individuals not in the ihmeuw org to codeowners
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: other/misc
- *JIRA issue*: N/A

These individuals aren't in ihmeuw/vivarium-research but should be able to approve docs changes

### Testing
N/A