### PR TITLE
Add to the dataset documentation and create outline for rest of page

### DIFF
--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -3,7 +3,12 @@
 ========
 Datasets
 ========
-Here we cover the simulated datasets, which are analogous to 'real world' administrative records such as tax documents and census surveys, that users can generate using :code:`pseudopeople` to test their PRL methods. 
+Here we cover the simulated datasets, which are analogous to 'real world' administrative records such as tax documents
+and census surveys, that users can generate using :code:`pseudopeople` to test their PRL methods.
+
+The below table offers a list of the datasets that can be generated. Each row of a given dataset represents
+an individual simulant, with the columns representing different simulant attributes, such as name, age, sex, et cetera.
+
 
 .. contents::
    :depth: 2
@@ -11,22 +16,78 @@ Here we cover the simulated datasets, which are analogous to 'real world' admini
    :backlinks: none
 
 
-.. list-table:: **Types of Forms**
+.. list-table:: **Available Datasets**
    :header-rows: 1
    :widths: 20
 
    * - Name
-   * - | Decennial census
-   * - | American communities survey
-   * - | Current population survey
-   * - | Women, infants, and children survey
-   * - | Social security
-   * - | Tax W2 and 1099 forms
-   * - | Tax 1040 form
-
-Decennial Census
-----------------
+   * - | US Decennial Census
+   * - | American Communities Survey (ACS)
+   * - | Current Population Survey (CPS)
+   * - | Women, Infants, and Children (WIC) Administrative Data
+   * - | Social Security Administration Data
+   * - | Tax W2 and 1099 Forms
+   * - | Tax 1040 Form
 
 
-Household Surveys: American Communities Survey and Current Population Survey
-----------------------------------------------------------------------------
+US Decennial Census
+-------------------
+The Decennial Census dataset is a simulated enumeration of the US Census Bureau's Decennial Census Survey. The years
+that have been simulated are 2020, 2030, and 2040.
+
+The following simulant attributes are included in this dataset:
+
+.. list-table:: **Simulant attributes**
+   :header-rows: 1
+
+   * - Attribute Name
+     - Column Name
+   * - Unique simulant ID
+     - 
+   * - First name
+     - :code:`first_name`
+   * - Middle initial
+     - :code:`middle_initial`
+   * - Last name
+     - :code:`last_name`
+   * - Age
+     - :code:`age`  
+   * - Date of birth
+     - :code:`date_of_birth`
+   * - Physical address street number
+     - :code:`street_number`
+   * - Physical address street name
+     - :code:`street_name`
+   * - Physical address unit
+     - :code:`unit_number`
+   * - Physical address city
+     - :code:`city`    
+   * - Physical address state
+     - :code:`state`  
+   * - Physical address ZIP code
+     - :code:`zipcode`
+   * - Relationship to person 1 (head of household)
+     - :code:`relationship_to_household_head` 
+   * - Sex (binary; 'male' or 'female')
+     - :code:`sex`  
+   * - Race/ethnicity
+     - :code:`race_ethnicity` 
+
+Household Surveys: ACS and CPS
+------------------------------
+
+
+WIC
+---
+
+
+Social Security
+---------------
+
+
+Tax W-2 & 1099
+--------------
+
+
+Tax 1040
+--------


### PR DESCRIPTION
## Title: Add to the dataset documentation and create outline for rest of page
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*:  documentation <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: None

Adds more description to Census dataset (table of attribute names and corresponding column names); and creates an outline for the rest of the page. 

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
Docs built locally and checked visually by using 'make html' 
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

