### PR TITLE
Add attribute and column names to household survey docs

### DIFF
--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -76,7 +76,7 @@ The following simulant attributes are included in this dataset:
 
 Household Surveys: ACS and CPS
 ------------------------------
-There are two simulated household survey datasets that can be loaded using :code:`pseudopeople`: the American
+There are two simulated household survey datasets that can be used: the American
 Communities Survey (ACS) and the Current Population Survey (CPS). 
 
 .. list-table:: **Simulant attributes**

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -3,8 +3,9 @@
 ========
 Datasets
 ========
-Here we cover the simulated datasets, which are analogous to 'real world' administrative records such as tax documents
-and census surveys, that users can generate using :code:`pseudopeople` to test their PRL methods.
+Here we cover the realistic simulated datasets, which are analogous to 'real world' administrative records such as tax documents
+and census surveys, that users can generate using :code:`pseudopeople` for developing and testing Entity Resolution algorithms 
+and software.
 
 The below table offers a list of the datasets that can be generated. Each row of a given dataset represents
 an individual simulant, with the columns representing different simulant attributes, such as name, age, sex, et cetera.
@@ -41,7 +42,7 @@ The following simulant attributes are included in this dataset:
    :header-rows: 1
 
    * - Attribute Name
-     - Column Name
+     - Column Name    
    * - Unique simulant ID
      - 
    * - First name
@@ -75,7 +76,46 @@ The following simulant attributes are included in this dataset:
 
 Household Surveys: ACS and CPS
 ------------------------------
+There are two simulated household survey datasets that can be loaded using :code:`pseudopeople`: the American
+Communities Survey (ACS) and the Current Population Survey (CPS). 
 
+.. list-table:: **Simulant attributes**
+   :header-rows: 1
+
+   * - Attribute Name
+     - Column Name
+   * - Unique simulant ID
+     - 
+   * - Household ID 
+     -  
+   * - First name
+     - :code:`first_name`
+   * - Middle initial
+     - :code:`middle_initial`
+   * - Last name
+     - :code:`last_name`
+   * - Age
+     - :code:`age`  
+   * - Date of birth
+     - :code:`date_of_birth`
+   * - Physical address street number
+     - :code:`street_number`
+   * - Physical address street name
+     - :code:`street_name`
+   * - Physical address unit
+     - :code:`unit_number`
+   * - Physical address city
+     - :code:`city`    
+   * - Physical address state
+     - :code:`state`  
+   * - Physical address ZIP code
+     - :code:`zipcode`
+   * - Relationship to person 1 (head of household)
+     - :code:`relationship_to_household_head` 
+   * - Sex (binary; 'male' or 'female')
+     - :code:`sex`  
+   * - Race/ethnicity
+     - :code:`race_ethnicity` 
 
 WIC
 ---


### PR DESCRIPTION
## Title: Add attribute and column names to household survey docs
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: none

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
Docs built locally and checked visually by using 'make html'
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

