### PR TITLE
Feature/sbachmei/mic 3945 remove default token noise level

### DIFF
--- a/src/pseudopeople/configuration/entities.py
+++ b/src/pseudopeople/configuration/entities.py
@@ -4,6 +4,7 @@ class Keys:
     ROW_NOISE = "row_noise"  # second layer, eg <form>: row_noise: {...}
     COLUMN_NOISE = "column_noise"  # second layer, eg <form>: column_noise: {...}
     PROBABILITY = "probability"
+    CELL_PROBABILITY = "cell_probability"
     TOKEN_NOISE_LEVEL = "token_noise_level"
     AGE_MISWRITING_PERTURBATIONS = "possible_perturbations"
     ZIPCODE_DIGIT_PROBABILITIES = "digit_probabilities"

--- a/src/pseudopeople/configuration/entities.py
+++ b/src/pseudopeople/configuration/entities.py
@@ -6,6 +6,7 @@ class Keys:
     PROBABILITY = "probability"
     CELL_PROBABILITY = "cell_probability"
     TOKEN_NOISE_LEVEL = "token_noise_level"
+    REPLACE_TOKEN_PROBABILITY = "replace_token_probability"
     AGE_MISWRITING_PERTURBATIONS = "possible_perturbations"
     ZIPCODE_DIGIT_PROBABILITIES = "digit_probabilities"
     REPLACE_TOKEN_PROBABILITY = "replace_token_probability"

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -80,10 +80,6 @@ def _generate_default_configuration() -> ConfigTree:
                 column_noise_type_dict = {}
                 if noise_type.probability is not None:
                     column_noise_type_dict[Keys.PROBABILITY] = noise_type.probability
-                if noise_type.token_noise_level is not None:
-                    column_noise_type_dict[
-                        Keys.TOKEN_NOISE_LEVEL
-                    ] = noise_type.token_noise_level
                 if noise_type.additional_parameters is not None:
                     for key, value in noise_type.additional_parameters.items():
                         column_noise_type_dict[key] = value

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -54,7 +54,6 @@ class ColumnNoiseType:
     name: str
     noise_function: Callable[[pd.Series, ConfigTree, RandomnessStream, Any], pd.Series]
     probability: float = 0.01
-    token_noise_level: Optional[float] = 0.1
     noise_level_scaling_function: Callable[[str], float] = lambda x: 1.0
     additional_parameters: Dict[str, Any] = None
 

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -66,7 +66,12 @@ class ColumnNoiseType:
         additional_key: Any,
     ) -> pd.Series:
         column = column.copy()
-        noise_level = configuration[Keys.PROBABILITY] * self.noise_level_scaling_function(
+        probability_key = (
+            Keys.PROBABILITY
+            if Keys.PROBABILITY in configuration.keys()
+            else Keys.CELL_PROBABILITY
+        )
+        noise_level = configuration[probability_key] * self.noise_level_scaling_function(
             column.name
         )
         to_noise_idx = get_index_to_noise(

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -20,13 +20,11 @@ class __NoiseTypes(NamedTuple):
     missing_data: ColumnNoiseType = ColumnNoiseType(
         "leave_blank",
         noise_functions.generate_missing_data,
-        token_noise_level=None,
     )
     incorrect_selection: ColumnNoiseType = ColumnNoiseType(
         "choose_wrong_option",
         noise_functions.generate_incorrect_selections,
         noise_level_scaling_function=utilities.noise_scaling_incorrect_selection,
-        token_noise_level=None,
     )
     # copy_from_within_household: ColumnNoiseType = ColumnNoiseType(
     #     "copy_from_household_member",
@@ -40,7 +38,6 @@ class __NoiseTypes(NamedTuple):
         "write_wrong_zipcode_digits",
         noise_functions.miswrite_zipcodes,
         probability=None,
-        token_noise_level=None,
         additional_parameters={
             Keys.CELL_PROBABILITY: 0.01,
             Keys.ZIPCODE_DIGIT_PROBABILITIES: [0.04, 0.04, 0.20, 0.36, 0.36],
@@ -49,12 +46,16 @@ class __NoiseTypes(NamedTuple):
     age_miswriting: ColumnNoiseType = ColumnNoiseType(
         "misreport_age",
         noise_functions.miswrite_ages,
-        token_noise_level=None,
         additional_parameters={Keys.AGE_MISWRITING_PERTURBATIONS: {-1: 0.5, 1: 0.5}},
     )
     numeric_miswriting: ColumnNoiseType = ColumnNoiseType(
         "write_wrong_digits",
         noise_functions.miswrite_numerics,
+        probability=None,
+        additional_parameters={  # TODO: need to clarify these
+            Keys.CELL_PROBABILITY: 0.01,
+            Keys.REPLACE_TOKEN_PROBABILITY: 0.1,
+        },
     )
     # nickname: ColumnNoiseType = ColumnNoiseType(
     #     "use_nickname",
@@ -70,6 +71,7 @@ class __NoiseTypes(NamedTuple):
     #     probability=None,
     #     additional_parameters={
     #         Keys.CELL_PROBABILITY: 0.01,
+    #         Keys.REPLACE_TOKEN_PROBABILITY: 0.1,
     #     },
     # )
     # ocr: ColumnNoiseType = ColumnNoiseType(
@@ -77,15 +79,17 @@ class __NoiseTypes(NamedTuple):
     #     noise_functions.generate_ocr_errors,
     #     probability=None,
     #     additional_parameters={
-    #         Keys.CELL_PROBABILITY: 0.01
+    #         Keys.CELL_PROBABILITY: 0.01,
+    #         Keys.REPLACE_TOKEN_PROBABILITY: 0.1,
     #     },
     # )
     typographic: ColumnNoiseType = ColumnNoiseType(
         "make_typos",
         noise_functions.generate_typographical_errors,
         probability=None,
-        additional_parameters={
+        additional_parameters={  # TODO: need to clarify these
             Keys.CELL_PROBABILITY: 0.01,
+            Keys.TOKEN_NOISE_LEVEL: 0.1,
             Keys.REPLACE_TOKEN_PROBABILITY: 0.9,
         },
     )

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -39,9 +39,11 @@ class __NoiseTypes(NamedTuple):
     zipcode_miswriting: ColumnNoiseType = ColumnNoiseType(
         "write_wrong_zipcode_digits",
         noise_functions.miswrite_zipcodes,
+        probability=None,
         token_noise_level=None,
         additional_parameters={
-            Keys.ZIPCODE_DIGIT_PROBABILITIES: [0.04, 0.04, 0.20, 0.36, 0.36]
+            Keys.CELL_PROBABILITY: 0.01,
+            Keys.ZIPCODE_DIGIT_PROBABILITIES: [0.04, 0.04, 0.20, 0.36, 0.36],
         },
     )
     age_miswriting: ColumnNoiseType = ColumnNoiseType(
@@ -65,15 +67,27 @@ class __NoiseTypes(NamedTuple):
     # phonetic: ColumnNoiseType = ColumnNoiseType(
     #     "make_phonetic_errors",
     #     noise_functions.generate_phonetic_errors,
+    #     probability=None,
+    #     additional_parameters={
+    #         Keys.CELL_PROBABILITY: 0.01,
+    #     },
     # )
     # ocr: ColumnNoiseType = ColumnNoiseType(
     #     "make_ocr_errors",
     #     noise_functions.generate_ocr_errors,
+    #     probability=None,
+    #     additional_parameters={
+    #         Keys.CELL_PROBABILITY: 0.01
+    #     },
     # )
     typographic: ColumnNoiseType = ColumnNoiseType(
         "make_typos",
         noise_functions.generate_typographical_errors,
-        additional_parameters={Keys.REPLACE_TOKEN_PROBABILITY: 0.9},
+        probability=None,
+        additional_parameters={
+            Keys.CELL_PROBABILITY: 0.01,
+            Keys.REPLACE_TOKEN_PROBABILITY: 0.9,
+        },
     )
 
 

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -217,7 +217,7 @@ def miswrite_numerics(
     if column.empty:
         return column
     # This is a fix to not replacing the original token for noise options
-    token_noise_level = configuration.token_noise_level / 0.9
+    token_noise_level = configuration[Keys.REPLACE_TOKEN_PROBABILITY] / 0.9
     rng = np.random.default_rng(randomness_stream.seed)
     column = column.astype(str)
     longest_str = column.str.len().max()

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -187,7 +187,7 @@ def test_miswrite_zipcodes(dummy_dataset):
                 Keys.COLUMN_NOISE: {
                     "zipcode": {
                         NOISE_TYPES.zipcode_miswriting.name: {
-                            Keys.PROBABILITY: 0.5,
+                            Keys.CELL_PROBABILITY: 0.5,
                             Keys.ZIPCODE_DIGIT_PROBABILITIES: dummy_digit_probabilities,
                         },
                     },
@@ -200,7 +200,7 @@ def test_miswrite_zipcodes(dummy_dataset):
     ]
 
     # Get configuration values for each piece of 5 digit zipcode
-    probability = config[Keys.PROBABILITY]
+    probability = config[Keys.CELL_PROBABILITY]
     data = dummy_dataset["zipcode"]
     noised_data = NOISE_TYPES.zipcode_miswriting(data, config, RANDOMNESS0, "test_zipcode")
 
@@ -567,7 +567,7 @@ def test_generate_typographical_errors(dummy_dataset, column):
                 Keys.COLUMN_NOISE: {
                     column: {
                         NOISE_TYPES.typographic.name: {
-                            Keys.PROBABILITY: 0.1,
+                            Keys.CELL_PROBABILITY: 0.1,
                             "token_noise_level": 0.1,
                             "replace_token_probability": 0.9,
                         },
@@ -586,7 +586,7 @@ def test_generate_typographical_errors(dummy_dataset, column):
     check_noised = noised_data.loc[not_missing_idx]
 
     # Check for expected noise level
-    p_row_noise = config[Keys.PROBABILITY]
+    p_row_noise = config[Keys.CELL_PROBABILITY]
     p_token_noise = config.token_noise_level
     str_lengths = check_original.str.len()  # pd.Series
     p_token_not_noised = 1 - p_token_noise

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -372,8 +372,8 @@ def test_miswrite_numerics(string_series):
                 Keys.COLUMN_NOISE: {
                     "street_number": {
                         NOISE_TYPES.numeric_miswriting.name: {
-                            Keys.PROBABILITY: 0.4,
-                            "token_noise_level": 0.5,
+                            Keys.CELL_PROBABILITY: 0.4,
+                            Keys.REPLACE_TOKEN_PROBABILITY: 0.5,
                         },
                     },
                 },
@@ -383,8 +383,8 @@ def test_miswrite_numerics(string_series):
     config = config[FORMS.census.name][Keys.COLUMN_NOISE]["street_number"][
         NOISE_TYPES.numeric_miswriting.name
     ]
-    p_row_noise = config[Keys.PROBABILITY]
-    p_token_noise = config.token_noise_level
+    p_row_noise = config[Keys.CELL_PROBABILITY]
+    p_token_noise = config[Keys.REPLACE_TOKEN_PROBABILITY]
     data = string_series
     # Hack: we need to name the series something with the miswrite_numeric noising
     # function applied to check dtypes.
@@ -568,8 +568,8 @@ def test_generate_typographical_errors(dummy_dataset, column):
                     column: {
                         NOISE_TYPES.typographic.name: {
                             Keys.CELL_PROBABILITY: 0.1,
-                            "token_noise_level": 0.1,
-                            "replace_token_probability": 0.9,
+                            Keys.TOKEN_NOISE_LEVEL: 0.1,
+                            Keys.REPLACE_TOKEN_PROBABILITY: 0.9,
                         },
                     },
                 },
@@ -587,7 +587,7 @@ def test_generate_typographical_errors(dummy_dataset, column):
 
     # Check for expected noise level
     p_row_noise = config[Keys.CELL_PROBABILITY]
-    p_token_noise = config.token_noise_level
+    p_token_noise = config[Keys.TOKEN_NOISE_LEVEL]
     str_lengths = check_original.str.len()  # pd.Series
     p_token_not_noised = 1 - p_token_noise
     p_strings_not_noised = p_token_not_noised**str_lengths  # pd.Series

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -58,24 +58,11 @@ def test_default_configuration_structure():
                         assert config_probability == noise_type.probability
                     else:
                         assert config_probability == default_probability
-                if noise_type.token_noise_level:
-                    config_token_noise_level = config_level.token_noise_level
-                    default_token_noise_level = (
-                        DEFAULT_NOISE_VALUES.get(form.name, {})
-                        .get(Keys.COLUMN_NOISE, {})
-                        .get(col.name, {})
-                        .get(noise_type.name, {})
-                        .get("token_noise_level", "no default")
-                    )
-                    if default_token_noise_level == "no default":
-                        assert config_token_noise_level == noise_type.token_noise_level
-                    else:
-                        assert config_token_noise_level == default_token_noise_level
                 if noise_type.additional_parameters:
                     config_additional_parameters = {
                         k: v
                         for k, v in config_level.to_dict().items()
-                        if k not in [Keys.PROBABILITY, "token_noise_level"]
+                        if k != Keys.PROBABILITY
                     }
                     default_additional_parameters = (
                         DEFAULT_NOISE_VALUES.get(form.name, {})
@@ -86,7 +73,7 @@ def test_default_configuration_structure():
                     default_additional_parameters = {
                         k: v
                         for k, v in default_additional_parameters.items()
-                        if k not in [Keys.PROBABILITY, "token_noise_level"]
+                        if k != Keys.PROBABILITY
                     }
                     if default_additional_parameters == {}:
                         assert (


### PR DESCRIPTION
## Title: Remove default token noise level

### Description
- *Category*: other
- *JIRA issue*: [MIC-3945](https://jira.ihme.washington.edu/browse/MIC-XYZ)

This removes the token noise level attribute from the ColumnNOiseType
class. The end goals is to not have anything called "token_noise_probability"
but due to late-afternoon confusion and discussion with RT, I left it there
for the typographic noising function for now.

### Testing
tests pass

