### PR TITLE
Feature/sbachmei/mic 3945 final cleanup

### DIFF
--- a/src/pseudopeople/configuration/entities.py
+++ b/src/pseudopeople/configuration/entities.py
@@ -5,8 +5,7 @@ class Keys:
     COLUMN_NOISE = "column_noise"  # second layer, eg <form>: column_noise: {...}
     PROBABILITY = "probability"
     CELL_PROBABILITY = "cell_probability"
-    TOKEN_NOISE_LEVEL = "token_noise_level"
-    REPLACE_TOKEN_PROBABILITY = "replace_token_probability"
-    AGE_MISWRITING_PERTURBATIONS = "possible_perturbations"
+    TOKEN_PROBABILITY = "token_probability"
+    INCLUDE_ORIGINAL_TOKEN_PROBABILITY = "include_original_token_probability"
+    POSSIBLE_AGE_DIFFERENCES = "possible_age_differences"
     ZIPCODE_DIGIT_PROBABILITIES = "digit_probabilities"
-    REPLACE_TOKEN_PROBABILITY = "replace_token_probability"

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -84,11 +84,16 @@ def _generate_default_configuration() -> ConfigTree:
                     for key, value in noise_type.additional_parameters.items():
                         column_noise_type_dict[key] = value
                 if column_noise_type_dict:
+                    # We should not have both 'probability' and 'cell_probability'
+                    if Keys.PROBABILITY in column_noise_type_dict and Keys.CELL_PROBABILITY in column_noise_type_dict:
+                        raise ValueError(
+                            "'probability' and 'cell_probability' are mutually exclusive "
+                            "but both are found in the default configuration for "
+                            f"form '{form.name}', column '{column.name}', noise type '{noise_type.name}'"
+                        )
                     column_noise_dict[noise_type.name] = column_noise_type_dict
             if column_noise_dict:
                 column_dict[column.name] = column_noise_dict
-
-        # TODO: add check that we are not adding `probability` and `cell_probability`
 
         # Compile
         if row_noise_dict:

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -85,7 +85,10 @@ def _generate_default_configuration() -> ConfigTree:
                         column_noise_type_dict[key] = value
                 if column_noise_type_dict:
                     # We should not have both 'probability' and 'cell_probability'
-                    if Keys.PROBABILITY in column_noise_type_dict and Keys.CELL_PROBABILITY in column_noise_type_dict:
+                    if (
+                        Keys.PROBABILITY in column_noise_type_dict
+                        and Keys.CELL_PROBABILITY in column_noise_type_dict
+                    ):
                         raise ValueError(
                             "'probability' and 'cell_probability' are mutually exclusive "
                             "but both are found in the default configuration for "
@@ -141,14 +144,14 @@ def _format_age_miswriting_perturbations(default_config: ConfigTree, user_dict: 
             .get(Keys.COLUMN_NOISE, {})
             .get("age", {})
             .get(NOISE_TYPES.age_miswriting.name, {})
-            .get(Keys.AGE_MISWRITING_PERTURBATIONS, {})
+            .get(Keys.POSSIBLE_AGE_DIFFERENCES, {})
         )
         if not user_perturbations:
             continue
         formatted = {}
         default_perturbations = default_config[form][Keys.COLUMN_NOISE]["age"][
             NOISE_TYPES.age_miswriting.name
-        ][Keys.AGE_MISWRITING_PERTURBATIONS]
+        ][Keys.POSSIBLE_AGE_DIFFERENCES]
         # Replace default configuration with 0 probabilities
         for perturbation in default_perturbations:
             formatted[perturbation] = 0
@@ -162,7 +165,7 @@ def _format_age_miswriting_perturbations(default_config: ConfigTree, user_dict: 
                 formatted[perturbation] = prob
 
         user_dict[form][Keys.COLUMN_NOISE]["age"][NOISE_TYPES.age_miswriting.name][
-            Keys.AGE_MISWRITING_PERTURBATIONS
+            Keys.POSSIBLE_AGE_DIFFERENCES
         ] = formatted
 
     return user_dict

--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -56,7 +56,7 @@ def _validate_noise_type_config(
     for parameter, parameter_config in noise_type_config.items():
         parameter_config_validator = {
             # todo add additional config value validators
-            Keys.AGE_MISWRITING_PERTURBATIONS: _validate_age_miswriting_perturbations_config
+            Keys.POSSIBLE_AGE_DIFFERENCES: _validate_age_miswriting_perturbations_config
         }.get(parameter, lambda *_: _)
 
         _ = _get_default_config_node(
@@ -106,13 +106,13 @@ def _validate_age_miswriting_perturbations_config(
     for key in noise_type_config:
         if not isinstance(key, int):
             raise TypeError(
-                "All possible age miswriting perturbations must be ints. "
+                "All possible age miswriting differences must be ints. "
                 f"Provided {key} of type {type(key)} in the configuration "
                 f"for form {form} and column {column}."
             )
         if key == 0:
             raise ValueError(
-                "Cannot include 0 as an age miswriting perturbation. "
+                "Cannot include 0 as an age miswriting difference. "
                 f"Provided 0 in the configuration for form {form} and "
                 f"column {column}."
             )

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -46,15 +46,15 @@ class __NoiseTypes(NamedTuple):
     age_miswriting: ColumnNoiseType = ColumnNoiseType(
         "misreport_age",
         noise_functions.miswrite_ages,
-        additional_parameters={Keys.AGE_MISWRITING_PERTURBATIONS: {-1: 0.5, 1: 0.5}},
+        additional_parameters={Keys.POSSIBLE_AGE_DIFFERENCES: {-1: 0.5, 1: 0.5}},
     )
     numeric_miswriting: ColumnNoiseType = ColumnNoiseType(
         "write_wrong_digits",
         noise_functions.miswrite_numerics,
         probability=None,
-        additional_parameters={  # TODO: need to clarify these
+        additional_parameters={
             Keys.CELL_PROBABILITY: 0.01,
-            Keys.REPLACE_TOKEN_PROBABILITY: 0.1,
+            Keys.TOKEN_PROBABILITY: 0.1,
         },
     )
     # nickname: ColumnNoiseType = ColumnNoiseType(
@@ -71,7 +71,7 @@ class __NoiseTypes(NamedTuple):
     #     probability=None,
     #     additional_parameters={
     #         Keys.CELL_PROBABILITY: 0.01,
-    #         Keys.REPLACE_TOKEN_PROBABILITY: 0.1,
+    #         Keys.TOKEN_PROBABILITY: 0.1,
     #     },
     # )
     # ocr: ColumnNoiseType = ColumnNoiseType(
@@ -80,7 +80,7 @@ class __NoiseTypes(NamedTuple):
     #     probability=None,
     #     additional_parameters={
     #         Keys.CELL_PROBABILITY: 0.01,
-    #         Keys.REPLACE_TOKEN_PROBABILITY: 0.1,
+    #         Keys.TOKEN_PROBABILITY: 0.1,
     #     },
     # )
     typographic: ColumnNoiseType = ColumnNoiseType(
@@ -89,8 +89,8 @@ class __NoiseTypes(NamedTuple):
         probability=None,
         additional_parameters={  # TODO: need to clarify these
             Keys.CELL_PROBABILITY: 0.01,
-            Keys.TOKEN_NOISE_LEVEL: 0.1,
-            Keys.REPLACE_TOKEN_PROBABILITY: 0.9,
+            Keys.TOKEN_PROBABILITY: 0.1,
+            Keys.INCLUDE_ORIGINAL_TOKEN_PROBABILITY: 0.1,
         },
     )
 

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -182,7 +182,7 @@ def miswrite_ages(
     :param additional_key: additional key used for randomness_stream calls
     :return:
     """
-    possible_perturbations = configuration.possible_perturbations.to_dict()
+    possible_perturbations = configuration[Keys.POSSIBLE_AGE_DIFFERENCES].to_dict()
     perturbations = vectorized_choice(
         options=list(possible_perturbations.keys()),
         weights=list(possible_perturbations.values()),
@@ -217,7 +217,7 @@ def miswrite_numerics(
     if column.empty:
         return column
     # This is a fix to not replacing the original token for noise options
-    token_noise_level = configuration[Keys.REPLACE_TOKEN_PROBABILITY] / 0.9
+    token_noise_level = configuration[Keys.TOKEN_PROBABILITY] / 0.9
     rng = np.random.default_rng(randomness_stream.seed)
     column = column.astype(str)
     longest_str = column.str.len().max()
@@ -336,7 +336,7 @@ def generate_typographical_errors(
     with open(paths.QWERTY_ERRORS) as f:
         qwerty_errors = yaml.full_load(f)
 
-    def keyboard_corrupt(truth, corrupted_pr, replace_pr, rng):
+    def keyboard_corrupt(truth, corrupted_pr, addl_pr, rng):
         """For each string, loop through each character and determine if
         it is to be corrupted. If so, uniformly choose from the appropriate
         values to mistype. Also determine which mistyped characters should
@@ -353,7 +353,7 @@ def generate_typographical_errors(
                 if random_number < corrupted_pr:
                     err += rng.choice(qwerty_errors[token])
                     random_number = rng.uniform()
-                    if random_number >= replace_pr:
+                    if random_number < addl_pr:
                         err += token
                     i += 1
                     error_introduced = True
@@ -362,8 +362,8 @@ def generate_typographical_errors(
                 i += 1
         return err
 
-    token_noise_level = configuration.token_noise_level
-    replace_token_probability_level = configuration[Keys.REPLACE_TOKEN_PROBABILITY]
+    token_noise_level = configuration[Keys.TOKEN_PROBABILITY]
+    include_token_probability_level = configuration[Keys.INCLUDE_ORIGINAL_TOKEN_PROBABILITY]
 
     rng = np.random.default_rng(seed=randomness_stream.seed)
     column = column.astype(str)
@@ -371,7 +371,7 @@ def generate_typographical_errors(
         noised_value = keyboard_corrupt(
             column[idx],
             token_noise_level,
-            replace_token_probability_level,
+            include_token_probability_level,
             rng,
         )
         column[idx] = noised_value

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -258,7 +258,7 @@ def test_miswrite_ages_uniform_probabilities():
                     "age": {
                         NOISE_TYPES.age_miswriting.name: {
                             Keys.PROBABILITY: 1,
-                            "possible_perturbations": perturbations,
+                            Keys.POSSIBLE_AGE_DIFFERENCES: perturbations,
                         },
                     },
                 },
@@ -287,7 +287,7 @@ def test_miswrite_ages_provided_probabilities():
                     "age": {
                         NOISE_TYPES.age_miswriting.name: {
                             Keys.PROBABILITY: 1,
-                            "possible_perturbations": perturbations,
+                            Keys.POSSIBLE_AGE_DIFFERENCES: perturbations,
                         },
                     },
                 },
@@ -320,7 +320,7 @@ def test_miswrite_ages_handles_perturbation_to_same_age():
                     "age": {
                         NOISE_TYPES.age_miswriting.name: {
                             Keys.PROBABILITY: 1,
-                            "possible_perturbations": perturbations,
+                            Keys.POSSIBLE_AGE_DIFFERENCES: perturbations,
                         },
                     },
                 },
@@ -347,7 +347,7 @@ def test_miswrite_ages_flips_negative_to_positive():
                     "age": {
                         NOISE_TYPES.age_miswriting.name: {
                             Keys.PROBABILITY: 1,
-                            "possible_perturbations": perturbations,
+                            Keys.POSSIBLE_AGE_DIFFERENCES: perturbations,
                         },
                     },
                 },
@@ -373,7 +373,7 @@ def test_miswrite_numerics(string_series):
                     "street_number": {
                         NOISE_TYPES.numeric_miswriting.name: {
                             Keys.CELL_PROBABILITY: 0.4,
-                            Keys.REPLACE_TOKEN_PROBABILITY: 0.5,
+                            Keys.TOKEN_PROBABILITY: 0.5,
                         },
                     },
                 },
@@ -384,7 +384,7 @@ def test_miswrite_numerics(string_series):
         NOISE_TYPES.numeric_miswriting.name
     ]
     p_row_noise = config[Keys.CELL_PROBABILITY]
-    p_token_noise = config[Keys.REPLACE_TOKEN_PROBABILITY]
+    p_token_noise = config[Keys.TOKEN_PROBABILITY]
     data = string_series
     # Hack: we need to name the series something with the miswrite_numeric noising
     # function applied to check dtypes.
@@ -568,8 +568,8 @@ def test_generate_typographical_errors(dummy_dataset, column):
                     column: {
                         NOISE_TYPES.typographic.name: {
                             Keys.CELL_PROBABILITY: 0.1,
-                            Keys.TOKEN_NOISE_LEVEL: 0.1,
-                            Keys.REPLACE_TOKEN_PROBABILITY: 0.9,
+                            Keys.TOKEN_PROBABILITY: 0.1,
+                            Keys.INCLUDE_ORIGINAL_TOKEN_PROBABILITY: 0.1,
                         },
                     },
                 },
@@ -587,7 +587,7 @@ def test_generate_typographical_errors(dummy_dataset, column):
 
     # Check for expected noise level
     p_row_noise = config[Keys.CELL_PROBABILITY]
-    p_token_noise = config[Keys.TOKEN_NOISE_LEVEL]
+    p_token_noise = config[Keys.TOKEN_PROBABILITY]
     str_lengths = check_original.str.len()  # pd.Series
     p_token_not_noised = 1 - p_token_noise
     p_strings_not_noised = p_token_not_noised**str_lengths  # pd.Series
@@ -598,7 +598,7 @@ def test_generate_typographical_errors(dummy_dataset, column):
 
     # Check for expected string growth due to keeping original noised token
     assert (check_noised.str.len() >= check_original.str.len()).all()
-    p_include_original_token = 1 - config[Keys.REPLACE_TOKEN_PROBABILITY]
+    p_include_original_token = config[Keys.INCLUDE_ORIGINAL_TOKEN_PROBABILITY]
     p_token_does_not_increase_string_length = 1 - p_token_noise * p_include_original_token
     p_strings_do_not_increase_length = (
         p_token_does_not_increase_string_length**str_lengths

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -140,8 +140,8 @@ def test_loading_from_yaml(tmp_path):
     ][NOISE_TYPES.age_miswriting.name].to_dict()
 
     assert (
-        default_config[Keys.AGE_MISWRITING_PERTURBATIONS]
-        == updated_config[Keys.AGE_MISWRITING_PERTURBATIONS]
+        default_config[Keys.POSSIBLE_AGE_DIFFERENCES]
+        == updated_config[Keys.POSSIBLE_AGE_DIFFERENCES]
     )
     # check that 1 got replaced with 0 probability
     assert updated_config[Keys.PROBABILITY] == 0.5
@@ -164,7 +164,7 @@ def test_format_miswrite_ages(user_config, expected):
             Keys.COLUMN_NOISE: {
                 COLUMNS.age.name: {
                     NOISE_TYPES.age_miswriting.name: {
-                        Keys.AGE_MISWRITING_PERTURBATIONS: user_config,
+                        Keys.POSSIBLE_AGE_DIFFERENCES: user_config,
                     },
                 },
             },
@@ -173,7 +173,7 @@ def test_format_miswrite_ages(user_config, expected):
 
     config = get_configuration(user_config)[FORMS.census.name][Keys.COLUMN_NOISE][
         COLUMNS.age.name
-    ][NOISE_TYPES.age_miswriting.name][Keys.AGE_MISWRITING_PERTURBATIONS].to_dict()
+    ][NOISE_TYPES.age_miswriting.name][Keys.POSSIBLE_AGE_DIFFERENCES].to_dict()
 
     assert config == expected
 
@@ -259,7 +259,7 @@ def test_validate_miswrite_ages_failures(perturbations, error, match):
                         COLUMNS.age.name: {
                             NOISE_TYPES.age_miswriting.name: {
                                 Keys.PROBABILITY: 1,
-                                Keys.AGE_MISWRITING_PERTURBATIONS: perturbations,
+                                Keys.POSSIBLE_AGE_DIFFERENCES: perturbations,
                             },
                         },
                     },

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -58,11 +58,11 @@ def dummy_config_noise_numbers():
                         "month_day_swap": {Keys.PROBABILITY: 0.01},
                         NOISE_TYPES.zipcode_miswriting.name: {
                             Keys.PROBABILITY: 0.01,
-                            "zipcode_miswriting": [0.04, 0.04, 0.2, 0.36, 0.36],
+                            Keys.ZIPCODE_DIGIT_PROBABILITIES: [0.04, 0.04, 0.2, 0.36, 0.36],
                         },
                         NOISE_TYPES.age_miswriting.name: {
                             Keys.PROBABILITY: 0.01,
-                            "age_miswriting": [1, -1],
+                            Keys.POSSIBLE_AGE_DIFFERENCES: [1, -1],
                         },
                         NOISE_TYPES.numeric_miswriting.name: {
                             Keys.PROBABILITY: 0.01,
@@ -72,15 +72,15 @@ def dummy_config_noise_numbers():
                         NOISE_TYPES.fake_name.name: {Keys.PROBABILITY: 0.01},
                         "phonetic": {
                             Keys.PROBABILITY: 0.01,
-                            "token_noise_level": 0.1,
+                            Keys.TOKEN_PROBABILITY: 0.1,
                         },
                         "ocr": {
                             Keys.PROBABILITY: 0.01,
-                            "token_noise_level": 0.1,
+                            Keys.TOKEN_PROBABILITY: 0.1,
                         },
                         NOISE_TYPES.typographic.name: {
                             Keys.PROBABILITY: 0.01,
-                            "token_noise_level": 0.1,
+                            Keys.TOKEN_PROBABILITY: 0.1,
                         },
                     },
                 },


### PR DESCRIPTION
## Title: Final config key cleanup

### Description
- *Category*: other
- *JIRA issue*: [MIC-3945](https://jira.ihme.washington.edu/browse/MIC-3945)

NOTE: this reverts the change Jim did last week in typograhpic noising function back
to the original implementation since we fundamentally misunderstood what RT
was asking. And update to typographic noising functionality is in another ticket.

### Testing
pytests pass
