### PR TITLE
add user config value validation

### DIFF
--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -6,7 +6,8 @@ from vivarium.config_tree import ConfigTree
 
 from pseudopeople.configuration import Keys
 from pseudopeople.configuration.validator import validate_user_configuration
-from pseudopeople.schema_entities import FORMS, NOISE_TYPES
+from pseudopeople.noise_entities import NOISE_TYPES
+from pseudopeople.schema_entities import FORMS
 
 # Define non-baseline default items
 # NOTE: default values are defined in entity_types.RowNoiseType and entity_types.ColumnNoiseType

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -85,6 +85,7 @@ def _generate_default_configuration() -> ConfigTree:
                         column_noise_type_dict[key] = value
                 if column_noise_type_dict:
                     # We should not have both 'probability' and 'cell_probability'
+                    # TODO: move this into a pytest
                     if (
                         Keys.PROBABILITY in column_noise_type_dict
                         and Keys.CELL_PROBABILITY in column_noise_type_dict

--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -65,15 +65,9 @@ def _validate_noise_type_config(
     """
     for parameter, parameter_config in noise_type_config.items():
         parameter_config_validator = {
-            (
-                NOISE_TYPES.age_miswriting.name,
-                Keys.POSSIBLE_AGE_DIFFERENCES,
-            ): _validate_possible_age_differences,
-            (
-                NOISE_TYPES.zipcode_miswriting.name,
-                Keys.ZIPCODE_DIGIT_PROBABILITIES,
-            ): _validate_zipcode_digit_probabilities,
-        }.get((noise_type, parameter), _validate_default_standard_parameters)
+            Keys.POSSIBLE_AGE_DIFFERENCES: _validate_possible_age_differences,
+            Keys.ZIPCODE_DIGIT_PROBABILITIES: _validate_zipcode_digit_probabilities,
+        }.get(parameter, _validate_default_standard_parameters)
 
         _ = _get_default_config_node(
             default_noise_type_config, parameter, "parameter", form, column, noise_type

--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -128,7 +128,8 @@ def _validate_possible_age_differences(
         for value in noise_type_config.values():
             if not isinstance(value, (float, int)):
                 raise ConfigurationError(
-                    base_error_message + f"'{parameter}' probabilities must be floats or ints. "
+                    base_error_message
+                    + f"'{parameter}' probabilities must be floats or ints. "
                     f"Provided {value} of type {type(value)}."
                 )
             if not (0 <= value <= 1):

--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Dict, List, Union
 
 import numpy as np
 from vivarium.config_tree import ConfigTree, ConfigurationKeyError

--- a/src/pseudopeople/constants/metadata.py
+++ b/src/pseudopeople/constants/metadata.py
@@ -1,0 +1,8 @@
+class Forms:
+    ACS = "american_communities_survey"
+    CENSUS = "decennial_census"
+    CPS = "current_population_survey"
+    SSA = "social_security"
+    TAXES_1040 = "taxes_1040"
+    TAXES_W2_1099 = "taxes_w2_and_1099"
+    WIC = "women_infants_and_children"

--- a/src/pseudopeople/constants/metadata.py
+++ b/src/pseudopeople/constants/metadata.py
@@ -1,4 +1,6 @@
-class Forms:
+class FormNames:
+    """Container for Form names"""
+
     ACS = "american_communities_survey"
     CENSUS = "decennial_census"
     CPS = "current_population_survey"

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -6,9 +6,9 @@ import yaml
 from vivarium import ConfigTree
 from vivarium.framework.randomness import RandomnessStream
 
-from pseudopeople import schema_entities
 from pseudopeople.configuration import Keys
 from pseudopeople.constants import paths
+from pseudopeople.constants.metadata import Forms
 from pseudopeople.data.fake_names import fake_first_names, fake_last_names
 from pseudopeople.utilities import get_index_to_noise, vectorized_choice
 
@@ -31,7 +31,7 @@ def omit_rows(
 
     noise_level = configuration.probability
     # Account for ACS and CPS oversampling
-    if form_name in [schema_entities.FORMS.acs.name, schema_entities.FORMS.cps.name]:
+    if form_name in [Forms.ACS, Forms.CPS]:
         noise_level = 0.5 + noise_level / 2
     # Omit rows
     to_noise_index = get_index_to_noise(

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -8,7 +8,7 @@ from vivarium.framework.randomness import RandomnessStream
 
 from pseudopeople.configuration import Keys
 from pseudopeople.constants import paths
-from pseudopeople.constants.metadata import Forms
+from pseudopeople.constants.metadata import FormNames
 from pseudopeople.data.fake_names import fake_first_names, fake_last_names
 from pseudopeople.utilities import get_index_to_noise, vectorized_choice
 
@@ -31,7 +31,7 @@ def omit_rows(
 
     noise_level = configuration.probability
     # Account for ACS and CPS oversampling
-    if form_name in [Forms.ACS, Forms.CPS]:
+    if form_name in [FormNames.ACS, FormNames.CPS]:
         noise_level = 0.5 + noise_level / 2
     # Omit rows
     to_noise_index = get_index_to_noise(

--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from typing import NamedTuple, Tuple
 
-from pseudopeople.noise_entities import NOISE_TYPES
+from pseudopeople.constants.metadata import Forms
 from pseudopeople.entity_types import ColumnNoiseType, RowNoiseType
+from pseudopeople.noise_entities import NOISE_TYPES
 
 
 class DtypeNames:
@@ -369,7 +370,7 @@ class __Forms(NamedTuple):
     """NamedTuple that contains information about forms and their related columns"""
 
     census: Form = Form(
-        "decennial_census",
+        Forms.CENSUS,
         columns=(  # This defines the output column order
             COLUMNS.simulant_id,
             COLUMNS.first_name,
@@ -390,7 +391,7 @@ class __Forms(NamedTuple):
         date_column="year",
     )
     acs: Form = Form(
-        "american_communities_survey",
+        Forms.ACS,
         columns=(  # This defines the output column order
             COLUMNS.household_id,
             COLUMNS.simulant_id,
@@ -412,7 +413,7 @@ class __Forms(NamedTuple):
         date_column="survey_date",
     )
     cps: Form = Form(
-        "current_population_survey",
+        Forms.CPS,
         columns=(  # This defines the output column order
             COLUMNS.household_id,
             COLUMNS.simulant_id,
@@ -434,7 +435,7 @@ class __Forms(NamedTuple):
         date_column="survey_date",
     )
     wic: Form = Form(
-        "women_infants_and_children",
+        Forms.WIC,
         columns=(  # This defines the output column order
             COLUMNS.household_id,
             COLUMNS.simulant_id,
@@ -454,7 +455,7 @@ class __Forms(NamedTuple):
         date_column="year",
     )
     ssa: Form = Form(
-        "social_security",
+        Forms.SSA,
         columns=(  # This defines the output column order
             COLUMNS.simulant_id,
             COLUMNS.first_name,
@@ -468,7 +469,7 @@ class __Forms(NamedTuple):
         date_column="event_date",
     )
     tax_w2_1099: Form = Form(
-        "taxes_w2_and_1099",
+        Forms.TAXES_W2_1099,
         columns=(  # This defines the output column order
             COLUMNS.simulant_id,
             COLUMNS.first_name,
@@ -498,7 +499,7 @@ class __Forms(NamedTuple):
         date_column="tax_year",
     )
     # tax_1040: Form = Form(
-    #     "taxes_1040",
+    #     Forms.TAXES_1040,
     # )
 
 

--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import NamedTuple, Tuple
 
-from pseudopeople.constants.metadata import Forms
+from pseudopeople.constants.metadata import FormNames
 from pseudopeople.entity_types import ColumnNoiseType, RowNoiseType
 from pseudopeople.noise_entities import NOISE_TYPES
 
@@ -370,7 +370,7 @@ class __Forms(NamedTuple):
     """NamedTuple that contains information about forms and their related columns"""
 
     census: Form = Form(
-        Forms.CENSUS,
+        FormNames.CENSUS,
         columns=(  # This defines the output column order
             COLUMNS.simulant_id,
             COLUMNS.first_name,
@@ -391,7 +391,7 @@ class __Forms(NamedTuple):
         date_column="year",
     )
     acs: Form = Form(
-        Forms.ACS,
+        FormNames.ACS,
         columns=(  # This defines the output column order
             COLUMNS.household_id,
             COLUMNS.simulant_id,
@@ -413,7 +413,7 @@ class __Forms(NamedTuple):
         date_column="survey_date",
     )
     cps: Form = Form(
-        Forms.CPS,
+        FormNames.CPS,
         columns=(  # This defines the output column order
             COLUMNS.household_id,
             COLUMNS.simulant_id,
@@ -435,7 +435,7 @@ class __Forms(NamedTuple):
         date_column="survey_date",
     )
     wic: Form = Form(
-        Forms.WIC,
+        FormNames.WIC,
         columns=(  # This defines the output column order
             COLUMNS.household_id,
             COLUMNS.simulant_id,
@@ -455,7 +455,7 @@ class __Forms(NamedTuple):
         date_column="year",
     )
     ssa: Form = Form(
-        Forms.SSA,
+        FormNames.SSA,
         columns=(  # This defines the output column order
             COLUMNS.simulant_id,
             COLUMNS.first_name,
@@ -469,7 +469,7 @@ class __Forms(NamedTuple):
         date_column="event_date",
     )
     tax_w2_1099: Form = Form(
-        Forms.TAXES_W2_1099,
+        FormNames.TAXES_W2_1099,
         columns=(  # This defines the output column order
             COLUMNS.simulant_id,
             COLUMNS.first_name,

--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
 from typing import NamedTuple, Tuple
 
-from pseudopeople.noise_entities import NOISE_TYPES, ColumnNoiseType, RowNoiseType
+from pseudopeople.noise_entities import NOISE_TYPES
+from pseudopeople.entity_types import ColumnNoiseType, RowNoiseType
 
 
 class DtypeNames:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,4 @@
 import pytest
-import yaml
-
-from pseudopeople.configuration import get_configuration
-
 
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
@@ -20,16 +16,3 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
-
-
-@pytest.fixture(scope="session")
-def user_config_path(tmp_path_factory):
-    """This simply copies the default config file to a temp directory
-    to be used as a user-provided config file in integration tests
-    """
-    config = get_configuration().to_dict()  # gets default config
-    config_path = tmp_path_factory.getbasetemp() / "dummy_config.yaml"
-    with open(config_path, "w") as file:
-        yaml.dump(config, file)
-
-    return config_path

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -229,6 +229,38 @@ def test_overriding_nonexistent_keys_fails(config, match):
 
 
 @pytest.mark.parametrize(
+    "value, error, match",
+    [
+        (-0.01, ValueError, "must be between 0.0 and 1.0"),
+        (1.01, ValueError, "must be between 0.0 and 1.0"),
+        (2, TypeError, "must be a float"),
+        ("a", TypeError, "must be a float"),
+    ],
+)
+def test_validate_standard_parameters_failures(value, error, match):
+    """Test that a runtime error is thrown if a user provides bad standard
+    probability values
+
+    NOTE: This also includes cell_probability values and technically any
+    other values not provided a unique validation function.
+    """
+    with pytest.raises(error, match=match):
+        get_configuration(
+            {
+                FORMS.census.name: {
+                    Keys.COLUMN_NOISE: {
+                        COLUMNS.age.name: {
+                            NOISE_TYPES.age_miswriting.name: {
+                                Keys.PROBABILITY: value,
+                            },
+                        },
+                    },
+                },
+            },
+        )
+
+
+@pytest.mark.parametrize(
     "perturbations, error, match",
     [
         (-1, TypeError, "Invalid configuration type"),
@@ -250,7 +282,7 @@ def test_overriding_nonexistent_keys_fails(config, match):
     ],
 )
 def test_validate_miswrite_ages_failures(perturbations, error, match):
-    """Test that a runtime error is thrown if the user includes 0 as a possible perturbation"""
+    """Test that a runtime error is thrown if the user provides bad possible_age_differences"""
     with pytest.raises(error, match=match):
         get_configuration(
             {
@@ -260,6 +292,36 @@ def test_validate_miswrite_ages_failures(perturbations, error, match):
                             NOISE_TYPES.age_miswriting.name: {
                                 Keys.PROBABILITY: 1,
                                 Keys.POSSIBLE_AGE_DIFFERENCES: perturbations,
+                            },
+                        },
+                    },
+                },
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    "probabilities, error, match",
+    [
+        (0.2, TypeError, "Invalid configuration type"),
+        ([0.5, 0.5, 0.5, 0.5], ValueError, "must be 5"),
+        ([1, 0.0, 0.0, 0.0, 0.0], TypeError, "must be floats"),
+        ([0.2, 0.2, "foo", 0.2, 0.2], TypeError, "must be floats"),
+        ([-0.1, 0.2, 0.2, 0.2, 0.2], ValueError, "must be between 0.0 and 1.0"),
+        ([1.01, 0.2, 0.2, 0.2, 0.2], ValueError, "must be between 0.0 and 1.0"),
+    ],
+)
+def test_validate_miswrite_zipcode_digit_probabilities_failures(probabilities, error, match):
+    """Test that a runtime error is thrown if the user provides bad zipcode_digit_probabilities"""
+    with pytest.raises(error, match=match):
+        get_configuration(
+            {
+                FORMS.census.name: {
+                    Keys.COLUMN_NOISE: {
+                        COLUMNS.zipcode.name: {
+                            NOISE_TYPES.zipcode_miswriting.name: {
+                                Keys.CELL_PROBABILITY: 1,
+                                Keys.ZIPCODE_DIGIT_PROBABILITIES: probabilities,
                             },
                         },
                     },

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -262,8 +262,8 @@ def test_validate_standard_parameters_failures(value, match):
     "perturbations, match",
     [
         (-1, "must be a Dict or List"),
-        ([-1, 0.4, 1], "must be ints"),
-        ({-1: 0.5, 0.4: 0.2, 1: 0.3}, "must be ints"),
+        ([-1, 0.4, 1], "must be a List of ints"),
+        ({-1: 0.5, 0.4: 0.2, 1: 0.3}, "must be a List of ints"),
         ([-1, 0, 1], "cannot include 0"),
         ({-1: 0.5, 4: 0.2, 0: 0.3}, "cannot include 0"),
         ({-1: 0.1, 1: 0.8}, "must sum to 1"),

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -223,7 +223,7 @@ def test_format_miswrite_ages(user_config, expected):
     ],
 )
 def test_overriding_nonexistent_keys_fails(config, match):
-    with pytest.raises(ValueError, match=match):
+    with pytest.raises(ConfigurationError, match=match):
         get_configuration(config)
 
 

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,10 +1,9 @@
-from pathlib import Path
-
 import pytest
 import yaml
 
 from pseudopeople.configuration import Keys, get_configuration
 from pseudopeople.configuration.generator import DEFAULT_NOISE_VALUES
+from pseudopeople.configuration.validator import ConfigurationError
 from pseudopeople.noise_entities import NOISE_TYPES
 from pseudopeople.schema_entities import COLUMNS, FORMS
 
@@ -229,22 +228,21 @@ def test_overriding_nonexistent_keys_fails(config, match):
 
 
 @pytest.mark.parametrize(
-    "value, error, match",
+    "value, match",
     [
-        (-0.01, ValueError, "must be between 0.0 and 1.0"),
-        (1.01, ValueError, "must be between 0.0 and 1.0"),
-        (2, TypeError, "must be a float"),
-        ("a", TypeError, "must be a float"),
+        ("a", "must be floats or ints"),
+        (-0.01, "must be between 0 and 1"),
+        (1.01, "must be between 0 and 1"),
     ],
 )
-def test_validate_standard_parameters_failures(value, error, match):
+def test_validate_standard_parameters_failures(value, match):
     """Test that a runtime error is thrown if a user provides bad standard
     probability values
 
     NOTE: This also includes cell_probability values and technically any
     other values not provided a unique validation function.
     """
-    with pytest.raises(error, match=match):
+    with pytest.raises(ConfigurationError, match=match):
         get_configuration(
             {
                 FORMS.census.name: {
@@ -261,15 +259,16 @@ def test_validate_standard_parameters_failures(value, error, match):
 
 
 @pytest.mark.parametrize(
-    "perturbations, error, match",
+    "perturbations, match",
     [
-        (-1, TypeError, "Invalid configuration type"),
-        ([-1, 0.4, 1], TypeError, "must be ints"),
-        ({-1: 0.5, 0.4: 0.2, 1: 0.3}, TypeError, "must be ints"),
-        ([-1, 0, 1], ValueError, "Cannot include 0"),
-        ({-1: 0.5, 4: 0.2, 0: 0.3}, ValueError, "Cannot include 0"),
-        ({-1: 0.1, 1: 1}, TypeError, "must be floats"),
-        ({-1: 0.1, 1: 0.8}, ValueError, "must sum to 1"),
+        (-1, "must be a Dict or List"),
+        ([-1, 0.4, 1], "must be ints"),
+        ({-1: 0.5, 0.4: 0.2, 1: 0.3}, "must be ints"),
+        ([-1, 0, 1], "cannot include 0"),
+        ({-1: 0.5, 4: 0.2, 0: 0.3}, "cannot include 0"),
+        ({-1: 0.1, 1: 0.8}, "must sum to 1"),
+        ({-1: 0.1, 1: "a"}, "must be floats or ints"),
+        ({-1: -0.2, 1: 1.2}, "must be between 0 and 1"),
     ],
     ids=[
         "bad type",
@@ -277,13 +276,14 @@ def test_validate_standard_parameters_failures(value, error, match):
         "non-int keys dict",
         "include 0 list",
         "include 0 dict",
-        "non-float values",
         "not sum to 1",
+        "non-float values",
+        "out of range",
     ],
 )
-def test_validate_miswrite_ages_failures(perturbations, error, match):
+def test_validate_miswrite_ages_failures(perturbations, match):
     """Test that a runtime error is thrown if the user provides bad possible_age_differences"""
-    with pytest.raises(error, match=match):
+    with pytest.raises(ConfigurationError, match=match):
         get_configuration(
             {
                 FORMS.census.name: {
@@ -301,19 +301,18 @@ def test_validate_miswrite_ages_failures(perturbations, error, match):
 
 
 @pytest.mark.parametrize(
-    "probabilities, error, match",
+    "probabilities, match",
     [
-        (0.2, TypeError, "Invalid configuration type"),
-        ([0.5, 0.5, 0.5, 0.5], ValueError, "must be 5"),
-        ([1, 0.0, 0.0, 0.0, 0.0], TypeError, "must be floats"),
-        ([0.2, 0.2, "foo", 0.2, 0.2], TypeError, "must be floats"),
-        ([-0.1, 0.2, 0.2, 0.2, 0.2], ValueError, "must be between 0.0 and 1.0"),
-        ([1.01, 0.2, 0.2, 0.2, 0.2], ValueError, "must be between 0.0 and 1.0"),
+        (0.2, "must be a List"),
+        ([0.5, 0.5, 0.5, 0.5], "must be a List of 5"),
+        ([0.2, 0.2, "foo", 0.2, 0.2], "must be floats or ints"),
+        ([-0.1, 0.2, 0.2, 0.2, 0.2], "must be between 0 and 1"),
+        ([1.01, 0.2, 0.2, 0.2, 0.2], "must be between 0 and 1"),
     ],
 )
-def test_validate_miswrite_zipcode_digit_probabilities_failures(probabilities, error, match):
+def test_validate_miswrite_zipcode_digit_probabilities_failures(probabilities, match):
     """Test that a runtime error is thrown if the user provides bad zipcode_digit_probabilities"""
-    with pytest.raises(error, match=match):
+    with pytest.raises(ConfigurationError, match=match):
         get_configuration(
             {
                 FORMS.census.name: {


### PR DESCRIPTION
## Title: Add user configuration value validation

### Description
- *Category*: feature
- *JIRA issue*: [MIC-4007](https://jira.ihme.washington.edu/browse/MIC-4007)

This PR adds to the already-existing age perturbation value checks. Specifically:
* zipcode digit probabilities: is it a list of exactly 5 floats between [0, 1]
* everything without a special validation function: is it a float between [0, 1] 

### Testing
added pytests. all tests pass.
