### PR TITLE
Scale ACS and CPS omission for oversampling

### DIFF
--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict
 
 import pandas as pd
 from loguru import logger
@@ -30,11 +30,12 @@ class RowNoiseType:
 
     def __call__(
         self,
+        form_name: str,
         form_data: pd.DataFrame,
         configuration: ConfigTree,
         randomness_stream: RandomnessStream,
     ) -> pd.DataFrame:
-        return self.noise_function(form_data, configuration, randomness_stream)
+        return self.noise_function(form_name, form_data, configuration, randomness_stream)
 
 
 @dataclass

--- a/src/pseudopeople/noise.py
+++ b/src/pseudopeople/noise.py
@@ -57,6 +57,7 @@ def noise_form(
             ):
                 # Apply row noise
                 form_data = noise_type(
+                    form.name,
                     form_data,
                     noise_configuration[Keys.ROW_NOISE][noise_type.name],
                     randomness,

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -6,6 +6,7 @@ import yaml
 from vivarium import ConfigTree
 from vivarium.framework.randomness import RandomnessStream
 
+from pseudopeople import schema_entities
 from pseudopeople.configuration import Keys
 from pseudopeople.constants import paths
 from pseudopeople.data.fake_names import fake_first_names, fake_last_names
@@ -30,7 +31,7 @@ def omit_rows(
 
     noise_level = configuration.probability
     # Account for ACS and CPS oversampling
-    if form_name in ["american_communities_survey", "current_population_survey"]:
+    if form_name in [schema_entities.FORMS.acs.name, schema_entities.FORMS.cps.name]:
         noise_level = 0.5 + noise_level / 2
     # Omit rows
     to_noise_index = get_index_to_noise(

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -13,12 +13,15 @@ from pseudopeople.utilities import get_index_to_noise, vectorized_choice
 
 
 def omit_rows(
+    form_name: str,
     form_data: pd.DataFrame,
     configuration: ConfigTree,
     randomness_stream: RandomnessStream,
 ) -> pd.DataFrame:
     """
-
+    Function that omits rows from a dataset and returns only the remaining rows.  Note that for the ACS and CPS forms
+      we need to account for oversampling in the PRL simulation so a helper function has been hadded here to do so.
+    :param form_name: Form object being noised
     :param form_data:  pd.DataFrame of one of the form types used in Pseudopeople
     :param configuration: ConfigTree object containing noise level values
     :param randomness_stream: RandomnessStream object to make random selection for noise
@@ -26,10 +29,17 @@ def omit_rows(
     """
 
     noise_level = configuration.probability
-    to_noise_idx = get_index_to_noise(
-        form_data, noise_level, randomness_stream, "omission_choice"
+    # Account for ACS and CPS oversampling
+    if form_name in ["american_communities_survey", "current_population_survey"]:
+        noise_level = 0.5 + noise_level / 2
+    # Omit rows
+    to_noise_index = get_index_to_noise(
+        form_data,
+        noise_level,
+        randomness_stream,
+        f"{form_name}_omit_choice",
     )
-    noised_data = form_data.loc[form_data.index.difference(to_noise_idx)]
+    noised_data = form_data.loc[form_data.index.difference(to_noise_index)]
 
     return noised_data
 

--- a/tests/unit/test_row_noise.py
+++ b/tests/unit/test_row_noise.py
@@ -33,12 +33,22 @@ def dummy_data():
 
 def test_omission(dummy_data):
     config = get_configuration()[FORMS.census.name][Keys.ROW_NOISE][NOISE_TYPES.omission.name]
-    noised_data = NOISE_TYPES.omission(dummy_data, config, RANDOMNESS)
+    form_name_1 = "dummY_form_name"
+    form_name_2 = "american_communities_survey"
+    noised_data1 = NOISE_TYPES.omission(form_name_1, dummy_data, config, RANDOMNESS)
+    noised_data2 = NOISE_TYPES.omission(form_name_2, dummy_data, config, RANDOMNESS)
 
-    expected_noise = config[Keys.PROBABILITY]
-    assert np.isclose(1 - len(noised_data) / len(dummy_data), expected_noise, rtol=0.02)
-    assert set(noised_data.columns) == set(dummy_data.columns)
-    assert (noised_data.dtypes == dummy_data.dtypes).all()
+    expected_noise_1 = config[Keys.PROBABILITY]
+    assert np.isclose(1 - len(noised_data1) / len(dummy_data), expected_noise_1, rtol=0.02)
+    assert set(noised_data1.columns) == set(dummy_data.columns)
+    assert (noised_data1.dtypes == dummy_data.dtypes).all()
+
+    # Check ACS data is scaled properly due to oversampling
+    expected_noise_2 = 0.5 + config[Keys.PROBABILITY] / 2
+    assert np.isclose(1 - len(noised_data2) / len(dummy_data), expected_noise_2, rtol=0.02)
+    assert set(noised_data2.columns) == set(dummy_data.columns)
+    assert (noised_data2.dtypes == dummy_data.dtypes).all()
+    assert len(noised_data1) != len(noised_data2)
 
 
 @pytest.mark.skip(reason="TODO")

--- a/tests/unit/test_row_noise.py
+++ b/tests/unit/test_row_noise.py
@@ -33,7 +33,7 @@ def dummy_data():
 
 def test_omission(dummy_data):
     config = get_configuration()[FORMS.census.name][Keys.ROW_NOISE][NOISE_TYPES.omission.name]
-    form_name_1 = "dummY_form_name"
+    form_name_1 = "dummy_form_name"
     form_name_2 = "american_communities_survey"
     noised_data1 = NOISE_TYPES.omission(form_name_1, dummy_data, config, RANDOMNESS)
     noised_data2 = NOISE_TYPES.omission(form_name_2, dummy_data, config, RANDOMNESS)


### PR DESCRIPTION
## Scale ACS and CPS omission for oversampling

### Adds scale factor for ACS and CPS omit roise noise level.
- *Category*: Other
- *JIRA issue*: [MIC-4008](https://jira.ihme.washington.edu/browse/MIC-4008)

Adjust noise level for ACS and CPS omit rows
-Pass FORM object into row noise functions

### Testing
All tests pass successfully

