### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # Local user jupyter notebooks directory
 notebooks/
+
+# Mac OS stuff
+.DS_Store


### PR DESCRIPTION
## Ignore .DS_Store files in macOS
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> documentation, other/misc
- *JIRA issue*: none

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
-->

Ignore .DS_Store file system files when working on a Mac.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

