### PR TITLE
Rename probability to cell and row probability

### DIFF
--- a/src/pseudopeople/configuration/entities.py
+++ b/src/pseudopeople/configuration/entities.py
@@ -3,7 +3,7 @@ class Keys:
 
     ROW_NOISE = "row_noise"  # second layer, eg <dataset>: row_noise: {...}
     COLUMN_NOISE = "column_noise"  # second layer, eg <dataset>: column_noise: {...}
-    PROBABILITY = "probability"
+    ROW_PROBABILITY = "row_probability"
     CELL_PROBABILITY = "cell_probability"
     TOKEN_PROBABILITY = "token_probability"
     POSSIBLE_AGE_DIFFERENCES = "possible_age_differences"

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -15,28 +15,28 @@ DEFAULT_NOISE_VALUES = {
     DATASETS.census.name: {
         Keys.ROW_NOISE: {
             NOISE_TYPES.omission.name: {
-                Keys.PROBABILITY: 0.0145,
+                Keys.ROW_PROBABILITY: 0.0145,
             }
         },
     },
     DATASETS.acs.name: {
         Keys.ROW_NOISE: {
             NOISE_TYPES.omission.name: {
-                Keys.PROBABILITY: 0.0145,
+                Keys.ROW_PROBABILITY: 0.0145,
             },
         },
     },
     DATASETS.cps.name: {
         Keys.ROW_NOISE: {
             NOISE_TYPES.omission.name: {
-                Keys.PROBABILITY: 0.2905,
+                Keys.ROW_PROBABILITY: 0.2905,
             },
         },
     },
     DATASETS.tax_w2_1099.name: {
         Keys.ROW_NOISE: {
             NOISE_TYPES.omission.name: {
-                Keys.PROBABILITY: 0.005,
+                Keys.ROW_PROBABILITY: 0.005,
             },
         },
     },
@@ -45,11 +45,7 @@ DEFAULT_NOISE_VALUES = {
         Keys.COLUMN_NOISE: {
             COLUMNS.ssn.name: {
                 noise_type.name: {
-                    (
-                        Keys.PROBABILITY
-                        if noise_type.probability is not None
-                        else Keys.CELL_PROBABILITY
-                    ): 0.0,
+                    Keys.CELL_PROBABILITY: 0.0,
                 }
                 for noise_type in COLUMNS.ssn.noise_types
             }
@@ -91,8 +87,8 @@ def _generate_default_configuration() -> ConfigTree:
         # Loop through row noise types
         for row_noise in dataset.row_noise_types:
             row_noise_type_dict = {}
-            if row_noise.probability is not None:
-                row_noise_type_dict[Keys.PROBABILITY] = row_noise.probability
+            if row_noise.row_probability is not None:
+                row_noise_type_dict[Keys.ROW_PROBABILITY] = row_noise.row_probability
             if row_noise_type_dict:
                 row_noise_dict[row_noise.name] = row_noise_type_dict
 
@@ -101,23 +97,14 @@ def _generate_default_configuration() -> ConfigTree:
             column_noise_dict = {}
             for noise_type in column.noise_types:
                 column_noise_type_dict = {}
-                if noise_type.probability is not None:
-                    column_noise_type_dict[Keys.PROBABILITY] = noise_type.probability
+                if noise_type.cell_probability is not None:
+                    column_noise_type_dict[
+                        Keys.CELL_PROBABILITY
+                    ] = noise_type.cell_probability
                 if noise_type.additional_parameters is not None:
                     for key, value in noise_type.additional_parameters.items():
                         column_noise_type_dict[key] = value
                 if column_noise_type_dict:
-                    # We should not have both 'probability' and 'cell_probability'
-                    # TODO: move this into a pytest
-                    if (
-                        Keys.PROBABILITY in column_noise_type_dict
-                        and Keys.CELL_PROBABILITY in column_noise_type_dict
-                    ):
-                        raise ValueError(
-                            "'probability' and 'cell_probability' are mutually exclusive "
-                            "but both are found in the default configuration for "
-                            f"dataset '{dataset.name}', column '{column.name}', noise type '{noise_type.name}'"
-                        )
                     column_noise_dict[noise_type.name] = column_noise_type_dict
             if column_noise_dict:
                 column_dict[column.name] = column_noise_dict

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -26,7 +26,7 @@ class RowNoiseType:
 
     name: str
     noise_function: Callable[[str, pd.DataFrame, ConfigTree, RandomnessStream], pd.DataFrame]
-    probability: float = 0.0
+    row_probability: float = 0.0
 
     def __call__(
         self,
@@ -56,7 +56,7 @@ class ColumnNoiseType:
 
     name: str
     noise_function: Callable[[pd.Series, ConfigTree, RandomnessStream, Any], pd.Series]
-    probability: Optional[float] = 0.01
+    cell_probability: Optional[float] = 0.01
     noise_level_scaling_function: Callable[[str], float] = lambda x: 1.0
     additional_parameters: Dict[str, Any] = None
 
@@ -68,14 +68,9 @@ class ColumnNoiseType:
         additional_key: Any,
     ) -> pd.Series:
         column = column.copy()
-        probability_key = (
+        noise_level = configuration[
             Keys.CELL_PROBABILITY
-            if Keys.CELL_PROBABILITY in configuration.keys()
-            else Keys.PROBABILITY
-        )
-        noise_level = configuration[probability_key] * self.noise_level_scaling_function(
-            column.name
-        )
+        ] * self.noise_level_scaling_function(column.name)
         to_noise_idx = get_index_to_noise(
             column, noise_level, randomness_stream, f"{self.name}_{additional_key}"
         )

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -37,9 +37,7 @@ class __NoiseTypes(NamedTuple):
     zipcode_miswriting: ColumnNoiseType = ColumnNoiseType(
         "write_wrong_zipcode_digits",
         noise_functions.miswrite_zipcodes,
-        probability=None,
         additional_parameters={
-            Keys.CELL_PROBABILITY: 0.01,
             Keys.ZIPCODE_DIGIT_PROBABILITIES: [0.04, 0.04, 0.20, 0.36, 0.36],
         },
     )
@@ -53,9 +51,7 @@ class __NoiseTypes(NamedTuple):
     numeric_miswriting: ColumnNoiseType = ColumnNoiseType(
         "write_wrong_digits",
         noise_functions.miswrite_numerics,
-        probability=None,
         additional_parameters={
-            Keys.CELL_PROBABILITY: 0.01,
             Keys.TOKEN_PROBABILITY: 0.1,
         },
     )
@@ -88,9 +84,7 @@ class __NoiseTypes(NamedTuple):
     typographic: ColumnNoiseType = ColumnNoiseType(
         "make_typos",
         noise_functions.generate_typographical_errors,
-        probability=None,
-        additional_parameters={  # TODO: need to clarify these
-            Keys.CELL_PROBABILITY: 0.01,
+        additional_parameters={
             Keys.TOKEN_PROBABILITY: 0.1,
         },
     )

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -29,7 +29,7 @@ def omit_rows(
     :return: pd.DataFrame with rows from the original dataframe removed
     """
 
-    noise_level = configuration.probability
+    noise_level = configuration[Keys.ROW_PROBABILITY]
     # Account for ACS and CPS oversampling
     if dataset_name in [DatasetNames.ACS, DatasetNames.CPS]:
         noise_level = 0.5 + noise_level / 2

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -121,7 +121,7 @@ def test_generate_missing_data(dummy_dataset):
                 Keys.COLUMN_NOISE: {
                     "zipcode": {
                         NOISE_TYPES.missing_data.name: {
-                            Keys.PROBABILITY: 0.25,
+                            Keys.CELL_PROBABILITY: 0.25,
                         },
                     },
                 },
@@ -138,7 +138,7 @@ def test_generate_missing_data(dummy_dataset):
     ]
 
     # Check for expected noise level
-    expected_noise = config[Keys.PROBABILITY]
+    expected_noise = config[Keys.CELL_PROBABILITY]
     actual_noise = len(newly_missing_idx) / len(orig_non_missing_idx)
     assert np.isclose(expected_noise, actual_noise, rtol=0.02)
 
@@ -156,7 +156,7 @@ def test_incorrect_selection(categorical_series):
     )
 
     # Check for expected noise level
-    expected_noise = config[Keys.PROBABILITY]
+    expected_noise = config[Keys.CELL_PROBABILITY]
     # todo: Update when generate_incorrect_selection uses exclusive resampling
     # Get real expected noise to account for possibility of noising with original value
     # Here we have a a possibility of choosing any of the 50 states for our categorical series fixture
@@ -229,7 +229,7 @@ def test_miswrite_ages_default_config(dummy_dataset):
 
     # Check for expected noise level
     not_missing_idx = data.index[data != ""]
-    expected_noise = config[Keys.PROBABILITY]
+    expected_noise = config[Keys.CELL_PROBABILITY]
     actual_noise = (noised_data[not_missing_idx] != data[not_missing_idx]).mean()
     # NOTE: we increase the relative tolerance a bit here because the expected
     # noise calculated above does not account for the fact that if a perturbed
@@ -257,7 +257,7 @@ def test_miswrite_ages_uniform_probabilities():
                 Keys.COLUMN_NOISE: {
                     "age": {
                         NOISE_TYPES.age_miswriting.name: {
-                            Keys.PROBABILITY: 1,
+                            Keys.CELL_PROBABILITY: 1,
                             Keys.POSSIBLE_AGE_DIFFERENCES: perturbations,
                         },
                     },
@@ -286,7 +286,7 @@ def test_miswrite_ages_provided_probabilities():
                 Keys.COLUMN_NOISE: {
                     "age": {
                         NOISE_TYPES.age_miswriting.name: {
-                            Keys.PROBABILITY: 1,
+                            Keys.CELL_PROBABILITY: 1,
                             Keys.POSSIBLE_AGE_DIFFERENCES: perturbations,
                         },
                     },
@@ -319,7 +319,7 @@ def test_miswrite_ages_handles_perturbation_to_same_age():
                 Keys.COLUMN_NOISE: {
                     "age": {
                         NOISE_TYPES.age_miswriting.name: {
-                            Keys.PROBABILITY: 1,
+                            Keys.CELL_PROBABILITY: 1,
                             Keys.POSSIBLE_AGE_DIFFERENCES: perturbations,
                         },
                     },
@@ -346,7 +346,7 @@ def test_miswrite_ages_flips_negative_to_positive():
                 Keys.COLUMN_NOISE: {
                     "age": {
                         NOISE_TYPES.age_miswriting.name: {
-                            Keys.PROBABILITY: 1,
+                            Keys.CELL_PROBABILITY: 1,
                             Keys.POSSIBLE_AGE_DIFFERENCES: perturbations,
                         },
                     },
@@ -484,10 +484,10 @@ def test_generate_fake_names(dummy_dataset):
                 Keys.COLUMN_NOISE: {
                     "first_name": {
                         NOISE_TYPES.fake_name.name: {
-                            Keys.PROBABILITY: 0.4,
+                            Keys.CELL_PROBABILITY: 0.4,
                         },
                     },
-                    "last_name": {NOISE_TYPES.fake_name.name: {Keys.PROBABILITY: 0.5}},
+                    "last_name": {NOISE_TYPES.fake_name.name: {Keys.CELL_PROBABILITY: 0.5}},
                 },
             },
         }
@@ -519,12 +519,12 @@ def test_generate_fake_names(dummy_dataset):
     # todo: equal across fake values
     # Check noised values
     assert np.isclose(
-        first_name_config[Keys.PROBABILITY],
+        first_name_config[Keys.CELL_PROBABILITY],
         (first_name_data[~orig_missing] != noised_first_names[~orig_missing]).mean(),
         rtol=0.02,
     )
     assert np.isclose(
-        last_name_config[Keys.PROBABILITY],
+        last_name_config[Keys.CELL_PROBABILITY],
         (last_name_data[~orig_missing] != noised_last_names[~orig_missing]).mean(),
         rtol=0.02,
     )

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -25,16 +25,16 @@ def test_default_configuration_structure():
         # Check row noise
         for row_noise in dataset.row_noise_types:
             config_probability = config[dataset.name][Keys.ROW_NOISE][row_noise.name][
-                Keys.PROBABILITY
+                Keys.ROW_PROBABILITY
             ]
             default_probability = (
                 DEFAULT_NOISE_VALUES.get(dataset.name, {})
                 .get(Keys.ROW_NOISE, {})
                 .get(row_noise.name, {})
-                .get(Keys.PROBABILITY, "no default")
+                .get(Keys.ROW_PROBABILITY, "no default")
             )
             if default_probability == "no default":
-                assert config_probability == row_noise.probability
+                assert config_probability == row_noise.row_probability
             else:
                 assert config_probability == default_probability
         for col in dataset.columns:
@@ -45,24 +45,24 @@ def test_default_configuration_structure():
                 #  being row_noise, token_noise, and additional parameters at the
                 #  baseline level ('noise_type in col.noise_types')
                 #  Would we ever want to allow for adding non-baseline default noise?
-                if noise_type.probability:
-                    config_probability = config_level[Keys.PROBABILITY]
+                if noise_type.cell_probability:
+                    config_probability = config_level[Keys.CELL_PROBABILITY]
                     default_probability = (
                         DEFAULT_NOISE_VALUES.get(dataset.name, {})
                         .get(Keys.COLUMN_NOISE, {})
                         .get(col.name, {})
                         .get(noise_type.name, {})
-                        .get(Keys.PROBABILITY, "no default")
+                        .get(Keys.CELL_PROBABILITY, "no default")
                     )
                     if default_probability == "no default":
-                        assert config_probability == noise_type.probability
+                        assert config_probability == noise_type.cell_probability
                     else:
                         assert config_probability == default_probability
                 if noise_type.additional_parameters:
                     config_additional_parameters = {
                         k: v
                         for k, v in config_level.to_dict().items()
-                        if k != Keys.PROBABILITY
+                        if k != Keys.CELL_PROBABILITY
                     }
                     default_additional_parameters = (
                         DEFAULT_NOISE_VALUES.get(dataset.name, {})
@@ -73,7 +73,7 @@ def test_default_configuration_structure():
                     default_additional_parameters = {
                         k: v
                         for k, v in default_additional_parameters.items()
-                        if k != Keys.PROBABILITY
+                        if k != Keys.CELL_PROBABILITY
                     }
                     if default_additional_parameters == {}:
                         assert (
@@ -100,9 +100,9 @@ def test_get_configuration_with_user_override(mocker):
     mock = mocker.patch("pseudopeople.configuration.generator.ConfigTree")
     config = {
         DATASETS.census.name: {
-            Keys.ROW_NOISE: {NOISE_TYPES.omission.name: {Keys.PROBABILITY: 0.05}},
+            Keys.ROW_NOISE: {NOISE_TYPES.omission.name: {Keys.ROW_PROBABILITY: 0.05}},
             Keys.COLUMN_NOISE: {
-                "first_name": {NOISE_TYPES.typographic.name: {Keys.PROBABILITY: 0.05}}
+                "first_name": {NOISE_TYPES.typographic.name: {Keys.CELL_PROBABILITY: 0.05}}
             },
         }
     }
@@ -122,7 +122,7 @@ def test_loading_from_yaml(tmp_path):
             Keys.COLUMN_NOISE: {
                 COLUMNS.age.name: {
                     NOISE_TYPES.age_miswriting.name: {
-                        Keys.PROBABILITY: 0.5,
+                        Keys.CELL_PROBABILITY: 0.5,
                     },
                 },
             },
@@ -144,7 +144,7 @@ def test_loading_from_yaml(tmp_path):
         == updated_config[Keys.POSSIBLE_AGE_DIFFERENCES]
     )
     # check that 1 got replaced with 0 probability
-    assert updated_config[Keys.PROBABILITY] == 0.5
+    assert updated_config[Keys.CELL_PROBABILITY] == 0.5
 
 
 @pytest.mark.parametrize(
@@ -250,7 +250,7 @@ def test_validate_standard_parameters_failures(value, match):
                     Keys.COLUMN_NOISE: {
                         COLUMNS.age.name: {
                             NOISE_TYPES.age_miswriting.name: {
-                                Keys.PROBABILITY: value,
+                                Keys.CELL_PROBABILITY: value,
                             },
                         },
                     },
@@ -291,7 +291,7 @@ def test_validate_miswrite_ages_failures(perturbations, match):
                     Keys.COLUMN_NOISE: {
                         COLUMNS.age.name: {
                             NOISE_TYPES.age_miswriting.name: {
-                                Keys.PROBABILITY: 1,
+                                Keys.CELL_PROBABILITY: 1,
                                 Keys.POSSIBLE_AGE_DIFFERENCES: perturbations,
                             },
                         },
@@ -336,7 +336,7 @@ def test_get_config(caplog):
             Keys.COLUMN_NOISE: {
                 "zipcode": {
                     NOISE_TYPES.missing_data.name: {
-                        Keys.PROBABILITY: 0.25,
+                        Keys.CELL_PROBABILITY: 0.25,
                     },
                 },
             },

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -52,44 +52,44 @@ def dummy_config_noise_numbers():
             DATASETS.census.name: {
                 Keys.COLUMN_NOISE: {
                     "event_type": {
-                        NOISE_TYPES.missing_data.name: {Keys.PROBABILITY: 0.01},
-                        NOISE_TYPES.incorrect_selection.name: {Keys.PROBABILITY: 0.01},
-                        "copy_from_within_household": {Keys.PROBABILITY: 0.01},
-                        "month_day_swap": {Keys.PROBABILITY: 0.01},
+                        NOISE_TYPES.missing_data.name: {Keys.CELL_PROBABILITY: 0.01},
+                        NOISE_TYPES.incorrect_selection.name: {Keys.CELL_PROBABILITY: 0.01},
+                        "copy_from_within_household": {Keys.CELL_PROBABILITY: 0.01},
+                        "month_day_swap": {Keys.CELL_PROBABILITY: 0.01},
                         NOISE_TYPES.zipcode_miswriting.name: {
-                            Keys.PROBABILITY: 0.01,
+                            Keys.CELL_PROBABILITY: 0.01,
                             Keys.ZIPCODE_DIGIT_PROBABILITIES: [0.04, 0.04, 0.2, 0.36, 0.36],
                         },
                         NOISE_TYPES.age_miswriting.name: {
-                            Keys.PROBABILITY: 0.01,
+                            Keys.CELL_PROBABILITY: 0.01,
                             Keys.POSSIBLE_AGE_DIFFERENCES: [1, -1],
                         },
                         NOISE_TYPES.numeric_miswriting.name: {
-                            Keys.PROBABILITY: 0.01,
+                            Keys.CELL_PROBABILITY: 0.01,
                             "numeric_miswriting": [0.1],
                         },
-                        "nickname": {Keys.PROBABILITY: 0.01},
-                        NOISE_TYPES.fake_name.name: {Keys.PROBABILITY: 0.01},
+                        "nickname": {Keys.CELL_PROBABILITY: 0.01},
+                        NOISE_TYPES.fake_name.name: {Keys.CELL_PROBABILITY: 0.01},
                         "phonetic": {
-                            Keys.PROBABILITY: 0.01,
+                            Keys.CELL_PROBABILITY: 0.01,
                             Keys.TOKEN_PROBABILITY: 0.1,
                         },
                         "ocr": {
-                            Keys.PROBABILITY: 0.01,
+                            Keys.CELL_PROBABILITY: 0.01,
                             Keys.TOKEN_PROBABILITY: 0.1,
                         },
                         NOISE_TYPES.typographic.name: {
-                            Keys.PROBABILITY: 0.01,
+                            Keys.CELL_PROBABILITY: 0.01,
                             Keys.TOKEN_PROBABILITY: 0.1,
                         },
                     },
                 },
                 Keys.ROW_NOISE: {
                     "duplication": {
-                        Keys.PROBABILITY: 0.01,
+                        Keys.ROW_PROBABILITY: 0.01,
                     },
                     NOISE_TYPES.omission.name: {
-                        Keys.PROBABILITY: 0.01,
+                        Keys.ROW_PROBABILITY: 0.01,
                     },
                 },
             },
@@ -158,7 +158,7 @@ def test_columns_noised(dummy_data):
             DATASETS.census.name: {
                 Keys.COLUMN_NOISE: {
                     "event_type": {
-                        NOISE_TYPES.missing_data.name: {Keys.PROBABILITY: 0.1},
+                        NOISE_TYPES.missing_data.name: {Keys.CELL_PROBABILITY: 0.1},
                     },
                 },
             },
@@ -200,12 +200,12 @@ def test_two_noise_functions_are_independent(mocker):
             DATASETS.census.name: {
                 "column_noise": {
                     "fake_column_one": {
-                        "alpha": {Keys.PROBABILITY: 0.20},
-                        "beta": {Keys.PROBABILITY: 0.30},
+                        "alpha": {Keys.CELL_PROBABILITY: 0.20},
+                        "beta": {Keys.CELL_PROBABILITY: 0.30},
                     },
                     "fake_column_two": {
-                        "alpha": {Keys.PROBABILITY: 0.40},
-                        "beta": {Keys.PROBABILITY: 0.50},
+                        "alpha": {Keys.CELL_PROBABILITY: 0.40},
+                        "beta": {Keys.CELL_PROBABILITY: 0.50},
                     },
                 },
             }
@@ -241,16 +241,16 @@ def test_two_noise_functions_are_independent(mocker):
 
     # Get config values for testing
     col1_expected_abc_proportion = (
-        config_tree.decennial_census.column_noise.fake_column_one.alpha[Keys.PROBABILITY]
+        config_tree.decennial_census.column_noise.fake_column_one.alpha[Keys.CELL_PROBABILITY]
     )
     col2_expected_abc_proportion = (
-        config_tree.decennial_census.column_noise.fake_column_two.alpha[Keys.PROBABILITY]
+        config_tree.decennial_census.column_noise.fake_column_two.alpha[Keys.CELL_PROBABILITY]
     )
     col1_expected_123_proportion = (
-        config_tree.decennial_census.column_noise.fake_column_one.beta[Keys.PROBABILITY]
+        config_tree.decennial_census.column_noise.fake_column_one.beta[Keys.CELL_PROBABILITY]
     )
     col2_expected_123_proportion = (
-        config_tree.decennial_census.column_noise.fake_column_two.beta[Keys.PROBABILITY]
+        config_tree.decennial_census.column_noise.fake_column_two.beta[Keys.CELL_PROBABILITY]
     )
 
     assert np.isclose(

--- a/tests/unit/test_row_noise.py
+++ b/tests/unit/test_row_noise.py
@@ -40,13 +40,13 @@ def test_omission(dummy_data):
     noised_data1 = NOISE_TYPES.omission(dataset_name_1, dummy_data, config, RANDOMNESS)
     noised_data2 = NOISE_TYPES.omission(dataset_name_2, dummy_data, config, RANDOMNESS)
 
-    expected_noise_1 = config[Keys.PROBABILITY]
+    expected_noise_1 = config[Keys.ROW_PROBABILITY]
     assert np.isclose(1 - len(noised_data1) / len(dummy_data), expected_noise_1, rtol=0.02)
     assert set(noised_data1.columns) == set(dummy_data.columns)
     assert (noised_data1.dtypes == dummy_data.dtypes).all()
 
     # Check ACS data is scaled properly due to oversampling
-    expected_noise_2 = 0.5 + config[Keys.PROBABILITY] / 2
+    expected_noise_2 = 0.5 + config[Keys.ROW_PROBABILITY] / 2
     assert np.isclose(1 - len(noised_data2) / len(dummy_data), expected_noise_2, rtol=0.02)
     assert set(noised_data2.columns) == set(dummy_data.columns)
     assert (noised_data2.dtypes == dummy_data.dtypes).all()


### PR DESCRIPTION
## Rename probability to cell and row probability

### Changes name of probability to cell and row probability
- *Category*: Refactor
- *JIRA issue*: [MIC-4022](https://jira.ihme.washington.edu/browse/MIC-4022)
- - *JIRA issue*: [MIC-4023](https://jira.ihme.washington.edu/browse/MIC-4023)

-Changes probability to cell probability for column noise types
-Changes probability to row probability for row noise types

### Testing
All tests pass

