### PR TITLE
dual progress bars

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -36,6 +36,7 @@ from typing import Dict, List, Union
 import pandas as pd
 import pyarrow.parquet as pq
 from loguru import logger
+from tqdm import tqdm
 
 from pseudopeople.configuration import get_configuration
 from pseudopeople.constants import paths
@@ -90,8 +91,14 @@ def _generate_dataset(
             "Please provide the path to the unmodified root data directory."
         )
     noised_dataset = []
-    for data_path in data_paths:
-        logger.info(f"Loading data from {data_path}.")
+    iterator = (
+        tqdm(data_paths, desc="Noising data", leave=False)
+        if len(data_paths) > 1
+        else data_paths
+    )
+    # for data_path in tqdm(data_paths, desc="Noising data", leave=False):
+    for data_path in iterator:
+        logger.debug(f"Loading data from {data_path}.")
         data = _load_data_from_path(data_path, year_filter)
 
         data = _reformat_dates_for_noising(data, dataset)
@@ -105,6 +112,8 @@ def _generate_dataset(
     # Known pandas bug: pd.concat does not preserve category dtypes so we coerce
     # again after concat (https://github.com/pandas-dev/pandas/issues/51362)
     noised_dataset = _coerce_dtypes(noised_dataset, dataset)
+
+    logger.debug("*** Finished ***")
 
     return noised_dataset
 

--- a/src/pseudopeople/noise.py
+++ b/src/pseudopeople/noise.py
@@ -49,7 +49,7 @@ def noise_dataset(
     randomness = get_randomness_stream(dataset.name, seed)
 
     noise_configuration = configuration[dataset.name]
-    for noise_type in tqdm(NOISE_TYPES, desc="Applying noise", unit="type"):
+    for noise_type in tqdm(NOISE_TYPES, desc="Applying noise", unit="type", leave=False):
         if isinstance(noise_type, RowNoiseType):
             if (
                 Keys.ROW_NOISE in noise_configuration


### PR DESCRIPTION
## Title: Implement two progress bars

### Description
- *Category*: feature
- *JIRA issue*: na

Adds two static progress bars. top one for overall progress and bottom one
for specific file noising.

For sample data (ie only one dataset), only one progress bar.

### Testing
we all did it on zoom and saw things
