### PR TITLE
Separate ACS and CPS dataset descriptions and remove redundant table

### DIFF
--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -163,7 +163,7 @@ contingent employment, worker displacement, job tenure, and more. To find out mo
 
 Generate CPS data with :func:`pseudopeople.interface.generate_current_population_survey`
 
-The following columns are included in these datasets:
+The following columns are included in this dataset:
 
 .. list-table:: **Dataset columns**
    :header-rows: 1

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -5,12 +5,13 @@ Datasets
 ========
 
 Here we cover the realistic simulated datasets, which are analogous to "real world" administrative records such as tax documents
-and routinely generated files of social security numbers, that users can generate using Pseudopeople for developing and testing Entity Resolution algorithms 
-and software. 
+and routinely generated files of social security numbers, that users can generate using Pseudopeople for developing and testing Entity
+Resolution algorithms and software. 
 
 Each of the datasets that can be generated using Pseudopeople have "noise" added to them, thereby realistically 
 simulating how administrative records can be corrupted or distorted, which creates challenges in linking those 
-records. To read more about the different kinds of noise that can be applied to the different datasets, please see the `Noise page <https://pseudopeople.readthedocs.io/en/latest/noise_functions/index.html#noise-functions>`_.
+records. To read more about the different kinds of noise that can be applied to the different datasets, please see the
+ `Noise page <https://pseudopeople.readthedocs.io/en/latest/noise_functions/index.html#noise-functions>`_.
 
 The below table offers a list of the datasets that can be generated. Each row of a given dataset represents
 an individual simulant, with the columns representing different simulant attributes, such as name, age, sex, et cetera.
@@ -22,31 +23,17 @@ an individual simulant, with the columns representing different simulant attribu
    :backlinks: none
 
 
-.. list-table:: **Available Datasets**
-   :header-rows: 1
-
-   * - Name
-   * - | US Decennial Census
-   * - | American Community Survey (ACS)
-   * - | Current Population Survey (CPS)
-   * - | Women, Infants, and Children (WIC) Administrative Data
-   * - | Social Security Administration (SSA) Data
-   * - | Tax W2 and 1099 Forms
-   * - | Tax 1040 Form
-
-
 US Decennial Census
 -------------------
-
 The Decennial Census dataset is a simulated enumeration of the US Census Bureau's Decennial Census of Population and Housing. The years
 that have been simulated are 2020, 2030, and 2040. To find out more about the Decennial Census, please visit the Decennial Census
 `homepage <https://www.census.gov/programs-surveys/decennial-census.html>`_.   
 
 Generate Decennial Census data with :func:`pseudopeople.interface.generate_decennial_census`
 
-The following simulant attributes are included in this dataset:
+The following columns are included in this dataset:
 
-.. list-table:: **Simulant attributes**
+.. list-table:: **Dataset columns**
    :header-rows: 1
 
    * - Attribute Name
@@ -102,28 +89,83 @@ The following simulant attributes are included in this dataset:
        White; Black; Latino; American Indian and Alaskan Native (AIAN); Asian; Native Hawaiian and Other Pacific Islander (NHOPI); and
        Multiracial or Some Other Race. 
 
-Household Surveys: ACS and CPS
-------------------------------
-There are two simulated household survey datasets that can be used: the American
-Community Survey (ACS) and the Current Population Survey (CPS). 
-
-ACS is an ongoing household survey conducted by the US Census Bureau that gathers information on a rolling basis about
-American community populations. Information collected includes ancestry, citizenship, education, income, language proficienccy, migration, 
-employment, disability, and housing characteristics. To find out more about ACS, please visit the `ACS homepage <https://www.census.gov/programs-surveys/acs/about.html>`_.
-
-CPS is another household survey conducted by the US Census Bureau and the US Bureau of Labor Statistics. This survey is administered by Census 
-Bureau field representatives across the country through both personal and telephone interviews. CPS collects labor force data, such as annual
-work activity and income, veteran status, school enrollment, contingent employment, worker displacement, job tenure, and more. To find out more
-about CPS, please visit the `CPS homepage <https://www.census.gov/programs-surveys/cps.html>`_. 
-
+American Community Survey (ACS)
+-------------------------------
+ACS is one of two household surveys that can currently be simulated using Pseudopeople. ACS is an ongoing household survey conducted by the US Census
+Bureau that gathers information on a rolling basis about American community populations. Information collected includes ancestry, citizenship,
+education, income, language proficienccy, migration, employment, disability, and housing characteristics. To find out more about ACS, please
+visit the `ACS homepage <https://www.census.gov/programs-surveys/acs/about.html>`_.
 
 Generate ACS data with :func:`pseudopeople.interface.generate_american_community_survey`
 
+The following columns are included in these datasets:
+
+.. list-table:: **Dataset columns**
+   :header-rows: 1
+
+   * - Attribute Name
+     - Column Name
+     - Notes
+   * - Unique simulant ID
+     - :code:`simulant_id`
+     - Not affected by noise functions; intended use is "ground truth" for testing and validation. 
+   * - Household ID 
+     - :code:`household_id` 
+     - Not affected by noise functions; intended use is "ground truth" for testing and validation.
+   * - First name
+     - :code:`first_name`
+     - 
+   * - Middle initial
+     - :code:`middle_initial`
+     - 
+   * - Last name
+     - :code:`last_name`
+     - 
+   * - Age
+     - :code:`age`  
+     - Rounded down to an integer.
+   * - Date of birth
+     - :code:`date_of_birth`
+     - Formatted as YYYY-MM-DD.
+   * - Physical address street number
+     - :code:`street_number`
+     - 
+   * - Physical address street name
+     - :code:`street_name`
+     - 
+   * - Physical address unit number
+     - :code:`unit_number`
+     - 
+   * - Physical address city
+     - :code:`city`    
+     - 
+   * - Physical address state
+     - :code:`state`  
+     - 
+   * - Physical address ZIP code
+     - :code:`zipcode`
+     - 
+   * - Sex 
+     - :code:`sex`  
+     - Binary; "male" or "female"
+   * - Race/ethnicity
+     - :code:`race_ethnicity` 
+     - The exhaustive and mutually exclusive categories for the single composite "race/ethnicity" indicator are as follows:
+       White; Black; Latino; American Indian and Alaskan Native (AIAN); Asian; Native Hawaiian and Other Pacific Islander (NHOPI); and
+       Multiracial or Some Other Race.  
+
+Current Population Survey (CPS)
+-------------------------------
+CPS is another household survey that can be simulated using Pseudopeople. CPS is conducted jointly by the US Census Bureau and the US 
+Bureau of Labor Statistics. CPS collects labor force data, such as annual work activity and income, veteran status, school enrollment, 
+contingent employment, worker displacement, job tenure, and more. To find out more about CPS, please visit the 
+`CPS homepage <https://www.census.gov/programs-surveys/cps.html>`_. 
+
 Generate CPS data with :func:`pseudopeople.interface.generate_current_population_survey`
 
-The following simulant attributes are included in these datasets:
+The following columns are included in these datasets:
 
-.. list-table:: **Simulant attributes**
+.. list-table:: **Dataset columns**
    :header-rows: 1
 
    * - Attribute Name
@@ -178,8 +220,9 @@ The following simulant attributes are included in these datasets:
        Multiracial or Some Other Race.  
 
 
-WIC
----
+
+Women, Infants, and Children (WIC)
+----------------------------------
 The Special Supplemental Nutrition Program for Women, Infants, and Children (WIC) is a government benefits program designed to support mothers and young
 children. The main qualifications are income and the presence of young children in the home. To find out more about this service, please visit the `WIC 
 homepage <https://www.fns.usda.gov/wic>`_.
@@ -189,9 +232,9 @@ simulants enrolled in the program as of the end of that year.
 
 Generate WIC data with :func:`pseudopeople.interface.generate_women_infants_and_children` 
 
-The following simulant attributes are included in this dataset:
+The following columns are included in this dataset:
 
-.. list-table:: **Simulant attributes**
+.. list-table:: **Dataset columns**
    :header-rows: 1
 
    * - Attribute Name
@@ -246,8 +289,8 @@ The following simulant attributes are included in this dataset:
        Multiracial or Some Other Race.  
 
 
-Social Security
----------------
+Social Security Administration
+------------------------------
 The Social Security Administration (SSA) is the US federal government agency that administers Social Security, the social insurance program
 that consists of retirement, disability and survivor benefits. To find out more about this program, visit the `SSA homepage <https://www.ssa.gov/about-ssa>`_.
 
@@ -256,9 +299,9 @@ SSA data includes records of SSA creation and dates of death.
 
 Generate SSA data with :func:`pseudopeople.interface.generate_social_security` 
 
-The following simulant attributes are included in this dataset:
+The following columns are included in this dataset:
 
-.. list-table:: **Simulant attributes**
+.. list-table:: **Dataset columns**
    :header-rows: 1
 
    * - Attribute Name
@@ -293,16 +336,16 @@ The following simulant attributes are included in this dataset:
      - Possible values are "Creation" and "Death". 
 
 
-Tax W-2 & 1099
---------------
+Tax forms: W-2 & 1099
+---------------------
 Administrative data reported in annual tax forms, such as W-2s and 1099s, can also be simulated by Pseudopeople. 1099 forms are used for independent 
 contractors or self-employed individuals, while a W-2 form is used for employees (whose employer withholds payroll taxes from their earnings).
 
 Generate W-2 and 1099 data with :func:`pseudopeople.interface.generate_taxes_w2_and_1099` 
 
-The following simulant attributes are included in these datasets:
+The following columns are included in these datasets:
 
-.. list-table:: **Simulant attributes**
+.. list-table:: **Dataset columns**
    :header-rows: 1
 
    * - Attribute Name
@@ -378,7 +421,7 @@ The following simulant attributes are included in these datasets:
      - :code:`tax_form`
      - Possible values are "W2" or "1099".
 
-Tax 1040
---------
+Tax form: 1040
+-------------
 As with data collected from W-2 and 1099 forms, Pseudopeople will also enable the simulation of administrative records from 1040 forms, which are
 also reported to the IRS on an annual basis. This feature has not yet been implemented, so please stay tuned for more information! 

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -98,7 +98,7 @@ visit the `ACS homepage <https://www.census.gov/programs-surveys/acs/about.html>
 
 Generate ACS data with :func:`pseudopeople.interface.generate_american_community_survey`
 
-The following columns are included in these datasets:
+The following columns are included in this dataset:
 
 .. list-table:: **Dataset columns**
    :header-rows: 1

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -11,7 +11,7 @@ Resolution algorithms and software.
 Each of the datasets that can be generated using Pseudopeople have "noise" added to them, thereby realistically 
 simulating how administrative records can be corrupted or distorted, which creates challenges in linking those 
 records. To read more about the different kinds of noise that can be applied to the different datasets, please see the
- `Noise page <https://pseudopeople.readthedocs.io/en/latest/noise_functions/index.html#noise-functions>`_.
+`Noise page <https://pseudopeople.readthedocs.io/en/latest/noise_functions/index.html#noise-functions>`_.
 
 The below table offers a list of the datasets that can be generated. Each row of a given dataset represents
 an individual simulant, with the columns representing different simulant attributes, such as name, age, sex, et cetera.
@@ -422,6 +422,6 @@ The following columns are included in these datasets:
      - Possible values are "W2" or "1099".
 
 Tax form: 1040
--------------
+--------------
 As with data collected from W-2 and 1099 forms, Pseudopeople will also enable the simulation of administrative records from 1040 forms, which are
 also reported to the IRS on an annual basis. This feature has not yet been implemented, so please stay tuned for more information! 


### PR DESCRIPTION
## Title: Separate ACS and CPS dataset descriptions and remove redundant table
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*:none

This PR makes some updates to the Datasets page, based on conversations. Changes include: 
- separate ACS and CPS into their own sections
- remove overview table that was redundant
- change 'Simulant attributes' to 'Dataset columns'

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
checked using make html
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

