### PR TITLE
Implement targeted omission do_not_respond for census and surveys

### DIFF
--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -6,6 +6,7 @@ from vivarium.config_tree import ConfigTree
 
 from pseudopeople.configuration import Keys
 from pseudopeople.configuration.validator import validate_user_configuration
+from pseudopeople.constants.data_values import DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY
 from pseudopeople.noise_entities import NOISE_TYPES
 from pseudopeople.schema_entities import COLUMNS, DATASETS
 
@@ -14,22 +15,28 @@ from pseudopeople.schema_entities import COLUMNS, DATASETS
 DEFAULT_NOISE_VALUES = {
     DATASETS.census.name: {
         Keys.ROW_NOISE: {
-            NOISE_TYPES.omission.name: {
-                Keys.ROW_PROBABILITY: 0.0145,
+            NOISE_TYPES.do_not_respond.name: {
+                Keys.ROW_PROBABILITY: DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY[
+                    DATASETS.census.name
+                ],
             }
         },
     },
     DATASETS.acs.name: {
         Keys.ROW_NOISE: {
-            NOISE_TYPES.omission.name: {
-                Keys.ROW_PROBABILITY: 0.0145,
+            NOISE_TYPES.do_not_respond.name: {
+                Keys.ROW_PROBABILITY: DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY[
+                    DATASETS.acs.name
+                ],
             },
         },
     },
     DATASETS.cps.name: {
         Keys.ROW_NOISE: {
-            NOISE_TYPES.omission.name: {
-                Keys.ROW_PROBABILITY: 0.2905,
+            NOISE_TYPES.do_not_respond.name: {
+                Keys.ROW_PROBABILITY: DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY[
+                    DATASETS.cps.name
+                ],
             },
         },
     },

--- a/src/pseudopeople/constants/data_values.py
+++ b/src/pseudopeople/constants/data_values.py
@@ -1,0 +1,42 @@
+from typing import Dict
+
+import pandas as pd
+
+from pseudopeople.constants.metadata import DatasetNames
+
+# Targeted omission constants for do_not_respond
+DO_NOT_RESPOND_BASE_PROBABILITY = 0.0024
+
+DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_RACE: Dict[str, float] = {
+    "AIAN": 0.0067,
+    "Asian": -0.0286,
+    "Black": 0.0306,
+    "Latino": 0.0475,
+    "Multiracial or Other": 0.041,
+    "NHOPI": -0.0152,
+    "White": -0.0188,
+}
+
+DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_SEX_AGE: pd.DataFrame = pd.DataFrame(
+    [
+        ["Female", pd.Interval(0, 4), 0.0255],
+        ["Female", pd.Interval(5, 9), -0.0014],
+        ["Female", pd.Interval(10, 17), -0.0003],
+        ["Female", pd.Interval(18, 29), 0.0074],
+        ["Female", pd.Interval(30, 49), -0.0034],
+        ["Female", pd.Interval(50, 125), -0.0287],
+        ["Male", pd.Interval(0, 4), 0.0255],
+        ["Male", pd.Interval(5, 9), -0.0014],
+        ["Male", pd.Interval(10, 17), -0.0003],
+        ["Male", pd.Interval(18, 29), 0.0201],
+        ["Male", pd.Interval(30, 49), 0.0281],
+        ["Male", pd.Interval(50, 125), -0.0079],
+    ],
+    columns=["sex", "age_interval", "probability"],
+)
+
+DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY: Dict[str, float] = {
+    DatasetNames.ACS: 0.0145,  # 1.45%
+    DatasetNames.CPS: 0.2905,  # 29.05%
+    DatasetNames.CENSUS: 0.0145,  # 1.45%
+}

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -16,6 +16,9 @@ class __NoiseTypes(NamedTuple):
     """
 
     omission: RowNoiseType = RowNoiseType("omit_row", noise_functions.omit_rows)
+    do_not_respond: RowNoiseType = RowNoiseType(
+        "do_not_respond", noise_functions.omit_target_rows
+    )
     # duplication: RowNoiseType = RowNoiseType("duplicate_row", noise_functions.duplicate_rows)
     missing_data: ColumnNoiseType = ColumnNoiseType(
         "leave_blank",

--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -389,6 +389,10 @@ class __Datasets(NamedTuple):
             COLUMNS.race_ethnicity,
         ),
         date_column="year",
+        row_noise_types=(
+            NOISE_TYPES.do_not_respond,
+            # NOISE_TYPES.duplication,
+        ),
     )
     acs: Dataset = Dataset(
         DatasetNames.ACS,
@@ -411,6 +415,10 @@ class __Datasets(NamedTuple):
             COLUMNS.race_ethnicity,
         ),
         date_column="survey_date",
+        row_noise_types=(
+            NOISE_TYPES.do_not_respond,
+            # NOISE_TYPES.duplication,
+        ),
     )
     cps: Dataset = Dataset(
         DatasetNames.CPS,
@@ -433,6 +441,10 @@ class __Datasets(NamedTuple):
             COLUMNS.race_ethnicity,
         ),
         date_column="survey_date",
+        row_noise_types=(
+            NOISE_TYPES.do_not_respond,
+            # NOISE_TYPES.duplication,
+        ),
     )
     wic: Dataset = Dataset(
         DatasetNames.WIC,

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -191,7 +191,11 @@ def test_format_miswrite_ages(user_config, expected):
             "Invalid noise type '.*' provided for dataset '.*'. ",
         ),
         (
-            {DATASETS.acs.name: {Keys.ROW_NOISE: {NOISE_TYPES.do_not_respond.name: {"fake": {}}}}},
+            {
+                DATASETS.acs.name: {
+                    Keys.ROW_NOISE: {NOISE_TYPES.do_not_respond.name: {"fake": {}}}
+                }
+            },
             "Invalid parameter '.*' provided for dataset '.*' and noise type '.*'. ",
         ),
         (

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -191,7 +191,7 @@ def test_format_miswrite_ages(user_config, expected):
             "Invalid noise type '.*' provided for dataset '.*'. ",
         ),
         (
-            {DATASETS.acs.name: {Keys.ROW_NOISE: {NOISE_TYPES.omission.name: {"fake": {}}}}},
+            {DATASETS.acs.name: {Keys.ROW_NOISE: {NOISE_TYPES.do_not_respond.name: {"fake": {}}}}},
             "Invalid parameter '.*' provided for dataset '.*' and noise type '.*'. ",
         ),
         (
@@ -352,3 +352,16 @@ def test_get_config(caplog):
 
     with pytest.raises(ConfigurationError, match="bad_form_name"):
         get_config("bad_form_name")
+
+
+def test_omit_rows_do_not_respond_mutex_default_configuration():
+    """Test that omit_rows and do_not_respond are not both defined in the default configuration"""
+    config = get_configuration()
+    for dataset in DATASETS:
+        has_omit_rows = (
+            NOISE_TYPES.omission.name in config[dataset.name][Keys.ROW_NOISE].keys()
+        )
+        has_do_not_respond = (
+            NOISE_TYPES.do_not_respond.name in config[dataset.name][Keys.ROW_NOISE].keys()
+        )
+        assert not has_do_not_respond or not has_omit_rows

--- a/tests/unit/test_row_noise.py
+++ b/tests/unit/test_row_noise.py
@@ -32,11 +32,11 @@ def dummy_data():
 
 
 def test_omission(dummy_data):
-    config = get_configuration()[DATASETS.census.name][Keys.ROW_NOISE][
+    config = get_configuration()[DATASETS.tax_w2_1099.name][Keys.ROW_NOISE][
         NOISE_TYPES.omission.name
     ]
     dataset_name_1 = "dummy_dataset_name"
-    dataset_name_2 = DATASETS.acs.name
+    dataset_name_2 = DATASETS.tax_w2_1099.name
     noised_data1 = NOISE_TYPES.omission(dataset_name_1, dummy_data, config, RANDOMNESS)
     noised_data2 = NOISE_TYPES.omission(dataset_name_2, dummy_data, config, RANDOMNESS)
 
@@ -45,12 +45,47 @@ def test_omission(dummy_data):
     assert set(noised_data1.columns) == set(dummy_data.columns)
     assert (noised_data1.dtypes == dummy_data.dtypes).all()
 
+
+def test_do_not_respond(mocker, dummy_data):
+    config = get_configuration()[DATASETS.census.name][Keys.ROW_NOISE][
+        NOISE_TYPES.do_not_respond.name
+    ]
+    mocker.patch(
+        "pseudopeople.noise_functions._get_census_do_not_respond_demographic_probabilities",
+        side_effect=(lambda *_: config[Keys.ROW_PROBABILITY]),
+    )
+    dataset_name_1 = DATASETS.census.name
+    dataset_name_2 = DATASETS.acs.name
+    noised_data1 = NOISE_TYPES.do_not_respond(dataset_name_1, dummy_data, config, RANDOMNESS)
+    noised_data2 = NOISE_TYPES.do_not_respond(dataset_name_2, dummy_data, config, RANDOMNESS)
+
+    # Test that noising affects expected proportion with expected types
+    assert np.isclose(
+        1 - len(noised_data1) / len(dummy_data), config[Keys.ROW_PROBABILITY], rtol=0.02
+    )
+    assert set(noised_data1.columns) == set(dummy_data.columns)
+    assert (noised_data1.dtypes == dummy_data.dtypes).all()
+
     # Check ACS data is scaled properly due to oversampling
-    expected_noise_2 = 0.5 + config[Keys.ROW_PROBABILITY] / 2
-    assert np.isclose(1 - len(noised_data2) / len(dummy_data), expected_noise_2, rtol=0.02)
+    expected_noise = 0.5 + config[Keys.ROW_PROBABILITY] / 2
+    assert np.isclose(1 - len(noised_data2) / len(dummy_data), expected_noise, rtol=0.02)
     assert set(noised_data2.columns) == set(dummy_data.columns)
     assert (noised_data2.dtypes == dummy_data.dtypes).all()
     assert len(noised_data1) != len(noised_data2)
+    assert True
+
+
+@pytest.mark.parametrize(
+    "dataset_name",
+    [ds.name for ds in DATASETS if ds not in [DATASETS.acs, DATASETS.cps, DATASETS.census]],
+)
+def test_do_not_respond_wrong_dataset(dataset_name, dummy_data):
+    """Test do_not_respond only applies to expected datasets."""
+    config = get_configuration()[DATASETS.census.name][Keys.ROW_NOISE][
+        NOISE_TYPES.do_not_respond.name
+    ]
+    with pytest.raises(ValueError, match=dataset_name):
+        _ = NOISE_TYPES.do_not_respond(dataset_name, dummy_data, config, RANDOMNESS)
 
 
 @pytest.mark.skip(reason="TODO")


### PR DESCRIPTION
## Implement targeted omission do_not_respond for census and surveys

### Description
- *Category*: feature
- *JIRA issue*: [MIC-3934](https://jira.ihme.washington.edu/browse/MIC-3934)

#### Changes

### Testing


