### PR TITLE
Remove Python 3.7 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Pseudopeople
 Pseudopeople is a package intended to add configurable noise to a simulated
 census-scale data-set written using standard scientific Python tools.
 
-**Pseudopeople requires Python 3.7-3.10 to run**
+**Pseudopeople requires Python 3.8-3.10 to run**
 
 You can install ``pseudopeople`` from PyPI with pip:
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-min_version, max_version = ((3, 7), "3.7"), ((3, 10), "3.10")
+min_version, max_version = ((3, 8), "3.8"), ((3, 10), "3.10")
 
 if not (min_version[0] <= sys.version_info[:2] <= max_version[0]):
     # Python 3.5 does not support f-strings


### PR DESCRIPTION
## Remove Python 3.7 support

### Description
- *Category*: feature
- *JIRA issue*: [MIC-3934](https://jira.ihme.washington.edu/browse/MIC-3934)

Removes support for Python 3.7

### Testing
CI

