### PR TITLE
Implement targeted omission do_not_respond for census and surveys

### DIFF
--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -6,6 +6,7 @@ from vivarium.config_tree import ConfigTree
 
 from pseudopeople.configuration import Keys
 from pseudopeople.configuration.validator import validate_user_configuration
+from pseudopeople.constants.data_values import DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY
 from pseudopeople.noise_entities import NOISE_TYPES
 from pseudopeople.schema_entities import COLUMNS, DATASETS
 
@@ -14,22 +15,28 @@ from pseudopeople.schema_entities import COLUMNS, DATASETS
 DEFAULT_NOISE_VALUES = {
     DATASETS.census.name: {
         Keys.ROW_NOISE: {
-            NOISE_TYPES.omission.name: {
-                Keys.ROW_PROBABILITY: 0.0145,
+            NOISE_TYPES.do_not_respond.name: {
+                Keys.ROW_PROBABILITY: DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY[
+                    DATASETS.census.name
+                ],
             }
         },
     },
     DATASETS.acs.name: {
         Keys.ROW_NOISE: {
-            NOISE_TYPES.omission.name: {
-                Keys.ROW_PROBABILITY: 0.0145,
+            NOISE_TYPES.do_not_respond.name: {
+                Keys.ROW_PROBABILITY: DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY[
+                    DATASETS.acs.name
+                ],
             },
         },
     },
     DATASETS.cps.name: {
         Keys.ROW_NOISE: {
-            NOISE_TYPES.omission.name: {
-                Keys.ROW_PROBABILITY: 0.2905,
+            NOISE_TYPES.do_not_respond.name: {
+                Keys.ROW_PROBABILITY: DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY[
+                    DATASETS.cps.name
+                ],
             },
         },
     },

--- a/src/pseudopeople/constants/data_values.py
+++ b/src/pseudopeople/constants/data_values.py
@@ -1,0 +1,44 @@
+from typing import Dict
+
+import pandas as pd
+
+from pseudopeople.constants.metadata import DatasetNames
+
+# Targeted omission constants for do_not_respond
+DO_NOT_RESPOND_BASE_PROBABILITY = 0.0024
+
+DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_RACE: Dict[str, float] = {
+    "AIAN": 0.0067,
+    "Asian": -0.0286,
+    "Black": 0.0306,
+    "Latino": 0.0475,
+    "Multiracial or Other": 0.041,
+    "NHOPI": -0.0152,
+    "White": -0.0188,
+}
+
+DO_NOT_RESPOND_AGE_INTERVALS = [
+    pd.Interval(0, 4),
+    pd.Interval(5, 9),
+    pd.Interval(10, 17),
+    pd.Interval(18, 29),
+    pd.Interval(30, 49),
+    pd.Interval(50, 125),
+]
+
+DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_SEX_AGE: Dict[str, pd.Series] = {
+    "Female": pd.Series(
+        [0.0255, -0.0014, -0.0003, 0.0074, -0.0034, -0.0287],
+        index=DO_NOT_RESPOND_AGE_INTERVALS,
+    ),
+    "Male": pd.Series(
+        [0.0255, -0.0014, -0.0003, 0.0201, 0.0281, -0.0079],
+        index=DO_NOT_RESPOND_AGE_INTERVALS,
+    ),
+}
+
+DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY: Dict[str, float] = {
+    DatasetNames.ACS: 0.0145,  # 1.45%
+    DatasetNames.CPS: 0.2905,  # 29.05%
+    DatasetNames.CENSUS: 0.0145,  # 1.45%
+}

--- a/src/pseudopeople/constants/data_values.py
+++ b/src/pseudopeople/constants/data_values.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 
 import pandas as pd
 
@@ -17,7 +17,7 @@ DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_RACE: Dict[str, float] = {
     "White": -0.0188,
 }
 
-DO_NOT_RESPOND_AGE_INTERVALS = [
+DO_NOT_RESPOND_AGE_INTERVALS: List[pd.Interval] = [
     pd.Interval(0, 4),
     pd.Interval(5, 9),
     pd.Interval(10, 17),

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -17,7 +17,7 @@ class __NoiseTypes(NamedTuple):
 
     omission: RowNoiseType = RowNoiseType("omit_row", noise_functions.omit_rows)
     do_not_respond: RowNoiseType = RowNoiseType(
-        "do_not_respond", noise_functions.omit_target_rows
+        "do_not_respond", noise_functions.apply_do_not_respond
     )
     # duplication: RowNoiseType = RowNoiseType("duplicate_row", noise_functions.duplicate_rows)
     missing_data: ColumnNoiseType = ColumnNoiseType(

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -16,6 +16,9 @@ class __NoiseTypes(NamedTuple):
     """
 
     omission: RowNoiseType = RowNoiseType("omit_row", noise_functions.omit_rows)
+    do_not_respond: RowNoiseType = RowNoiseType(
+        "do_not_respond", noise_functions.omit_target_rows
+    )
     # duplication: RowNoiseType = RowNoiseType("duplicate_row", noise_functions.duplicate_rows)
     missing_data: ColumnNoiseType = ColumnNoiseType(
         "leave_blank",

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -70,10 +70,11 @@ def _get_census_omission_noise_levels(
             data_values.DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_SEX_AGE[sex]
         ).astype(float)
     probabilities[probabilities < 0.0] = 0.0
+    probabilities[probabilities > 1.0] = 1.0
     return probabilities
 
 
-def omit_target_rows(
+def apply_do_not_respond(
     dataset_name: str,
     dataset_data: pd.DataFrame,
     configuration: ConfigTree,

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -96,12 +96,14 @@ def apply_do_not_respond(
             f"Dataset {dataset_name} is missing required columns: {missing_columns}"
         )
 
+    # do_not_respond noise_levels are based on census
     noise_levels = _get_census_omission_noise_levels(dataset_data)
 
     # Apply an overall non-response rate of 27.6% for Current Population Survey (CPS)
     if dataset_name == DatasetNames.CPS:
         noise_levels += 0.276
 
+    # Apply user-configured noise level
     configured_noise_level = configuration[Keys.ROW_PROBABILITY]
     default_noise_level = data_values.DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY[dataset_name]
     noise_levels = noise_levels * (configured_noise_level / default_noise_level)

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -7,7 +7,7 @@ from vivarium import ConfigTree
 from vivarium.framework.randomness import RandomnessStream
 
 from pseudopeople.configuration import Keys
-from pseudopeople.constants import paths
+from pseudopeople.constants import data_values, paths
 from pseudopeople.constants.metadata import Attributes, DatasetNames
 from pseudopeople.data.fake_names import fake_first_names, fake_last_names
 from pseudopeople.exceptions import ConfigurationError
@@ -31,9 +31,6 @@ def omit_rows(
     """
 
     noise_level = configuration[Keys.ROW_PROBABILITY]
-    # Account for ACS and CPS oversampling
-    if dataset_name in [DatasetNames.ACS, DatasetNames.CPS]:
-        noise_level = 0.5 + noise_level / 2
     # Omit rows
     to_noise_index = get_index_to_noise(
         dataset_data,
@@ -42,6 +39,80 @@ def omit_rows(
         f"{dataset_name}_omit_choice",
     )
     noised_data = dataset_data.loc[dataset_data.index.difference(to_noise_index)]
+
+    return noised_data
+
+
+def _get_census_omission_noise_levels(
+    population: pd.DataFrame,
+    base_probability: float = data_values.DO_NOT_RESPOND_BASE_PROBABILITY,
+) -> pd.Series:
+    """
+    Helper function for do_not_respond noising based on demography of age, race/ethnicity, and sex.
+
+    :param population: a dataset containing records of simulants
+    :param base_probability: base probability for do_not_respond
+    :return: a pd.Series of probabilities
+    """
+    probabilities = pd.Series(base_probability, index=population.index)
+    probabilities += (
+        population["race_ethnicity"]
+        .astype(str)
+        .map(data_values.DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_RACE)
+    )
+    for sex in ["Female", "Male"]:
+        sex_mask = population["sex"] == sex
+        age_bins = pd.cut(
+            x=population[sex_mask]["age"],
+            bins=data_values.DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_SEX_AGE[sex].index,
+        )
+        probabilities[sex_mask] += age_bins.map(
+            data_values.DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_SEX_AGE[sex]
+        ).astype(float)
+    probabilities[probabilities < 0.0] = 0.0
+    return probabilities
+
+
+def omit_target_rows(
+    dataset_name: str,
+    dataset_data: pd.DataFrame,
+    configuration: ConfigTree,
+    randomness_stream: RandomnessStream,
+) -> pd.DataFrame:
+    """
+    Applies targeted omission based on demographic model for census and surveys.
+
+    :param dataset_name: Dataset object name being noised
+    :param dataset_data:  pd.DataFrame of one of the form types used in Pseudopeople
+    :param configuration: ConfigTree object containing noise level values
+    :param randomness_stream: RandomnessStream object to make random selection for noise
+    :return: pd.DataFrame with rows from the original dataframe removed
+    """
+    required_columns = ("age", "race_ethnicity", "sex")
+    missing_columns = [col for col in required_columns if col not in dataset_data.columns]
+    if len(missing_columns):
+        raise ValueError(
+            f"Dataset {dataset_name} is missing required columns: {missing_columns}"
+        )
+
+    noise_levels = _get_census_omission_noise_levels(dataset_data)
+
+    # Apply an overall non-response rate of 27.6% for Current Population Survey (CPS)
+    if dataset_name == DatasetNames.CPS:
+        noise_levels += 0.276
+
+    configured_noise_level = configuration[Keys.ROW_PROBABILITY]
+    default_noise_level = data_values.DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY[dataset_name]
+    noise_levels = noise_levels * (configured_noise_level / default_noise_level)
+
+    # Account for ACS and CPS oversampling
+    if dataset_name in [DatasetNames.ACS, DatasetNames.CPS]:
+        noise_levels = 0.5 + noise_levels / 2
+
+    to_noise_idx = get_index_to_noise(
+        dataset_data, noise_levels, randomness_stream, f"do_not_respond_{dataset_name}"
+    )
+    noised_data = dataset_data.loc[dataset_data.index.difference(to_noise_idx)]
 
     return noised_data
 

--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -389,6 +389,10 @@ class __Datasets(NamedTuple):
             COLUMNS.race_ethnicity,
         ),
         date_column="year",
+        row_noise_types=(
+            NOISE_TYPES.do_not_respond,
+            # NOISE_TYPES.duplication,
+        ),
     )
     acs: Dataset = Dataset(
         DatasetNames.ACS,
@@ -411,6 +415,10 @@ class __Datasets(NamedTuple):
             COLUMNS.race_ethnicity,
         ),
         date_column="survey_date",
+        row_noise_types=(
+            NOISE_TYPES.do_not_respond,
+            # NOISE_TYPES.duplication,
+        ),
     )
     cps: Dataset = Dataset(
         DatasetNames.CPS,
@@ -433,6 +441,10 @@ class __Datasets(NamedTuple):
             COLUMNS.race_ethnicity,
         ),
         date_column="survey_date",
+        row_noise_types=(
+            NOISE_TYPES.do_not_respond,
+            # NOISE_TYPES.duplication,
+        ),
     )
     wic: Dataset = Dataset(
         DatasetNames.WIC,

--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -359,11 +359,7 @@ class Dataset:
     name: str
     columns: Tuple[Column, ...]  # This defines the output column order
     date_column: str
-
-    row_noise_types: Tuple[RowNoiseType, ...] = (
-        NOISE_TYPES.omission,
-        # NOISE_TYPES.duplication,
-    )
+    row_noise_types: Tuple[RowNoiseType, ...]
 
 
 class __Datasets(NamedTuple):
@@ -465,6 +461,10 @@ class __Datasets(NamedTuple):
             COLUMNS.race_ethnicity,
         ),
         date_column="year",
+        row_noise_types=(
+            NOISE_TYPES.omission,
+            # NOISE_TYPES.duplication,
+        ),
     )
     ssa: Dataset = Dataset(
         DatasetNames.SSA,
@@ -479,6 +479,10 @@ class __Datasets(NamedTuple):
             COLUMNS.ssa_event_date,
         ),
         date_column="event_date",
+        row_noise_types=(
+            NOISE_TYPES.omission,
+            # NOISE_TYPES.duplication,
+        ),
     )
     tax_w2_1099: Dataset = Dataset(
         DatasetNames.TAXES_W2_1099,
@@ -509,6 +513,10 @@ class __Datasets(NamedTuple):
             COLUMNS.tax_form,
         ),
         date_column="tax_year",
+        row_noise_types=(
+            NOISE_TYPES.omission,
+            # NOISE_TYPES.duplication,
+        ),
     )
     # tax_1040: Dataset = Dataset(
     #     Datasets.TAXES_1040,

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -192,7 +192,11 @@ def test_format_miswrite_ages(user_config, expected):
             "Invalid noise type '.*' provided for dataset '.*'. ",
         ),
         (
-            {DATASETS.acs.name: {Keys.ROW_NOISE: {NOISE_TYPES.omission.name: {"fake": {}}}}},
+            {
+                DATASETS.acs.name: {
+                    Keys.ROW_NOISE: {NOISE_TYPES.do_not_respond.name: {"fake": {}}}
+                }
+            },
             "Invalid parameter '.*' provided for dataset '.*' and noise type '.*'. ",
         ),
         (
@@ -370,3 +374,15 @@ def test_date_format_config():
             date_attribute_cols.add(column.name)
 
     assert noise_cols.issubset(date_attribute_cols)
+
+def test_omit_rows_do_not_respond_mutex_default_configuration():
+    """Test that omit_rows and do_not_respond are not both defined in the default configuration"""
+    config = get_configuration()
+    for dataset in DATASETS:
+        has_omit_rows = (
+            NOISE_TYPES.omission.name in config[dataset.name][Keys.ROW_NOISE].keys()
+        )
+        has_do_not_respond = (
+            NOISE_TYPES.do_not_respond.name in config[dataset.name][Keys.ROW_NOISE].keys()
+        )
+        assert not has_do_not_respond or not has_omit_rows

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -375,6 +375,7 @@ def test_date_format_config():
 
     assert noise_cols.issubset(date_attribute_cols)
 
+
 def test_omit_rows_do_not_respond_mutex_default_configuration():
     """Test that omit_rows and do_not_respond are not both defined in the default configuration"""
     config = get_configuration()

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -88,7 +88,7 @@ def dummy_config_noise_numbers():
                     "duplication": {
                         Keys.ROW_PROBABILITY: 0.01,
                     },
-                    NOISE_TYPES.omission.name: {
+                    NOISE_TYPES.do_not_respond.name: {
                         Keys.ROW_PROBABILITY: 0.01,
                     },
                 },
@@ -113,7 +113,7 @@ def test_noise_order(mocker, dummy_data, dummy_config_noise_numbers):
     for field in NOISE_TYPES._fields:
         mock_return = (
             dummy_data[["event_type"]]
-            if field in ["omission", "duplication"]
+            if field in ["do_not_respond", "duplication"]
             else dummy_data["event_type"]
         )
         mock.attach_mock(
@@ -129,7 +129,8 @@ def test_noise_order(mocker, dummy_data, dummy_config_noise_numbers):
 
     call_order = [x[0] for x in mock.mock_calls if not x[0].startswith("__")]
     expected_call_order = [
-        "omission",
+        # "omit_rows",   # Census doesn't use omit_rows
+        "do_not_respond",
         # "duplication",
         "missing_data",
         "incorrect_selection",

--- a/tests/unit/test_row_noise.py
+++ b/tests/unit/test_row_noise.py
@@ -100,7 +100,7 @@ def test__get_census_omission_noise_levels(age, race_ethnicity, sex, expected_le
         columns=["age", "race_ethnicity", "sex"],
     )
     result = _get_census_omission_noise_levels(pop)
-    assert (np.isclose(result, expected_level, rtol=0.01)).all()
+    assert (np.isclose(result, expected_level, rtol=0.0001)).all()
 
 
 def test_do_not_respond_missing_columns(dummy_data):

--- a/tests/unit/test_row_noise.py
+++ b/tests/unit/test_row_noise.py
@@ -57,21 +57,29 @@ def test_do_not_respond(mocker, dummy_data):
     )
     dataset_name_1 = DATASETS.census.name
     dataset_name_2 = DATASETS.acs.name
-    noised_data1 = NOISE_TYPES.do_not_respond(dataset_name_1, dummy_data, config, RANDOMNESS)
-    noised_data2 = NOISE_TYPES.do_not_respond(dataset_name_2, dummy_data, config, RANDOMNESS)
+    my_dummy_data = dummy_data.copy()
+    my_dummy_data["age"] = 27
+    my_dummy_data["sex"] = "Female"
+    my_dummy_data["race_ethnicity"] = "Vulcan"
+    noised_data1 = NOISE_TYPES.do_not_respond(
+        dataset_name_1, my_dummy_data, config, RANDOMNESS
+    )
+    noised_data2 = NOISE_TYPES.do_not_respond(
+        dataset_name_2, my_dummy_data, config, RANDOMNESS
+    )
 
     # Test that noising affects expected proportion with expected types
     assert np.isclose(
-        1 - len(noised_data1) / len(dummy_data), config[Keys.ROW_PROBABILITY], rtol=0.02
+        1 - len(noised_data1) / len(my_dummy_data), config[Keys.ROW_PROBABILITY], rtol=0.02
     )
-    assert set(noised_data1.columns) == set(dummy_data.columns)
-    assert (noised_data1.dtypes == dummy_data.dtypes).all()
+    assert set(noised_data1.columns) == set(my_dummy_data.columns)
+    assert (noised_data1.dtypes == my_dummy_data.dtypes).all()
 
     # Check ACS data is scaled properly due to oversampling
     expected_noise = 0.5 + config[Keys.ROW_PROBABILITY] / 2
-    assert np.isclose(1 - len(noised_data2) / len(dummy_data), expected_noise, rtol=0.02)
-    assert set(noised_data2.columns) == set(dummy_data.columns)
-    assert (noised_data2.dtypes == dummy_data.dtypes).all()
+    assert np.isclose(1 - len(noised_data2) / len(my_dummy_data), expected_noise, rtol=0.02)
+    assert set(noised_data2.columns) == set(my_dummy_data.columns)
+    assert (noised_data2.dtypes == my_dummy_data.dtypes).all()
     assert len(noised_data1) != len(noised_data2)
     assert True
 

--- a/tests/unit/test_row_noise.py
+++ b/tests/unit/test_row_noise.py
@@ -52,7 +52,7 @@ def test_do_not_respond(mocker, dummy_data):
         NOISE_TYPES.do_not_respond.name
     ]
     mocker.patch(
-        "pseudopeople.noise_functions._get_census_do_not_respond_demographic_probabilities",
+        "pseudopeople.noise_functions._get_census_omission_noise_levels",
         side_effect=(lambda *_: config[Keys.ROW_PROBABILITY]),
     )
     dataset_name_1 = DATASETS.census.name

--- a/tests/unit/test_row_noise.py
+++ b/tests/unit/test_row_noise.py
@@ -37,9 +37,7 @@ def test_omission(dummy_data):
         NOISE_TYPES.omission.name
     ]
     dataset_name_1 = "dummy_dataset_name"
-    dataset_name_2 = DATASETS.tax_w2_1099.name
     noised_data1 = NOISE_TYPES.omission(dataset_name_1, dummy_data, config, RANDOMNESS)
-    noised_data2 = NOISE_TYPES.omission(dataset_name_2, dummy_data, config, RANDOMNESS)
 
     expected_noise_1 = config[Keys.ROW_PROBABILITY]
     assert np.isclose(1 - len(noised_data1) / len(dummy_data), expected_noise_1, rtol=0.02)


### PR DESCRIPTION
## Implement targeted omission do_not_respond for census and surveys

_Note: a previous version of this PR aimed at a deleted develop branch is [here](https://github.com/ihmeuw/pseudopeople/pull/139)_

### Description
- *Category*: feature
- *JIRA issue*: [MIC-3934](https://jira.ihme.washington.edu/browse/MIC-3934)

#### Changes
- Adds do_not_respond noising for census, ACS, and CPS
- Updates omission tests for the do_not_respond change
- Adds tests for do_not_respond proportionality and ports the oversampling testing previously done in the omission/omit_rows testing
- Adds test for incorrect dataset application of do_not_respond
- Adds test for omit_rows/do_not_respond mutual exclusivity 
- Adds test for correctness of census race/ethnicity, age, sex noise level adjustments

### Testing
All tests work.