### PR TITLE
include row-level noise in col-level integration tests

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -116,6 +116,7 @@ def _load_data_from_path(data_path: Path, year_filter: Dict[str, List]):
 
 def _reformat_dates_for_noising(data: pd.DataFrame, dataset: Dataset):
     """Formats SSA event_date and dates of birth, so they can be noised."""
+    data = data.copy()
     if COLUMNS.ssa_event_date.name in data.columns and dataset == DATASETS.ssa:
         # event_date -> YYYYMMDD
         data[COLUMNS.ssa_event_date.name] = data[COLUMNS.ssa_event_date.name].dt.strftime(

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -161,7 +161,7 @@ def test_generate_dataset_and_col_noising(
             ]
             # NOTE: The threshold assigned when we have token-level noising
             # is guessed at since it's difficult to calculate.
-            # TODO: Come up with a more accurate values. There are token probabilities
+            # TODO [MIC-4052]: Come up with a more accurate values. There are token probabilities
             # and additional parameters to consider as well as the rtol when the
             # number of compared is small.
             expected_noise = 1 - (1 - cell_probability) ** len(col.noise_types)

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -147,15 +147,16 @@ def test_generate_dataset_and_col_noising(
                 != check_noised.loc[shared_not_missing_idx, col_name].values
             ).any()
             # Check that the amount of noising seems reasonable
-            threshold = 1 - cell_probability ** len(col.noise_types)
+            threshold = 1 - (1 - cell_probability) ** len(col.noise_types)
             # NOTE: The threshold is not perfect - it is very underconservative
             #   because it does not account for token-level noising which could
             #   result in no actual changes to a value despite being chosen
             # TODO: generate more accurate thresholds
-            assert (
+            noise_level = (
                 check_original.loc[shared_not_missing_idx, col_name].values
                 != check_noised.loc[shared_not_missing_idx, col_name].values
-            ).mean() <= threshold
+            ).mean()
+            assert noise_level <= threshold
         else:
             assert (
                 check_original.loc[shared_not_missing_idx, col_name].values


### PR DESCRIPTION
## Title: Include row noise in col-level integration tests

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-4045](https://jira.ihme.washington.edu/browse/MIC-4045)

Instead of setting cell probability = 0, let's use their defaults but then increase
the column cell probabilities to 25% (which is enough to have noising
even for the sparsest columns, e.g. unit_number)

### Testing
tests pass

