### PR TITLE
Feature/sbachmei/mic 4046 4053 create fixtures of noised data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     install_requirements = [
         "pandas",
         "pyyaml>=5.1",
-        "vivarium",
+        "vivarium<1.1.0",
         "pyarrow",
         "tqdm",
     ]

--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -537,5 +537,14 @@ class __Datasets(NamedTuple):
     #     Datasets.TAXES_1040,
     # )
 
+    ##################
+    # Helper methods #
+    ##################
+
+    @staticmethod
+    def get_dataset(name: str) -> Dataset:
+        """Return the respective Dataset object given the dataset name"""
+        return [d for d in DATASETS if d.name == name][0]
+
 
 DATASETS = __Datasets()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,5 @@
-import pytest
-
 import pandas as pd
+import pytest
 
 from pseudopeople.configuration import Keys, get_configuration
 from pseudopeople.constants import paths
@@ -14,9 +13,9 @@ from pseudopeople.interface import (
 )
 from pseudopeople.schema_entities import COLUMNS, DATASETS, Dataset
 
-
 CELL_PROBABILITY = 0.25
 SEED = 0
+
 
 @pytest.fixture(scope="module")
 def config():
@@ -114,13 +113,50 @@ def noised_sample_data_taxes_w2_and_1099(config):
 
 
 # @pytest.fixture(scope="module")
-# def noised_sample_data_taxes_1040():
+# def noised_sample_data_taxes_1040(config):
 #     return generate_taxes_1040(seed=SEED, year=None, config=config)
+
+
+# Noised sample datasets for year=2030
+@pytest.fixture(scope="module")
+def noised_sample_data_2030_decennial_census():
+    return generate_decennial_census(seed=SEED, year=2030)
+
+
+@pytest.fixture(scope="module")
+def noised_sample_data_2030_american_community_survey():
+    return generate_american_community_survey(seed=SEED, year=2030)
+
+
+@pytest.fixture(scope="module")
+def noised_sample_data_2030_current_population_survey():
+    return generate_current_population_survey(seed=SEED, year=2030)
+
+
+@pytest.fixture(scope="module")
+def noised_sample_data_2030_women_infants_and_children():
+    return generate_women_infants_and_children(seed=SEED, year=2030)
+
+
+@pytest.fixture(scope="module")
+def noised_sample_data_2030_social_security():
+    return generate_social_security(seed=SEED, year=2030)
+
+
+@pytest.fixture(scope="module")
+def noised_sample_data_2030_taxes_w2_and_1099():
+    return generate_taxes_w2_and_1099(seed=SEED, year=2030)
+
+
+# @pytest.fixture(scope="module")
+# def noised_sample_data_2030_taxes_1040():
+#     return generate_taxes_1040(seed=SEED, year=2030)
 
 
 ####################
 # HELPER FUNCTIONS #
 ####################
+
 
 def _load_sample_data(dataset):
     data_path = paths.SAMPLE_DATA_ROOT / dataset / f"{dataset}.parquet"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -117,42 +117,6 @@ def noised_sample_data_taxes_w2_and_1099(config):
 #     return generate_taxes_1040(seed=SEED, year=None, config=config)
 
 
-# Noised sample datasets for year=2030
-@pytest.fixture(scope="module")
-def noised_sample_data_2030_decennial_census():
-    return generate_decennial_census(seed=SEED, year=2030)
-
-
-@pytest.fixture(scope="module")
-def noised_sample_data_2030_american_community_survey():
-    return generate_american_community_survey(seed=SEED, year=2030)
-
-
-@pytest.fixture(scope="module")
-def noised_sample_data_2030_current_population_survey():
-    return generate_current_population_survey(seed=SEED, year=2030)
-
-
-@pytest.fixture(scope="module")
-def noised_sample_data_2030_women_infants_and_children():
-    return generate_women_infants_and_children(seed=SEED, year=2030)
-
-
-@pytest.fixture(scope="module")
-def noised_sample_data_2030_social_security():
-    return generate_social_security(seed=SEED, year=2030)
-
-
-@pytest.fixture(scope="module")
-def noised_sample_data_2030_taxes_w2_and_1099():
-    return generate_taxes_w2_and_1099(seed=SEED, year=2030)
-
-
-# @pytest.fixture(scope="module")
-# def noised_sample_data_2030_taxes_1040():
-#     return generate_taxes_1040(seed=SEED, year=2030)
-
-
 ####################
 # HELPER FUNCTIONS #
 ####################

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,7 +11,7 @@ from pseudopeople.interface import (
     generate_taxes_w2_and_1099,
     generate_women_infants_and_children,
 )
-from pseudopeople.schema_entities import COLUMNS, DATASETS, Dataset
+from pseudopeople.schema_entities import COLUMNS, DATASETS
 
 CELL_PROBABILITY = 0.25
 SEED = 0

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,127 @@
+import pytest
+
+import pandas as pd
+
+from pseudopeople.configuration import Keys, get_configuration
+from pseudopeople.constants import paths
+from pseudopeople.interface import (
+    generate_american_community_survey,
+    generate_current_population_survey,
+    generate_decennial_census,
+    generate_social_security,
+    generate_taxes_w2_and_1099,
+    generate_women_infants_and_children,
+)
+from pseudopeople.schema_entities import COLUMNS, DATASETS, Dataset
+
+
+CELL_PROBABILITY = 0.25
+SEED = 0
+
+@pytest.fixture(scope="module")
+def config():
+    """Returns a custom configuration to be used in noising"""
+    config = get_configuration().to_dict()  # default config
+
+    # Increase cell_probability to 25% to ensure we noise spare columns
+    for dataset_name in config:
+        dataset = DATASETS.get_dataset(dataset_name)
+        for col in [c for c in dataset.columns if c.noise_types]:
+            config[dataset_name][Keys.COLUMN_NOISE][col.name] = {
+                noise_type.name: {
+                    Keys.CELL_PROBABILITY: CELL_PROBABILITY,
+                }
+                for noise_type in col.noise_types
+            }
+
+    # Update SSA dataset to noise 'ssn' but NOT noise 'ssa_event_type' since that
+    # will be used as an identifier along with simulant_id
+    # TODO: Noise ssa_event_type when record IDs are implemented (MIC-4039)
+    config[DATASETS.ssa.name][Keys.COLUMN_NOISE][COLUMNS.ssa_event_type.name] = {
+        noise_type.name: {
+            Keys.CELL_PROBABILITY: 0,
+        }
+        for noise_type in COLUMNS.ssa_event_type.noise_types
+    }
+    return config
+
+
+# Raw sample datasets
+@pytest.fixture(scope="module")
+def sample_data_decennial_census():
+    return _load_sample_data("decennial_census")
+
+
+@pytest.fixture(scope="module")
+def sample_data_american_community_survey():
+    return _load_sample_data("american_community_survey")
+
+
+@pytest.fixture(scope="module")
+def sample_data_current_population_survey():
+    return _load_sample_data("current_population_survey")
+
+
+@pytest.fixture(scope="module")
+def sample_data_women_infants_and_children():
+    return _load_sample_data("women_infants_and_children")
+
+
+@pytest.fixture(scope="module")
+def sample_data_social_security():
+    return _load_sample_data("social_security")
+
+
+@pytest.fixture(scope="module")
+def sample_data_taxes_w2_and_1099():
+    return _load_sample_data("taxes_w2_and_1099")
+
+
+@pytest.fixture(scope="module")
+def sample_data_taxes_1040():
+    return _load_sample_data("taxes_1040")
+
+
+# Noised sample datasets
+@pytest.fixture(scope="module")
+def noised_sample_data_decennial_census(config):
+    return generate_decennial_census(seed=SEED, year=None, config=config)
+
+
+@pytest.fixture(scope="module")
+def noised_sample_data_american_community_survey(config):
+    return generate_american_community_survey(seed=SEED, year=None, config=config)
+
+
+@pytest.fixture(scope="module")
+def noised_sample_data_current_population_survey(config):
+    return generate_current_population_survey(seed=SEED, year=None, config=config)
+
+
+@pytest.fixture(scope="module")
+def noised_sample_data_women_infants_and_children(config):
+    return generate_women_infants_and_children(seed=SEED, year=None, config=config)
+
+
+@pytest.fixture(scope="module")
+def noised_sample_data_social_security(config):
+    return generate_social_security(seed=SEED, year=None, config=config)
+
+
+@pytest.fixture(scope="module")
+def noised_sample_data_taxes_w2_and_1099(config):
+    return generate_taxes_w2_and_1099(seed=SEED, year=None, config=config)
+
+
+# @pytest.fixture(scope="module")
+# def noised_sample_data_taxes_1040():
+#     return generate_taxes_1040(seed=SEED, year=None, config=config)
+
+
+####################
+# HELPER FUNCTIONS #
+####################
+
+def _load_sample_data(dataset):
+    data_path = paths.SAMPLE_DATA_ROOT / dataset / f"{dataset}.parquet"
+    return pd.read_parquet(data_path)

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -43,13 +43,13 @@ DATASET_GENERATION_FUNCS = {
 @pytest.mark.parametrize(
     "dataset_name",
     [
-        # DATASETS.census.name,
-        # DATASETS.acs.name,
-        # DATASETS.cps.name,
+        DATASETS.census.name,
+        DATASETS.acs.name,
+        DATASETS.cps.name,
         DATASETS.ssa.name,
-        # DATASETS.tax_w2_1099.name,
-        # DATASETS.wic.name,
-        # "TODO: tax_1040",
+        DATASETS.tax_w2_1099.name,
+        DATASETS.wic.name,
+        "TODO: tax_1040",
     ],
 )
 def test_generate_dataset_from_sample_and_source(dataset_name: str, config, tmpdir, request):
@@ -244,15 +244,15 @@ def test_generate_dataset_with_year(dataset_name: str, request):
 
 
 @pytest.mark.parametrize(
-    "dataset_name, date_column",
+    "dataset_name",
     [
-        (DATASETS.census.name, DATASETS.census.date_column),
-        (DATASETS.tax_w2_1099.name, DATASETS.tax_w2_1099.date_column),
-        (DATASETS.wic.name, DATASETS.wic.date_column),
-        ("TODO: tax_1040", "todo"),
+        DATASETS.census.name,
+        DATASETS.tax_w2_1099.name,
+        DATASETS.wic.name,
+        "TODO: tax_1040",
     ],
 )
-def test_dataset_filter_by_year(mocker, request, dataset_name: str, date_column: str):
+def test_dataset_filter_by_year(mocker, dataset_name: str):
     """Mock the noising function so that it returns the date column of interest
     with the original (unnoised) values to ensure filtering is happening
     """
@@ -263,7 +263,8 @@ def test_dataset_filter_by_year(mocker, request, dataset_name: str, date_column:
     mocker.patch("pseudopeople.interface.noise_dataset", side_effect=_mock_noise_dataset)
     noising_function = DATASET_GENERATION_FUNCS[dataset_name]
     noised_data = noising_function(year=year)
-    assert (noised_data[date_column] == year).all()
+    dataset = DATASETS.get_dataset(dataset_name)
+    assert (noised_data[dataset.date_column] == year).all()
 
 
 @pytest.mark.parametrize(
@@ -274,7 +275,7 @@ def test_dataset_filter_by_year(mocker, request, dataset_name: str, date_column:
         DATASETS.ssa.name,
     ],
 )
-def test_dataset_filter_by_year_with_full_dates(mocker, request, dataset_name: str):
+def test_dataset_filter_by_year_with_full_dates(mocker, dataset_name: str):
     """Mock the noising function so that it returns the date column of interest
     with the original (unnoised) values to ensure filtering is happening
     """


### PR DESCRIPTION
## Title: Create integration test fixtures

### Description
- *Category*: refactor
- *JIRA issue*: [MIC-4053](https://jira.ihme.washington.edu/browse/MIC-4053)

This PR makes fixtures out of
- sample (unnoised) datasets
- noised sample datasets

We currently have no need to fixtureize the noised 2030 datasets since we only
call the function once (two other tests mock portions of the function and so
fixtures can't be easily used - this caused me a serious headache)

### Testing
tests pass
