### PR TITLE
align noise entity class attributes with names

### DIFF
--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -42,7 +42,7 @@ DEFAULT_NOISE_VALUES = {
     },
     DATASETS.tax_w2_1099.name: {
         Keys.ROW_NOISE: {
-            NOISE_TYPES.omission.name: {
+            NOISE_TYPES.omit_row.name: {
                 Keys.ROW_PROBABILITY: 0.005,
             },
         },
@@ -150,25 +150,25 @@ def _format_user_configuration(default_config: ConfigTree, user_dict: Dict) -> D
     """Formats the user's configuration file as necessary, so it can properly
     update noising configuration to be used
     """
-    user_dict = _format_age_miswriting_perturbations(default_config, user_dict)
+    user_dict = _format_misreport_age_perturbations(default_config, user_dict)
     return user_dict
 
 
-def _format_age_miswriting_perturbations(default_config: ConfigTree, user_dict: Dict) -> Dict:
+def _format_misreport_age_perturbations(default_config: ConfigTree, user_dict: Dict) -> Dict:
     # Format any age perturbation lists as a dictionary with uniform probabilities
     for dataset in user_dict:
         user_perturbations = (
             user_dict[dataset]
             .get(Keys.COLUMN_NOISE, {})
             .get("age", {})
-            .get(NOISE_TYPES.age_miswriting.name, {})
+            .get(NOISE_TYPES.misreport_age.name, {})
             .get(Keys.POSSIBLE_AGE_DIFFERENCES, {})
         )
         if not user_perturbations:
             continue
         formatted = {}
         default_perturbations = default_config[dataset][Keys.COLUMN_NOISE]["age"][
-            NOISE_TYPES.age_miswriting.name
+            NOISE_TYPES.misreport_age.name
         ][Keys.POSSIBLE_AGE_DIFFERENCES]
         # Replace default configuration with 0 probabilities
         for perturbation in default_perturbations:
@@ -182,7 +182,7 @@ def _format_age_miswriting_perturbations(default_config: ConfigTree, user_dict: 
             for perturbation, prob in user_perturbations.items():
                 formatted[perturbation] = prob
 
-        user_dict[dataset][Keys.COLUMN_NOISE]["age"][NOISE_TYPES.age_miswriting.name][
+        user_dict[dataset][Keys.COLUMN_NOISE]["age"][NOISE_TYPES.misreport_age.name][
             Keys.POSSIBLE_AGE_DIFFERENCES
         ] = formatted
 

--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -47,7 +47,7 @@ def validate_user_configuration(user_config: Dict, default_config: ConfigTree) -
                     default_column_config, noise_type, "noise type", dataset, column
                 )
                 parameter_config_validator_map = {
-                    NOISE_TYPES.nickname.name: {
+                    NOISE_TYPES.use_nickname.name: {
                         Keys.CELL_PROBABILITY: _validate_nickname_probability
                     }
                 }.get(noise_type, DEFAULT_PARAMETER_CONFIG_VALIDATOR_MAP)

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -45,8 +45,8 @@ class ColumnNoiseType:
     """
     Defines a type of noise that can be applied to a column.
 
-    The name is the name of the particular noise type (e.g. "use_nickname" or
-    "make_phonetic_error").
+    The name is the name of the particular noise function (e.g. use_nickname" or
+    "make_phonetic_errors").
 
     The noise function takes as input a Series, the ConfigTree object for this
     ColumnNoise operation, a RandomnessStream for controlling randomness, and

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -45,8 +45,8 @@ class ColumnNoiseType:
     """
     Defines a type of noise that can be applied to a column.
 
-    The name is the name of the particular noise function (e.g. use_nickname" or
-    "make_phonetic_errors").
+    The name is the name of the particular noise type (e.g. "use_nickname" or
+    "make_phonetic_error").
 
     The noise function takes as input a Series, the ConfigTree object for this
     ColumnNoise operation, a RandomnessStream for controlling randomness, and

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -15,8 +15,8 @@ class RowNoiseType:
     """
     Defines a type of noise that can be applied to a row.
 
-    The name is the name of the particular noise function (e.g. "omission" or
-    "duplication").
+    The name is the name of the particular noise type (e.g. "omit_row" or
+    "duplicate_row").
 
     The noise function takes as input a DataFrame, the configuration value
     for this RowNoise operation, and a RandomnessStream for controlling
@@ -45,8 +45,8 @@ class ColumnNoiseType:
     """
     Defines a type of noise that can be applied to a column.
 
-    The name is the name of the particular noise function (e.g. "nickname" or
-    "phonetic").
+    The name is the name of the particular noise function (e.g. use_nickname" or
+    "make_phonetic_errors").
 
     The noise function takes as input a Series, the ConfigTree object for this
     ColumnNoise operation, a RandomnessStream for controlling randomness, and

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -45,7 +45,7 @@ class ColumnNoiseType:
     """
     Defines a type of noise that can be applied to a column.
 
-    The name is the name of the particular noise function (e.g. use_nickname" or
+    The name is the name of the particular noise type (e.g. use_nickname" or
     "make_phonetic_errors").
 
     The noise function takes as input a Series, the ConfigTree object for this

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -10,7 +10,7 @@ class __NoiseTypes(NamedTuple):
     omit_row, do_not_respond, duplicate_row, leave_blank, choose_wrong_option,
     copy_from_household_member, swap_month_and_day, write_wrong_zipcode_digits,
     misreport_age, write_wrong_digits, use_nickname, use_fake_name,
-    make_phonetic_errors, make_ocr_errors, make_typos
+    make_phonetic_error, make_ocr_errors, make_typos
 
     NOTE: Any configuration tree overwrites in these objects are what ends up
     in the "baseline" ConfigTree layer.
@@ -68,8 +68,8 @@ class __NoiseTypes(NamedTuple):
         "use_fake_name",
         noise_functions.use_fake_names,
     )
-    # make_phonetic_errors: ColumnNoiseType = ColumnNoiseType(
-    #     "make_phonetic_errors",
+    # make_phonetic_error: ColumnNoiseType = ColumnNoiseType(
+    #     "make_phonetic_error",
     #     noise_functions.make_phonetic_errors,
     #     probability=None,
     #     additional_parameters={

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -1,93 +1,94 @@
 from typing import NamedTuple
 
-from pseudopeople import noise_functions, noise_scaling, utilities
+from pseudopeople import noise_functions, noise_scaling
 from pseudopeople.configuration import Keys
 from pseudopeople.entity_types import ColumnNoiseType, RowNoiseType
 
 
 class __NoiseTypes(NamedTuple):
     """Container for all noise types in the order in which they should be applied:
-    omissions, duplications, missing data, incorrect selection, copy from w/in
-    household, month and day swaps, zip code miswriting, age miswriting,
-    numeric miswriting, nicknames, fake names, phonetic, OCR, typographic
+    omit_row, do_not_respond, duplicate_row, leave_blank, choose_wrong_option,
+    copy_from_household_member, swap_month_and_day, write_wrong_zipcode_digits,
+    misreport_age, write_wrong_digits, use_nickname, use_fake_name,
+    make_phonetic_errors, make_ocr_errors, make_typos
 
     NOTE: Any configuration tree overwrites in these objects are what ends up
     in the "baseline" ConfigTree layer.
     """
 
-    omission: RowNoiseType = RowNoiseType("omit_row", noise_functions.omit_rows)
+    omit_row: RowNoiseType = RowNoiseType("omit_row", noise_functions.omit_rows)
     do_not_respond: RowNoiseType = RowNoiseType(
         "do_not_respond", noise_functions.apply_do_not_respond
     )
-    # duplication: RowNoiseType = RowNoiseType("duplicate_row", noise_functions.duplicate_rows)
-    missing_data: ColumnNoiseType = ColumnNoiseType(
+    # duplicate_row: RowNoiseType = RowNoiseType("duplicate_row", noise_functions.duplicate_rows)
+    leave_blank: ColumnNoiseType = ColumnNoiseType(
         "leave_blank",
-        noise_functions.generate_missing_data,
+        noise_functions.leave_blanks,
     )
-    incorrect_selection: ColumnNoiseType = ColumnNoiseType(
+    choose_wrong_option: ColumnNoiseType = ColumnNoiseType(
         "choose_wrong_option",
-        noise_functions.generate_incorrect_selections,
-        noise_level_scaling_function=noise_scaling.noise_scaling_incorrect_selection,
+        noise_functions.choose_wrong_options,
+        noise_level_scaling_function=noise_scaling.scale_choose_wrong_option,
     )
-    # copy_from_within_household: ColumnNoiseType = ColumnNoiseType(
+    # copy_from_household_member: ColumnNoiseType = ColumnNoiseType(
     #     "copy_from_household_member",
-    #     noise_functions.generate_within_household_copies,
+    #     noise_functions.copy_from_household_members,
     # )
-    month_day_swap: ColumnNoiseType = ColumnNoiseType(
+    swap_month_and_day: ColumnNoiseType = ColumnNoiseType(
         "swap_month_and_day",
         noise_functions.swap_months_and_days,
     )
-    zipcode_miswriting: ColumnNoiseType = ColumnNoiseType(
+    write_wrong_zipcode_digits: ColumnNoiseType = ColumnNoiseType(
         "write_wrong_zipcode_digits",
-        noise_functions.miswrite_zipcodes,
+        noise_functions.write_wrong_zipcode_digits,
         additional_parameters={
             Keys.ZIPCODE_DIGIT_PROBABILITIES: [0.04, 0.04, 0.20, 0.36, 0.36],
         },
     )
-    age_miswriting: ColumnNoiseType = ColumnNoiseType(
+    misreport_age: ColumnNoiseType = ColumnNoiseType(
         "misreport_age",
-        noise_functions.miswrite_ages,
+        noise_functions.misreport_ages,
         additional_parameters={
             Keys.POSSIBLE_AGE_DIFFERENCES: {-2: 0.1, -1: 0.4, 1: 0.4, 2: 0.1}
         },
     )
-    numeric_miswriting: ColumnNoiseType = ColumnNoiseType(
+    write_wrong_digits: ColumnNoiseType = ColumnNoiseType(
         "write_wrong_digits",
-        noise_functions.miswrite_numerics,
+        noise_functions.write_wrong_digits,
         additional_parameters={
             Keys.TOKEN_PROBABILITY: 0.1,
         },
     )
-    nickname: ColumnNoiseType = ColumnNoiseType(
+    use_nickname: ColumnNoiseType = ColumnNoiseType(
         "use_nickname",
-        noise_functions.generate_nicknames,
+        noise_functions.use_nicknames,
         noise_level_scaling_function=noise_scaling.scale_nicknames,
     )
-    fake_name: ColumnNoiseType = ColumnNoiseType(
+    use_fake_name: ColumnNoiseType = ColumnNoiseType(
         "use_fake_name",
-        noise_functions.generate_fake_names,
+        noise_functions.use_fake_names,
     )
-    # phonetic: ColumnNoiseType = ColumnNoiseType(
+    # make_phonetic_errors: ColumnNoiseType = ColumnNoiseType(
     #     "make_phonetic_errors",
-    #     noise_functions.generate_phonetic_errors,
+    #     noise_functions.make_phonetic_errors,
     #     probability=None,
     #     additional_parameters={
     #         Keys.CELL_PROBABILITY: 0.01,
     #         Keys.TOKEN_PROBABILITY: 0.1,
     #     },
     # )
-    # ocr: ColumnNoiseType = ColumnNoiseType(
+    # make_ocr_errors: ColumnNoiseType = ColumnNoiseType(
     #     "make_ocr_errors",
-    #     noise_functions.generate_ocr_errors,
+    #     noise_functions.make_ocr_errors,
     #     probability=None,
     #     additional_parameters={
     #         Keys.CELL_PROBABILITY: 0.01,
     #         Keys.TOKEN_PROBABILITY: 0.1,
     #     },
     # )
-    typographic: ColumnNoiseType = ColumnNoiseType(
+    make_typos: ColumnNoiseType = ColumnNoiseType(
         "make_typos",
-        noise_functions.generate_typographical_errors,
+        noise_functions.make_typos,
         additional_parameters={
             Keys.TOKEN_PROBABILITY: 0.1,
         },

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -10,7 +10,7 @@ class __NoiseTypes(NamedTuple):
     omit_row, do_not_respond, duplicate_row, leave_blank, choose_wrong_option,
     copy_from_household_member, swap_month_and_day, write_wrong_zipcode_digits,
     misreport_age, write_wrong_digits, use_nickname, use_fake_name,
-    make_phonetic_error, make_ocr_errors, make_typos
+    make_phonetic_errors, make_ocr_errors, make_typos
 
     NOTE: Any configuration tree overwrites in these objects are what ends up
     in the "baseline" ConfigTree layer.
@@ -68,8 +68,8 @@ class __NoiseTypes(NamedTuple):
         "use_fake_name",
         noise_functions.use_fake_names,
     )
-    # make_phonetic_error: ColumnNoiseType = ColumnNoiseType(
-    #     "make_phonetic_error",
+    # make_phonetic_errors: ColumnNoiseType = ColumnNoiseType(
+    #     "make_phonetic_errors",
     #     noise_functions.make_phonetic_errors,
     #     probability=None,
     #     additional_parameters={

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -141,7 +141,7 @@ def apply_do_not_respond(
 #     return dataset_data
 
 
-def generate_incorrect_selections(
+def choose_wrong_options(
     column: pd.Series,
     _: ConfigTree,
     randomness_stream: RandomnessStream,
@@ -178,7 +178,7 @@ def generate_incorrect_selections(
     return pd.Series(new_values, index=column.index, name=column.name)
 
 
-# def generate_within_household_copies(
+# def copy_from_household_members(
 #     column: pd.Series,
 #     configuration: ConfigTree,
 #     randomness_stream: RandomnessStream,
@@ -240,7 +240,7 @@ def swap_months_and_days(
     return noised
 
 
-def miswrite_zipcodes(
+def write_wrong_zipcode_digits(
     column: pd.Series,
     configuration: ConfigTree,
     randomness_stream: RandomnessStream,
@@ -284,7 +284,7 @@ def miswrite_zipcodes(
     return new_zipcodes
 
 
-def miswrite_ages(
+def misreport_ages(
     column: pd.Series,
     configuration: ConfigTree,
     randomness_stream: RandomnessStream,
@@ -316,7 +316,7 @@ def miswrite_ages(
     return new_values
 
 
-def miswrite_numerics(
+def write_wrong_digits(
     column: pd.Series,
     configuration: ConfigTree,
     randomness_stream: RandomnessStream,
@@ -359,9 +359,9 @@ def miswrite_numerics(
     return noised_column
 
 
-def generate_nicknames(
+def use_nicknames(
     column: pd.Series,
-    configuration: ConfigTree,
+    _: ConfigTree,
     randomness_stream: RandomnessStream,
     additional_key: Any,
 ) -> pd.Series:
@@ -384,7 +384,7 @@ def generate_nicknames(
     return column
 
 
-def generate_fake_names(
+def use_fake_names(
     column: pd.Series,
     _: ConfigTree,
     randomness_stream: RandomnessStream,
@@ -413,7 +413,7 @@ def generate_fake_names(
     return pd.Series(new_values, index=column.index, name=column.name)
 
 
-# def generate_phonetic_errors(
+# def make_phonetic_errors(
 #     column: pd.Series,
 #     configuration: ConfigTree,
 #     randomness_stream: RandomnessStream,
@@ -431,7 +431,7 @@ def generate_fake_names(
 #     return column
 
 
-def generate_missing_data(column: pd.Series, *_: Any) -> pd.Series:
+def leave_blanks(column: pd.Series, *_: Any) -> pd.Series:
     """
     Function that takes a column and blanks out all values.
 
@@ -442,7 +442,7 @@ def generate_missing_data(column: pd.Series, *_: Any) -> pd.Series:
     return pd.Series(np.nan, index=column.index)
 
 
-def generate_typographical_errors(
+def make_typos(
     column: pd.Series,
     configuration: ConfigTree,
     randomness_stream: RandomnessStream,
@@ -504,7 +504,7 @@ def generate_typographical_errors(
     return column
 
 
-# def generate_ocr_errors(
+# def make_ocr_errors(
 #     column: pd.Series,
 #     configuration: ConfigTree,
 #     randomness_stream: RandomnessStream,

--- a/src/pseudopeople/noise_scaling.py
+++ b/src/pseudopeople/noise_scaling.py
@@ -4,9 +4,10 @@ import pandas as pd
 from pseudopeople.constants import metadata, paths
 
 
-def noise_scaling_incorrect_selection(column: pd.Series) -> float:
+def scale_choose_wrong_option(column: pd.Series) -> float:
     """
-    Function to scale noising for incorrect selection to adjust for the possibility of noising with the original values.
+    Function to scale noising for choose_wrong_option to adjust for the possibility
+    of noising with the original values.
     """
     from pseudopeople.schema_entities import COLUMNS
 

--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -28,41 +28,41 @@ class __Columns(NamedTuple):
     age: Column = Column(
         "age",
         (
-            NOISE_TYPES.missing_data,
+            NOISE_TYPES.leave_blank,
             # NOISE_TYPES.copy_from_within_household,
-            NOISE_TYPES.age_miswriting,
+            NOISE_TYPES.misreport_age,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     city: Column = Column(
         "city",
         (
-            NOISE_TYPES.missing_data,
+            NOISE_TYPES.leave_blank,
             # NOISE_TYPES.phonetic,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     dob: Column = Column(
         "date_of_birth",
         (
-            NOISE_TYPES.missing_data,
+            NOISE_TYPES.leave_blank,
             # NOISE_TYPES.copy_from_within_household,
-            NOISE_TYPES.month_day_swap,
-            NOISE_TYPES.numeric_miswriting,
+            NOISE_TYPES.swap_month_and_day,
+            NOISE_TYPES.write_wrong_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
         additional_attributes={Attributes.DATE_FORMAT: DATEFORMATS.MM_DD_YYYY},
     )
     employer_city: Column = Column(
         "employer_city",
         (
-            NOISE_TYPES.missing_data,
+            NOISE_TYPES.leave_blank,
             # NOISE_TYPES.phonetic,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     employer_id: Column = Column(
@@ -71,64 +71,64 @@ class __Columns(NamedTuple):
     employer_name: Column = Column(
         "employer_name",
         (
-            NOISE_TYPES.missing_data,
+            NOISE_TYPES.leave_blank,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     employer_state: Column = Column(
         "employer_state",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.incorrect_selection,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.choose_wrong_option,
         ),
         DtypeNames.CATEGORICAL,
     )
     employer_street_name: Column = Column(
         "employer_street_name",
         (
-            NOISE_TYPES.missing_data,
+            NOISE_TYPES.leave_blank,
             # NOISE_TYPES.phonetic,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     employer_street_number: Column = Column(
         "employer_street_number",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.numeric_miswriting,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.write_wrong_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     employer_unit_number: Column = Column(
         "employer_unit_number",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.numeric_miswriting,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.write_wrong_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     employer_zipcode: Column = Column(
         "employer_zipcode",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.zipcode_miswriting,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.write_wrong_zipcode_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     first_name: Column = Column(
         "first_name",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.nickname,
-            NOISE_TYPES.fake_name,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.use_nickname,
+            NOISE_TYPES.use_fake_name,
             # NOISE_TYPES.phonetic,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     household_id: Column = Column(
@@ -137,124 +137,124 @@ class __Columns(NamedTuple):
     income: Column = Column(
         "income",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.numeric_miswriting,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.write_wrong_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     itin: Column = Column(
         "itin",
         (
-            NOISE_TYPES.missing_data,
+            NOISE_TYPES.leave_blank,
             # NOISE_TYPES.copy_from_within_household,
-            NOISE_TYPES.numeric_miswriting,
+            NOISE_TYPES.write_wrong_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     last_name: Column = Column(
         "last_name",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.fake_name,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.use_fake_name,
             # NOISE_TYPES.phonetic,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     mailing_city: Column = Column(
         "mailing_address_city",
         (
-            NOISE_TYPES.missing_data,
+            NOISE_TYPES.leave_blank,
             # NOISE_TYPES.phonetic,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     mailing_po_box: Column = Column(
         "mailing_address_po_box",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.numeric_miswriting,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.write_wrong_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     mailing_state: Column = Column(
         "mailing_address_state",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.incorrect_selection,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.choose_wrong_option,
         ),
         DtypeNames.CATEGORICAL,
     )
     mailing_street_name: Column = Column(
         "mailing_address_street_name",
         (
-            NOISE_TYPES.missing_data,
+            NOISE_TYPES.leave_blank,
             # NOISE_TYPES.phonetic,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     mailing_street_number: Column = Column(
         "mailing_address_street_number",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.numeric_miswriting,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.write_wrong_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     mailing_unit_number: Column = Column(
         "mailing_address_unit_number",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.numeric_miswriting,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.write_wrong_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     mailing_zipcode: Column = Column(
         "mailing_address_zipcode",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.zipcode_miswriting,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.write_wrong_zipcode_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     middle_initial: Column = Column(
         "middle_initial",
         (
-            NOISE_TYPES.missing_data,
+            NOISE_TYPES.leave_blank,
             # NOISE_TYPES.phonetic,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     race_ethnicity: Column = Column(
         "race_ethnicity",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.incorrect_selection,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.choose_wrong_option,
         ),
         DtypeNames.CATEGORICAL,
     )
     relation_to_reference_person: Column = Column(
         "relation_to_reference_person",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.incorrect_selection,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.choose_wrong_option,
         ),
         DtypeNames.CATEGORICAL,
     )
     sex: Column = Column(
         "sex",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.incorrect_selection,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.choose_wrong_option,
         ),
         DtypeNames.CATEGORICAL,
     )
@@ -264,56 +264,56 @@ class __Columns(NamedTuple):
     ssa_event_date: Column = Column(
         "event_date",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.month_day_swap,
-            NOISE_TYPES.numeric_miswriting,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.swap_month_and_day,
+            NOISE_TYPES.write_wrong_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
         additional_attributes={Attributes.DATE_FORMAT: DATEFORMATS.YYYYMMDD},
     )
     ssa_event_type: Column = Column(
         "event_type",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.incorrect_selection,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.choose_wrong_option,
         ),
         DtypeNames.CATEGORICAL,
     )
     ssn: Column = Column(
         "ssn",
         (
-            NOISE_TYPES.missing_data,
+            NOISE_TYPES.leave_blank,
             # NOISE_TYPES.copy_from_within_household,
-            NOISE_TYPES.numeric_miswriting,
+            NOISE_TYPES.write_wrong_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     state: Column = Column(
         "state",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.incorrect_selection,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.choose_wrong_option,
         ),
         DtypeNames.CATEGORICAL,
     )
     street_name: Column = Column(
         "street_name",
         (
-            NOISE_TYPES.missing_data,
+            NOISE_TYPES.leave_blank,
             # NOISE_TYPES.phonetic,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     street_number: Column = Column(
         "street_number",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.numeric_miswriting,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.write_wrong_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     survey_date: Column = Column(
@@ -323,8 +323,8 @@ class __Columns(NamedTuple):
     tax_form: Column = Column(
         "tax_form",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.incorrect_selection,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.choose_wrong_option,
         ),
         DtypeNames.CATEGORICAL,
     )
@@ -334,10 +334,10 @@ class __Columns(NamedTuple):
     unit_number: Column = Column(
         "unit_number",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.numeric_miswriting,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.write_wrong_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
     year: Column = Column(
@@ -346,10 +346,10 @@ class __Columns(NamedTuple):
     zipcode: Column = Column(
         "zipcode",
         (
-            NOISE_TYPES.missing_data,
-            NOISE_TYPES.zipcode_miswriting,
+            NOISE_TYPES.leave_blank,
+            NOISE_TYPES.write_wrong_zipcode_digits,
             # NOISE_TYPES.ocr,
-            NOISE_TYPES.typographic,
+            NOISE_TYPES.make_typos,
         ),
     )
 
@@ -481,7 +481,7 @@ class __Datasets(NamedTuple):
         date_column_name=COLUMNS.year.name,
         state_column_name=COLUMNS.state.name,
         row_noise_types=(
-            NOISE_TYPES.omission,
+            NOISE_TYPES.omit_row,
             # NOISE_TYPES.duplication,
         ),
     )
@@ -500,7 +500,7 @@ class __Datasets(NamedTuple):
         date_column_name=COLUMNS.ssa_event_date.name,
         state_column_name=None,
         row_noise_types=(
-            NOISE_TYPES.omission,
+            NOISE_TYPES.omit_row,
             # NOISE_TYPES.duplication,
         ),
     )
@@ -536,7 +536,7 @@ class __Datasets(NamedTuple):
         date_column_name=COLUMNS.tax_year.name,
         state_column_name=COLUMNS.mailing_state.name,
         row_noise_types=(
-            NOISE_TYPES.omission,
+            NOISE_TYPES.omit_row,
             # NOISE_TYPES.duplication,
         ),
     )

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -242,8 +242,8 @@ def test_column_noising(dataset_name: str, user_config, request):
         "TODO: tax_1040",
     ],
 )
-def test_row_noising_omission_or_do_not_respond(dataset_name: str, user_config, request):
-    """Tests that omission and do not respond row noising are being applied"""
+def test_row_noising_omit_row_or_do_not_respond(dataset_name: str, user_config, request):
+    """Tests that omit_row and do_not_respond row noising are being applied"""
     if "TODO" in dataset_name:
         pytest.skip(reason=dataset_name)
     idx_cols = IDX_COLS.get(dataset_name)
@@ -253,9 +253,9 @@ def test_row_noising_omission_or_do_not_respond(dataset_name: str, user_config, 
     )
     config = get_configuration(user_config)[dataset_name][Keys.ROW_NOISE]
     noise_type = [
-        n for n in config if n in [NOISE_TYPES.omission.name, NOISE_TYPES.do_not_respond.name]
+        n for n in config if n in [NOISE_TYPES.omit_row.name, NOISE_TYPES.do_not_respond.name]
     ]
-    assert len(noise_type) < 2  # omission and do not respond should be mutually exclusive
+    assert len(noise_type) < 2  # omit_row and do_not_respond should be mutually exclusive
     if not noise_type:  # Check that there are no missing indexes
         assert noised_data.index.symmetric_difference(data.index).empty
     else:  # Check that there are some omissions

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -101,9 +101,9 @@ def test_get_configuration_with_user_override(mocker):
     mock = mocker.patch("pseudopeople.configuration.generator.ConfigTree")
     config = {
         DATASETS.census.name: {
-            Keys.ROW_NOISE: {NOISE_TYPES.omission.name: {Keys.ROW_PROBABILITY: 0.05}},
+            Keys.ROW_NOISE: {NOISE_TYPES.omit_row.name: {Keys.ROW_PROBABILITY: 0.05}},
             Keys.COLUMN_NOISE: {
-                "first_name": {NOISE_TYPES.typographic.name: {Keys.CELL_PROBABILITY: 0.05}}
+                "first_name": {NOISE_TYPES.make_typos.name: {Keys.CELL_PROBABILITY: 0.05}}
             },
         }
     }
@@ -122,7 +122,7 @@ def test_loading_from_yaml(tmp_path):
         DATASETS.census.name: {
             Keys.COLUMN_NOISE: {
                 COLUMNS.age.name: {
-                    NOISE_TYPES.age_miswriting.name: {
+                    NOISE_TYPES.misreport_age.name: {
                         Keys.CELL_PROBABILITY: 0.5,
                     },
                 },
@@ -135,10 +135,10 @@ def test_loading_from_yaml(tmp_path):
 
     default_config = get_configuration()[DATASETS.census.name][Keys.COLUMN_NOISE][
         COLUMNS.age.name
-    ][NOISE_TYPES.age_miswriting.name].to_dict()
+    ][NOISE_TYPES.misreport_age.name].to_dict()
     updated_config = get_configuration(filepath)[DATASETS.census.name][Keys.COLUMN_NOISE][
         COLUMNS.age.name
-    ][NOISE_TYPES.age_miswriting.name].to_dict()
+    ][NOISE_TYPES.misreport_age.name].to_dict()
 
     assert (
         default_config[Keys.POSSIBLE_AGE_DIFFERENCES]
@@ -164,7 +164,7 @@ def test_format_miswrite_ages(user_config, expected):
         DATASETS.census.name: {
             Keys.COLUMN_NOISE: {
                 COLUMNS.age.name: {
-                    NOISE_TYPES.age_miswriting.name: {
+                    NOISE_TYPES.misreport_age.name: {
                         Keys.POSSIBLE_AGE_DIFFERENCES: user_config,
                     },
                 },
@@ -174,7 +174,7 @@ def test_format_miswrite_ages(user_config, expected):
 
     config = get_configuration(user_config)[DATASETS.census.name][Keys.COLUMN_NOISE][
         COLUMNS.age.name
-    ][NOISE_TYPES.age_miswriting.name][Keys.POSSIBLE_AGE_DIFFERENCES].to_dict()
+    ][NOISE_TYPES.misreport_age.name][Keys.POSSIBLE_AGE_DIFFERENCES].to_dict()
 
     assert config == expected
 
@@ -211,7 +211,7 @@ def test_format_miswrite_ages(user_config, expected):
             {
                 DATASETS.acs.name: {
                     Keys.COLUMN_NOISE: {
-                        COLUMNS.age.name: {NOISE_TYPES.missing_data.name: {"fake": 1}}
+                        COLUMNS.age.name: {NOISE_TYPES.leave_blank.name: {"fake": 1}}
                     }
                 }
             },
@@ -254,7 +254,7 @@ def test_validate_standard_parameters_failures(value, match):
                 DATASETS.census.name: {
                     Keys.COLUMN_NOISE: {
                         COLUMNS.age.name: {
-                            NOISE_TYPES.age_miswriting.name: {
+                            NOISE_TYPES.misreport_age.name: {
                                 Keys.CELL_PROBABILITY: value,
                             },
                         },
@@ -295,7 +295,7 @@ def test_validate_miswrite_ages_failures(perturbations, match):
                 DATASETS.census.name: {
                     Keys.COLUMN_NOISE: {
                         COLUMNS.age.name: {
-                            NOISE_TYPES.age_miswriting.name: {
+                            NOISE_TYPES.misreport_age.name: {
                                 Keys.CELL_PROBABILITY: 1,
                                 Keys.POSSIBLE_AGE_DIFFERENCES: perturbations,
                             },
@@ -324,7 +324,7 @@ def test_validate_miswrite_zipcode_digit_probabilities_failures(probabilities, m
                 DATASETS.census.name: {
                     Keys.COLUMN_NOISE: {
                         COLUMNS.zipcode.name: {
-                            NOISE_TYPES.zipcode_miswriting.name: {
+                            NOISE_TYPES.write_wrong_zipcode_digits.name: {
                                 Keys.CELL_PROBABILITY: 1,
                                 Keys.ZIPCODE_DIGIT_PROBABILITIES: probabilities,
                             },
@@ -340,7 +340,7 @@ def test_get_config(caplog):
         DATASETS.acs.name: {
             Keys.COLUMN_NOISE: {
                 "zipcode": {
-                    NOISE_TYPES.missing_data.name: {
+                    NOISE_TYPES.leave_blank.name: {
                         Keys.CELL_PROBABILITY: 0.25,
                     },
                 },
@@ -368,7 +368,7 @@ def test_date_format_config():
     noise_cols = set()
 
     for column in COLUMNS:
-        if NOISE_TYPES.month_day_swap in column.noise_types:
+        if NOISE_TYPES.swap_month_and_day in column.noise_types:
             noise_cols.add(column.name)
         if Attributes.DATE_FORMAT in column.additional_attributes.keys():
             date_attribute_cols.add(column.name)
@@ -381,7 +381,7 @@ def test_omit_rows_do_not_respond_mutex_default_configuration():
     config = get_configuration()
     for dataset in DATASETS:
         has_omit_rows = (
-            NOISE_TYPES.omission.name in config[dataset.name][Keys.ROW_NOISE].keys()
+            NOISE_TYPES.omit_row.name in config[dataset.name][Keys.ROW_NOISE].keys()
         )
         has_do_not_respond = (
             NOISE_TYPES.do_not_respond.name in config[dataset.name][Keys.ROW_NOISE].keys()
@@ -401,7 +401,7 @@ def test_validate_nickname_configuration(caplog):
                 DATASETS.census.name: {
                     Keys.COLUMN_NOISE: {
                         COLUMNS.first_name.name: {
-                            NOISE_TYPES.nickname.name: {
+                            NOISE_TYPES.use_nickname.name: {
                                 Keys.CELL_PROBABILITY: config_value,
                             },
                         },

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -52,24 +52,24 @@ def dummy_config_noise_numbers():
             DATASETS.census.name: {
                 Keys.COLUMN_NOISE: {
                     "event_type": {
-                        NOISE_TYPES.missing_data.name: {Keys.CELL_PROBABILITY: 0.01},
-                        NOISE_TYPES.incorrect_selection.name: {Keys.CELL_PROBABILITY: 0.01},
-                        "copy_from_within_household": {Keys.CELL_PROBABILITY: 0.01},
-                        "month_day_swap": {Keys.CELL_PROBABILITY: 0.01},
-                        NOISE_TYPES.zipcode_miswriting.name: {
+                        NOISE_TYPES.leave_blank.name: {Keys.CELL_PROBABILITY: 0.01},
+                        NOISE_TYPES.choose_wrong_option.name: {Keys.CELL_PROBABILITY: 0.01},
+                        "copy_from_household_member": {Keys.CELL_PROBABILITY: 0.01},
+                        NOISE_TYPES.swap_month_and_day.name: {Keys.CELL_PROBABILITY: 0.01},
+                        NOISE_TYPES.write_wrong_zipcode_digits.name: {
                             Keys.CELL_PROBABILITY: 0.01,
                             Keys.ZIPCODE_DIGIT_PROBABILITIES: [0.04, 0.04, 0.2, 0.36, 0.36],
                         },
-                        NOISE_TYPES.age_miswriting.name: {
+                        NOISE_TYPES.misreport_age.name: {
                             Keys.CELL_PROBABILITY: 0.01,
                             Keys.POSSIBLE_AGE_DIFFERENCES: [1, -1],
                         },
-                        NOISE_TYPES.numeric_miswriting.name: {
+                        NOISE_TYPES.write_wrong_digits.name: {
                             Keys.CELL_PROBABILITY: 0.01,
-                            "numeric_miswriting": [0.1],
+                            Keys.TOKEN_PROBABILITY: 0.1,
                         },
-                        "nickname": {Keys.CELL_PROBABILITY: 0.01},
-                        NOISE_TYPES.fake_name.name: {Keys.CELL_PROBABILITY: 0.01},
+                        NOISE_TYPES.use_nickname.name: {Keys.CELL_PROBABILITY: 0.01},
+                        NOISE_TYPES.use_fake_name.name: {Keys.CELL_PROBABILITY: 0.01},
                         "phonetic": {
                             Keys.CELL_PROBABILITY: 0.01,
                             Keys.TOKEN_PROBABILITY: 0.1,
@@ -78,14 +78,14 @@ def dummy_config_noise_numbers():
                             Keys.CELL_PROBABILITY: 0.01,
                             Keys.TOKEN_PROBABILITY: 0.1,
                         },
-                        NOISE_TYPES.typographic.name: {
+                        NOISE_TYPES.make_typos.name: {
                             Keys.CELL_PROBABILITY: 0.01,
                             Keys.TOKEN_PROBABILITY: 0.1,
                         },
                     },
                 },
                 Keys.ROW_NOISE: {
-                    "duplication": {
+                    "duplicate_rows": {
                         Keys.ROW_PROBABILITY: 0.01,
                     },
                     NOISE_TYPES.do_not_respond.name: {
@@ -98,10 +98,11 @@ def dummy_config_noise_numbers():
 
 
 def test_noise_order(mocker, dummy_data, dummy_config_noise_numbers):
-    """From docs: "Noising should be applied in the following order: omissions, duplications,
-    missing data, incorrect selection, copy from w/in household, month and day
-    swaps, zip code miswriting, age miswriting, numeric miswriting, nicknames,
-    fake names, phonetic, OCR, typographic"
+    """From docs: "Noising should be applied in the following order: omit_row,
+    do_not_respond, duplicate_row, leave_blank, choose_wrong_option,
+    copy_from_household_member, swap_month_and_day, write_wrong_zipcode_digits,
+    misreport_age, write_wrong_digits, use_nickname, use_fake_name,
+    make_phonetic_errors, make_ocr_errors, make_typos
     """
     mock = mocker.MagicMock()
     # Mock the noise_functions functions so that they are not actually called and
@@ -129,21 +130,21 @@ def test_noise_order(mocker, dummy_data, dummy_config_noise_numbers):
 
     call_order = [x[0] for x in mock.mock_calls if not x[0].startswith("__")]
     expected_call_order = [
-        # "omit_rows",   # Census doesn't use omit_rows
-        "do_not_respond",
-        # "duplication",
-        "missing_data",
-        "incorrect_selection",
-        # "copy_from_within_household",
-        # "month_day_swap",
-        "zipcode_miswriting",
-        "age_miswriting",
-        "numeric_miswriting",
-        # "nickname",
-        "fake_name",
+        # NOISE_TYPES.omit_row.name,   # Census doesn't use omit_row
+        NOISE_TYPES.do_not_respond.name,
+        # NOISE_TYPES.duplicate_row.name,
+        NOISE_TYPES.leave_blank.name,
+        NOISE_TYPES.choose_wrong_option.name,
+        # NOISE_TYPES.copy_from_household_member.name,
+        NOISE_TYPES.swap_month_and_day.name,
+        NOISE_TYPES.write_wrong_zipcode_digits.name,
+        NOISE_TYPES.misreport_age.name,
+        NOISE_TYPES.write_wrong_digits.name,
+        NOISE_TYPES.use_nickname.name,
+        NOISE_TYPES.use_fake_name.name,
         # "phonetic",
         # "ocr",
-        "typographic",
+        NOISE_TYPES.make_typos.name,
     ]
 
     assert expected_call_order == call_order
@@ -159,7 +160,7 @@ def test_columns_noised(dummy_data):
             DATASETS.census.name: {
                 Keys.COLUMN_NOISE: {
                     "event_type": {
-                        NOISE_TYPES.missing_data.name: {Keys.CELL_PROBABILITY: 0.1},
+                        NOISE_TYPES.leave_blank.name: {Keys.CELL_PROBABILITY: 0.1},
                     },
                 },
             },

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -102,7 +102,7 @@ def test_noise_order(mocker, dummy_data, dummy_config_noise_numbers):
     do_not_respond, duplicate_row, leave_blank, choose_wrong_option,
     copy_from_household_member, swap_month_and_day, write_wrong_zipcode_digits,
     misreport_age, write_wrong_digits, use_nickname, use_fake_name,
-    make_phonetic_errors, make_ocr_errors, make_typos
+    make_phonetic_error, make_ocr_errors, make_typos
     """
     mock = mocker.MagicMock()
     # Mock the noise_functions functions so that they are not actually called and
@@ -142,7 +142,7 @@ def test_noise_order(mocker, dummy_data, dummy_config_noise_numbers):
         NOISE_TYPES.write_wrong_digits.name,
         NOISE_TYPES.use_nickname.name,
         NOISE_TYPES.use_fake_name.name,
-        # NOISE_TYPES.make_phonetic_errors.name,
+        # NOISE_TYPES.make_phonetic_error.name,
         # NOISE_TYPES.make_ocr_errors.name,
         NOISE_TYPES.make_typos.name,
     ]

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -102,7 +102,7 @@ def test_noise_order(mocker, dummy_data, dummy_config_noise_numbers):
     do_not_respond, duplicate_row, leave_blank, choose_wrong_option,
     copy_from_household_member, swap_month_and_day, write_wrong_zipcode_digits,
     misreport_age, write_wrong_digits, use_nickname, use_fake_name,
-    make_phonetic_error, make_ocr_errors, make_typos
+    make_phonetic_errors, make_ocr_errors, make_typos
     """
     mock = mocker.MagicMock()
     # Mock the noise_functions functions so that they are not actually called and
@@ -142,7 +142,7 @@ def test_noise_order(mocker, dummy_data, dummy_config_noise_numbers):
         NOISE_TYPES.write_wrong_digits.name,
         NOISE_TYPES.use_nickname.name,
         NOISE_TYPES.use_fake_name.name,
-        # NOISE_TYPES.make_phonetic_error.name,
+        # NOISE_TYPES.make_phonetic_errors.name,
         # NOISE_TYPES.make_ocr_errors.name,
         NOISE_TYPES.make_typos.name,
     ]

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -142,8 +142,8 @@ def test_noise_order(mocker, dummy_data, dummy_config_noise_numbers):
         NOISE_TYPES.write_wrong_digits.name,
         NOISE_TYPES.use_nickname.name,
         NOISE_TYPES.use_fake_name.name,
-        # "phonetic",
-        # "ocr",
+        # NOISE_TYPES.make_phonetic_errors.name,
+        # NOISE_TYPES.make_ocr_errors.name,
         NOISE_TYPES.make_typos.name,
     ]
 

--- a/tests/unit/test_row_noise.py
+++ b/tests/unit/test_row_noise.py
@@ -36,12 +36,12 @@ def dummy_data():
     )
 
 
-def test_omission(dummy_data):
+def test_omit_row(dummy_data):
     config = get_configuration()[DATASETS.tax_w2_1099.name][Keys.ROW_NOISE][
-        NOISE_TYPES.omission.name
+        NOISE_TYPES.omit_row.name
     ]
     dataset_name_1 = "dummy_dataset_name"
-    noised_data1 = NOISE_TYPES.omission(dataset_name_1, dummy_data, config, RANDOMNESS)
+    noised_data1 = NOISE_TYPES.omit_row(dataset_name_1, dummy_data, config, RANDOMNESS)
 
     expected_noise_1 = config[Keys.ROW_PROBABILITY]
     assert np.isclose(1 - len(noised_data1) / len(dummy_data), expected_noise_1, rtol=0.02)


### PR DESCRIPTION
## Title: Align noise entity class attributes with their names

### Description
- *Category*: other
- *JIRA issue*: [MIC-4003](https://jira.ihme.washington.edu/browse/MIC-4003)

After re-naming all of the config keys, the noise entity class attributes did not
match. While not user facing, it was annoying/confusing. 

### Testing
tests pass

