### PR TITLE
Configure readthedocs to build a PDF

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,3 +19,6 @@ python:
 # Doc builds will fail if there are any warnings
 sphinx:
   fail_on_warning: true
+
+formats:
+  - pdf


### PR DESCRIPTION
## Configure readthedocs to build a PDF

### Description
- *Category*: documentation
- *JIRA issue*: none

I've done this as a "docs hotfix" -- @ckkinuthia requested a PDF of the docs, so we can share it an a more easily comment-able form.

See RTD documentation on this: https://docs.readthedocs.io/en/latest/tutorial/index.html#enabling-pdf-and-epub-builds

### Testing

No testing; I don't think there is a way to test this without it being in main?