### PR TITLE
Document requesting no noise with a sentinel value

### DIFF
--- a/docs/source/api_reference/noising/index.rst
+++ b/docs/source/api_reference/noising/index.rst
@@ -12,7 +12,7 @@ All of the dataset generation functions have the same (optional) parameters.
 Notable parameters include:
 
     - a `source` path to the root directory of pseudopeople input data (defaults to using the sample dataset included with pseudopeople).
-    - a `config` path to a YAML file or a Python dictionary to :ref:`override the default configuration <configuration_main>`.
+    - a `config` path to a YAML file, a Python dictionary, or the special value :code:`pseudopeople.NO_NOISE`, to :ref:`override the default configuration <configuration_main>`.
     - a `year` (defaults to 2020).
 
 For applied examples of using these functions, see the :ref:`Quickstart <quickstart>` and :ref:`tutorials <tutorial_main>`.

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -19,6 +19,9 @@ Due to this fine-grained control, there are a very large number of settings.
 **It is not necessary to configure everything.**
 pseudopeople includes reasonable default noise settings
 and your configuration can override as few or as many of the default values as you like.
+You can also pass the special value :code:`pseudopeople.NO_NOISE`, which prevents all configurable noise types
+from occurring at all.
+
 To learn more about the default settings, see :ref:`Noise Type Details <noise_type_details>`.
 You can access the defaults from your Python code by calling the :func:`pseudopeople.get_config` function.
 
@@ -87,7 +90,8 @@ How to pass configuration to pseudopeople
 
 Each of pseudopeople's :ref:`dataset generation functions <dataset_generation_functions>` takes a :code:`config`
 argument.
-This argument can be passed either a Python dictionary or the path to a YAML file.
+This argument can be passed either a Python dictionary, the path to a YAML file, or the special value
+:code:`pseudopeople.NO_NOISE`, which prevents all configurable noise types from occurring at all.
 
 Configurable parameters
 -----------------------


### PR DESCRIPTION
## Document requesting no noise with a sentinel value

### Description
- *Category*: documentation
- *JIRA issue*: none

Adds some documentation of a special value that can be passed to dataset generation functions, to generate datasets with no (configurable) noise. (Configurable noise is all noise except "borrowed SSN.")

### Testing

Built locally.