### PR TITLE
Generate un-noised dataset

### DIFF
--- a/src/pseudopeople/configuration/entities.py
+++ b/src/pseudopeople/configuration/entities.py
@@ -8,3 +8,5 @@ class Keys:
     TOKEN_PROBABILITY = "token_probability"
     POSSIBLE_AGE_DIFFERENCES = "possible_age_differences"
     ZIPCODE_DIGIT_PROBABILITIES = "digit_probabilities"
+    NO_NOISE = "no_noise"
+    DEFAULT = "default"

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -80,6 +80,8 @@ def get_configuration(user_configuration: Union[Path, str, Dict] = None) -> Conf
         if user_configuration.lower() == Keys.NO_NOISE:
             config_type = Keys.NO_NOISE
             user_configuration = None
+        else:
+            config_type = Keys.DEFAULT
     else:
         config_type = Keys.DEFAULT
     noising_configuration = _generate_configuration(config_type)

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -76,12 +76,9 @@ def get_configuration(user_configuration: Union[Path, str, Dict] = None) -> Conf
     :return: a ConfigTree object of the noising configuration
     """
 
-    if type(user_configuration) == str:
-        if user_configuration.lower() == Keys.NO_NOISE:
-            config_type = Keys.NO_NOISE
-            user_configuration = None
-        else:
-            config_type = Keys.DEFAULT
+    if type(user_configuration) == str and user_configuration.lower() == Keys.NO_NOISE:
+        config_type = Keys.NO_NOISE
+        user_configuration = None
     else:
         config_type = Keys.DEFAULT
     noising_configuration = _generate_configuration(config_type)

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -148,7 +148,7 @@ def _generate_configuration(config_type: str) -> ConfigTree:
 
     # Update configuration with non-baseline default values
     if config_type == Keys.DEFAULT:
-        noising_configuration.update(DEFAULT_NOISE_VALUES, layer="default")
+        noising_configuration.update(DEFAULT_NOISE_VALUES, layer=config_type)
     return noising_configuration
 
 

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -419,7 +419,7 @@ def test_no_noise():
     # Tests that passing the sentinal no noise value results in a configuration
     # where all noise levels are 0.0
     no_noise_config = get_configuration("no_noise")
-    # breakpoint()
+
     for dataset in no_noise_config.keys():
         dataset_dict = no_noise_config[dataset]
         dataset_row_noise_dict = dataset_dict[Keys.ROW_NOISE]

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -413,3 +413,20 @@ def test_validate_nickname_configuration(caplog):
             assert not caplog.records
         else:
             assert "Noise level has been adjusted" in caplog.text
+
+
+def test_no_noise():
+    # Tests that passing the sentinal no noise value results in a configuration
+    # where all noise levels are 0.0
+    no_noise_config = get_configuration("no_noise")
+    # breakpoint()
+    for dataset in no_noise_config.keys():
+        dataset_dict = no_noise_config[dataset]
+        dataset_row_noise_dict = dataset_dict[Keys.ROW_NOISE]
+        dataset_column_dict = dataset_dict[Keys.COLUMN_NOISE]
+        for row_noise_type in dataset_row_noise_dict.keys():
+            assert dataset_row_noise_dict[row_noise_type][Keys.ROW_PROBABILITY] == 0.0
+        for column in dataset_column_dict.keys():
+            column_noise_dict = dataset_column_dict[column]
+            for column_noise_type in column_noise_dict.keys():
+                assert column_noise_dict[column_noise_type][Keys.CELL_PROBABILITY] == 0.0


### PR DESCRIPTION
## Generate un-noised dataset

### Adds ability to pass sentinel value "no_noise" as a user configuration to return an un-noised dataset.
- *Category*: Feature
- *JIRA issue*: [MIC-3968](https://jira.ihme.washington.edu/browse/MIC-3968)

-adds functionality for users to provide a value of "no_noise" as a user provided config to return an un-noised dataset.
-adds related test for functionality

### Testing
All tests pass.

