### PR TITLE
DOC: add link to mailing list signup page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,3 +22,7 @@ or build it from source with
 Documentation
 ======================
 You can view documentation at https://pseudopeople.readthedocs.io/en/latest/
+
+To receive updates about this software package `join the mailing list
+here
+<https://mailman11.u.washington.edu/mailman/listinfo/pseudopeople-users>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -146,6 +146,9 @@ here are some next steps:
   take a look at the :ref:`Input Data page <input_data_main>`.
 * To dive deeper into noise, read the docs about :ref:`noise <noise_main>` and
   :ref:`noise configuration <configuration_main>`.
+* To stay informed and recieve updates about this software package
+  `join the mailing list here
+  <https://mailman11.u.washington.edu/mailman/listinfo/pseudopeople-users>`_.
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
## Title: add link to mailing list signup page

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: DOC
- *JIRA issue*: none

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This adds a link to the pseudopeople mailing list signup page to the README and read-the-docs.

### Testing

successfully built docs without warning, reviewed README.rst in GitHub and confirmed that link works.
