### PR TITLE
Update noise table to include choose the wrong option

### DIFF
--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -143,23 +143,23 @@ Noise types for each column
     - Noise for all types of addresses works in the same way
   * - State for any address (physical, mailing, or employer)
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099
-    - Leave a field blank 
+    - Leave a field blank, choose the wrong option 
     - Noise for all types of addresses works in the same way
   * - ZIP code for any address (physical, mailing, or employer)
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099
     - Leave a field blank, write the wrong zipcode digits, make typos
     -
-  * - Relationship to head of household
+  * - Relationship to reference person
     - Decennial Census
-    - Leave a field blank
+    - Leave a field blank, choose the wrong option
     -
   * - Sex
     - Decennial Census, ACS, CPS, WIC
-    - Leave a field blank
+    - Leave a field blank, choose the wrong option
     -
   * - Race/ethnicity
     - Decennial Census, ACS, CPS, WIC
-    - Leave a field blank
+    - Leave a field blank, choose the wrong option
     -
   * - SSN
     - W-2 and 1099, SSA
@@ -179,11 +179,11 @@ Noise types for each column
     -
   * - Type of tax form
     - W-2 and 1099
-    - Leave a field blank
+    - Leave a field blank, choose the wrong option
     -
   * - Type of SSA event
     - SSA
-    - Leave a field blank
+    - Leave a field blank, choose the wrong option
     -
   * - Date of SSA event
     - SSA


### PR DESCRIPTION
## Title: Update noise table to include choose the wrong option
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: [SSCI-1376](https://jira.ihme.washington.edu/browse/SSCI-1376)

Re-doing this PR to merge to main instead of develop. 

'Choose the wrong option' (previously 'incorrect select' in concept model) was missing from the noise table in psp docs. Added for fields listed in concept model: state for any address; relationship to reference person; sex; race/ethnicity; type of tax form; and type of SSA event)

Edit: I also just noticed that 'head of household' is used in this table - I just updated it to 'reference person' to be consistent with the rest of documentation.

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

