### PR TITLE
Add docstring for no noise interface and fix bug

### DIFF
--- a/src/pseudopeople/__init__.py
+++ b/src/pseudopeople/__init__.py
@@ -8,6 +8,7 @@ from pseudopeople.__about__ import (
     __uri__,
     __version__,
 )
+from pseudopeople.configuration.entities import NO_NOISE
 from pseudopeople.configuration.interface import get_config
 from pseudopeople.interface import (
     generate_american_community_survey,

--- a/src/pseudopeople/configuration/__init__.py
+++ b/src/pseudopeople/configuration/__init__.py
@@ -1,2 +1,2 @@
-from pseudopeople.configuration.entities import Keys
+from pseudopeople.configuration.entities import DEFAULT, NO_NOISE, Keys
 from pseudopeople.configuration.generator import get_configuration

--- a/src/pseudopeople/configuration/__init__.py
+++ b/src/pseudopeople/configuration/__init__.py
@@ -1,2 +1,2 @@
-from pseudopeople.configuration.entities import DEFAULT, NO_NOISE, Keys
+from pseudopeople.configuration.entities import NO_NOISE, Keys
 from pseudopeople.configuration.generator import get_configuration

--- a/src/pseudopeople/configuration/entities.py
+++ b/src/pseudopeople/configuration/entities.py
@@ -11,4 +11,3 @@ class Keys:
 
 
 NO_NOISE = "no_noise"
-DEFAULT = "default"

--- a/src/pseudopeople/configuration/entities.py
+++ b/src/pseudopeople/configuration/entities.py
@@ -8,5 +8,7 @@ class Keys:
     TOKEN_PROBABILITY = "token_probability"
     POSSIBLE_AGE_DIFFERENCES = "possible_age_differences"
     ZIPCODE_DIGIT_PROBABILITIES = "digit_probabilities"
-    NO_NOISE = "no_noise"
-    DEFAULT = "default"
+
+
+NO_NOISE = "no_noise"
+DEFAULT = "default"

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 import yaml
 from vivarium.config_tree import ConfigTree
 
-from pseudopeople.configuration import DEFAULT, NO_NOISE, Keys
+from pseudopeople.configuration import NO_NOISE, Keys
 from pseudopeople.configuration.validator import validate_user_configuration
 from pseudopeople.constants.data_values import DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY
 from pseudopeople.noise_entities import NOISE_TYPES
@@ -75,15 +75,16 @@ def get_configuration(user_configuration: Union[Path, str, Dict] = None) -> Conf
     :param user_configuration: A path to the YAML file or a dictionary defining user overrides for the defaults
     :return: a ConfigTree object of the noising configuration
     """
+
     if isinstance(user_configuration, str) and user_configuration.lower() == NO_NOISE:
         config_type = NO_NOISE
         user_configuration = None
     elif isinstance(user_configuration, (Path, str)):
         with open(user_configuration, "r") as f:
             user_configuration = yaml.full_load(f)
-        config_type = DEFAULT
+        config_type = None
     else:
-        config_type = DEFAULT
+        config_type = None
     noising_configuration = _generate_configuration(config_type)
     if user_configuration:
         add_user_configuration(noising_configuration, user_configuration)
@@ -91,7 +92,7 @@ def get_configuration(user_configuration: Union[Path, str, Dict] = None) -> Conf
     return noising_configuration
 
 
-def _generate_configuration(config_type: str) -> ConfigTree:
+def _generate_configuration(config_type: str = None) -> ConfigTree:
     default_config_layers = [
         "baseline",
         "default",
@@ -150,8 +151,8 @@ def _generate_configuration(config_type: str) -> ConfigTree:
     noising_configuration.update(baseline_dict, layer="baseline")
 
     # Update configuration with non-baseline default values
-    if config_type == DEFAULT:
-        noising_configuration.update(DEFAULT_NOISE_VALUES, layer=config_type)
+    if not config_type:
+        noising_configuration.update(DEFAULT_NOISE_VALUES, layer="default")
     return noising_configuration
 
 

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 
 import yaml
 from vivarium.config_tree import ConfigTree
@@ -92,7 +92,7 @@ def get_configuration(user_configuration: Union[Path, str, Dict] = None) -> Conf
     return noising_configuration
 
 
-def _generate_configuration(config_type: str = None) -> ConfigTree:
+def _generate_configuration(config_type: Optional[str]) -> ConfigTree:
     default_config_layers = [
         "baseline",
         "default",

--- a/src/pseudopeople/configuration/interface.py
+++ b/src/pseudopeople/configuration/interface.py
@@ -50,7 +50,7 @@ def get_config(dataset_name: str = None, user_config: Union[Path, str, Dict] = N
             - "women_infants_and_children"
     :param user_config: An optional override to the default configuration. Can be
         a path to a configuration YAML file or a dictionary. Passing a sentinel value
-        of psp.NO_NOISE ("no_noise") will override default values and return a configuration
+        of psp.NO_NOISE will override default values and return a configuration
         where all noise levels are set to 0.
     :return: Dictionary of the config.
     :raises ConfigurationError: An invalid configuration is passed with user_config.

--- a/src/pseudopeople/configuration/interface.py
+++ b/src/pseudopeople/configuration/interface.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 from typing import Dict, Union
 
+import yaml
 from loguru import logger
 
+from pseudopeople.configuration.entities import NO_NOISE
 from pseudopeople.configuration.generator import get_configuration
 from pseudopeople.exceptions import ConfigurationError
 from pseudopeople.schema_entities import DATASETS
@@ -47,12 +49,20 @@ def get_config(dataset_name: str = None, user_config: Union[Path, str, Dict] = N
             - "taxes_w2_and_1099"
             - "women_infants_and_children"
     :param user_config: An optional override to the default configuration. Can be
-        a path to a configuration YAML file or a dictionary.
+        a path to a configuration YAML file or a dictionary. Passing a sentinel value
+        of psp.NO_NOISE ("no_noise") will override default values and return a configuration
+        where all noise levels are set to 0.
     :return: Dictionary of the config.
     :raises ConfigurationError: An invalid configuration is passed with user_config.
 
     """
-
+    if isinstance(user_config, (Path, str)) and user_config != NO_NOISE:
+        with open(user_config, "r") as f:
+            user_config = yaml.full_load(f)
+    if isinstance(user_config, dict) and dataset_name not in user_config.keys():
+        logger.warning(
+            f"'{dataset_name}' provided but is not in the user provided configuration."
+        )
     config = get_configuration(user_config)
     if dataset_name:
         if dataset_name in [dataset.name for dataset in DATASETS]:
@@ -61,9 +71,5 @@ def get_config(dataset_name: str = None, user_config: Union[Path, str, Dict] = N
             raise ConfigurationError(
                 f"'{dataset_name}' provided but is not a valid option for dataset type."
             )
-    if user_config and dataset_name not in user_config.keys():
-        logger.warning(
-            f"'{dataset_name}' provided but is not in the user provided configuration."
-        )
 
     return config.to_dict()

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -3,7 +3,7 @@ import itertools
 import pytest
 import yaml
 
-from pseudopeople.configuration import Keys, get_configuration
+from pseudopeople.configuration import NO_NOISE, Keys, get_configuration
 from pseudopeople.configuration.generator import DEFAULT_NOISE_VALUES
 from pseudopeople.configuration.interface import get_config
 from pseudopeople.configuration.validator import ConfigurationError
@@ -403,6 +403,17 @@ def test_get_config(caplog):
 
     with pytest.raises(ConfigurationError, match="bad_form_name"):
         get_config("bad_form_name")
+
+    config_3 = get_config(user_config=NO_NOISE)
+    for dataset in config_3.keys():
+        row_noise_dict = config_3[dataset][Keys.ROW_NOISE]
+        column_dict = config_3[dataset][Keys.COLUMN_NOISE]
+        for row_noise in row_noise_dict:
+            assert row_noise_dict[row_noise][Keys.ROW_PROBABILITY] == 0.0
+        for column in column_dict:
+            column_noise_dict = column_dict[column]
+            for column_noise in column_noise_dict:
+                assert column_noise_dict[column_noise][Keys.CELL_PROBABILITY] == 0.0
 
 
 def test_date_format_config():


### PR DESCRIPTION
## Add docstring for no noise interface

### Updates docstring for get_config to include option for psp.NO_NOISE and fixes bug handling strings and paths.
- *Category*: Bugfix
- *JIRA issue*: [MIC-4203](https://jira.ihme.washington.edu/browse/MIC-4203)

-adds options for users to pass sentinel psp.NO_NOISE value to get_config
-fixes bug where strings and paths were not properly handled in get_config

### Testing
All tests pass

