### PR TITLE
automatically tag all tests in integration/ as slow

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from _pytest.logging import LogCaptureFixture
 from loguru import logger
@@ -17,6 +19,9 @@ def pytest_collection_modifyitems(config, items):
         return
     skip_slow = pytest.mark.skip(reason="need --runslow option to run")
     for item in items:
+        # Automatically tag all tests in the tests/integration dir as slow
+        if Path(item.parent.path).parent.stem == "integration":
+            item.add_marker(pytest.mark.slow)
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
 


### PR DESCRIPTION
## Title: Auto-mark integration tests slow
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: other
- *JIRA issue*: na

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
The pytest suite is taking 15-20 minutes to run which is far too long. 
This auto-marks all tests in the tests/integration/ directory as "slow"
and skips them. 

This means that we need to manually run `pytest --runslow` locally!

### Testing
Tests are skipped. Went from 15 minutes to 2 on my laptop.
