### PR TITLE
Doc hotfix: Correct date formats

### DIFF
--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -61,7 +61,7 @@ The following columns are included in this dataset:
      - Rounded down to an integer. 
    * - Date of birth
      - :code:`date_of_birth`
-     - Formatted as YYYY-MM-DD.
+     - Formatted as MM/DD/YYYY.
    * - Physical address street number
      - :code:`street_number`
      - 
@@ -135,7 +135,7 @@ The following columns are included in this dataset:
      - Rounded down to an integer.
    * - Date of birth
      - :code:`date_of_birth`
-     - Formatted as YYYY-MM-DD.
+     - Formatted as MM/DD/YYYY.
    * - Physical address street number
      - :code:`street_number`
      - 
@@ -204,7 +204,7 @@ The following columns are included in this dataset:
      - Rounded down to an integer.
    * - Date of birth
      - :code:`date_of_birth`
-     - Formatted as YYYY-MM-DD.
+     - Formatted as MM/DD/YYYY.
    * - Physical address street number
      - :code:`street_number`
      - 
@@ -274,7 +274,7 @@ The following columns are included in this dataset:
      - Rounded down to an integer.
    * - Date of birth
      - :code:`date_of_birth`
-     - Formatted as YYYY-MM-DD.
+     - Formatted as MM/DD/YYYY.
    * - Physical address street number
      - :code:`street_number`
      - 
@@ -344,14 +344,14 @@ The following columns are included in this dataset:
      - Rounded down to an integer.
    * - Date of birth
      - :code:`date_of_birth`
-     - Formatted as YYYY-MM-DD.
+     - Formatted as MM/DD/YYYY.
    * - Social security number
      - :code:`ssn`
      - By default, the SSN column in the SSA dataset has no :ref:`column-based noise <column_noise>`.
        However, it can be :ref:`configured <configuration_main>` to have noise if desired.
    * - Date of event
      - :code:`event_date`
-     - Formatted as YYYY-MM-DD.  
+     - Formatted as YYYYMMDD.  
    * - Type of event
      - :code:`event_type`
      - Possible values are "Creation" and "Death". 
@@ -394,7 +394,7 @@ The following columns are included in these datasets:
      - Rounded down to an integer.
    * - Date of birth
      - :code:`date_of_birth`
-     - Formatted as YYYY-MM-DD.
+     - Formatted as MM/DD/YYYY.
    * - Mailing address street number
      - :code:`mailing_address_street_number`
      - 


### PR DESCRIPTION
## Doc hotfix: Correct date formats

### Description
- *Category*: documentation
- *JIRA issue*: none

Previously our docs said all datasets had dates in YYYY-MM-DD. In fact, this is not the case.

You can see that this matches the code here:
https://github.com/ihmeuw/pseudopeople/blob/d1bf3bec5679c6db9deb6117af27dd07257185d3/src/pseudopeople/interface.py#L120-L127

Note that this code is **also** wrong, in that it does not match the concept model.
I will make another PR against `develop` to get everything (code and docs) in alignment with the concept model.

### Testing

Built docs locally.