### PR TITLE
Match date formats to concept model

### DIFF
--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -281,7 +281,7 @@ The following columns are included in this dataset:
      - Rounded down to an integer.
    * - Date of birth
      - :code:`date_of_birth`
-     - Formatted as YYYY-MM-DD.
+     - Formatted as MMDDYYYY.
    * - Physical address street number
      - :code:`street_number`
      - 
@@ -351,14 +351,14 @@ The following columns are included in this dataset:
      - Rounded down to an integer.
    * - Date of birth
      - :code:`date_of_birth`
-     - Formatted as YYYY-MM-DD.
+     - Formatted as YYYYMMDD.
    * - Social security number
      - :code:`ssn`
      - By default, the SSN column in the SSA dataset has no :ref:`column-based noise <column_noise>`.
        However, it can be :ref:`configured <configuration_main>` to have noise if desired.
    * - Date of event
      - :code:`event_date`
-     - Formatted as YYYY-MM-DD.  
+     - Formatted as YYYYMMDD.  
    * - Type of event
      - :code:`event_type`
      - Possible values are "Creation" and "Death". 

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -159,7 +159,6 @@ def _generate_configuration(is_no_noise: bool) -> ConfigTree:
 def add_user_configuration(
     noising_configuration: ConfigTree, user_configuration: Dict
 ) -> None:
-
     validate_user_configuration(user_configuration, noising_configuration)
     user_configuration = _format_user_configuration(noising_configuration, user_configuration)
     noising_configuration.update(user_configuration, layer="user")

--- a/src/pseudopeople/constants/metadata.py
+++ b/src/pseudopeople/constants/metadata.py
@@ -16,13 +16,10 @@ class __DateFormats:
 
     YYYYMMDD = "%Y%m%d"
     MM_DD_YYYY = "%m/%d/%Y"
+    MMDDYYYY = "%m%d%Y"
 
 
 DATEFORMATS = __DateFormats()
-
-
-class Attributes:
-    DATE_FORMAT = "date_format"
 
 
 # Value calculated for noise scaling for nicknames

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -67,6 +67,7 @@ class ColumnNoiseType:
         data: pd.DataFrame,
         configuration: ConfigTree,
         randomness_stream: RandomnessStream,
+        dataset_name: str,
         column_name: str,
     ) -> pd.Series:
         if data[column_name].empty:
@@ -92,7 +93,11 @@ class ColumnNoiseType:
             )
             return data[column_name]
         noised_data = self.noise_function(
-            data.loc[to_noise_idx], configuration, randomness_stream, column_name
+            data.loc[to_noise_idx],
+            configuration,
+            randomness_stream,
+            dataset_name,
+            column_name,
         )
 
         # Coerce noised column dtype back to original column's if it has changed

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 
 from pseudopeople.configuration import get_configuration
 from pseudopeople.constants import paths
-from pseudopeople.constants.metadata import DatasetNames
+from pseudopeople.constants.metadata import COPY_HOUSEHOLD_MEMBER_COLS, DatasetNames
 from pseudopeople.exceptions import DataSourceError
 from pseudopeople.noise import noise_dataset
 from pseudopeople.schema_entities import COLUMNS, DATASETS, Dataset
@@ -115,16 +115,16 @@ def _load_data_from_path(data_path: Path, user_filters: List[Tuple]):
 
 
 def _reformat_dates_for_noising(data: pd.DataFrame, dataset: Dataset):
-    """Formats SSA event_date and dates of birth, so they can be noised."""
+    """Formats date columns so they can be noised as strings."""
     data = data.copy()
-    if COLUMNS.ssa_event_date.name in data.columns and dataset == DATASETS.ssa:
-        # event_date -> YYYYMMDD
-        data[COLUMNS.ssa_event_date.name] = data[COLUMNS.ssa_event_date.name].dt.strftime(
-            "%Y%m%d"
-        )
-    if COLUMNS.dob.name in data.columns:
-        # date_of_birth -> MM/DD/YYYY
-        data[COLUMNS.dob.name] = data[COLUMNS.dob.name].dt.strftime("%m/%d/%Y")
+
+    for date_column in [COLUMNS.dob.name, COLUMNS.ssa_event_date.name]:
+        # Format both the actual column, and the shadow version that will be used
+        # to copy from a household member
+        for column in [date_column, COPY_HOUSEHOLD_MEMBER_COLS.get(date_column)]:
+            if column in data.columns:
+                data[column] = data[column].dt.strftime(dataset.date_format)
+
     return data
 
 

--- a/src/pseudopeople/noise.py
+++ b/src/pseudopeople/noise.py
@@ -78,6 +78,7 @@ def noise_dataset(
                         dataset_data[required_cols],
                         noise_configuration.column_noise[column][noise_type.name],
                         randomness,
+                        dataset.name,
                         column,
                     )
         else:

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -220,13 +220,7 @@ def swap_months_and_days(
     """
     from pseudopeople.schema_entities import DATASETS, DATEFORMATS
 
-    try:
-        date_format = DATASETS.get_dataset(dataset_name).date_format
-    except KeyError:
-        raise ConfigurationError(
-            f"Error while running noise function `swap_months_and_days' on column '{column_name}'. "
-            f"'{column_name}' does not have attribute date format. "
-        ) from None
+    date_format = DATASETS.get_dataset(dataset_name).date_format
 
     column = data[column_name]
     if date_format == DATEFORMATS.YYYYMMDD:  # YYYYMMDD
@@ -246,7 +240,7 @@ def swap_months_and_days(
         noised = day + month + year
     else:
         raise ValueError(
-            f"Invalid datetime format in {column.name}.  Please check input data."
+            f"Invalid date format in {dataset_name}."
         )
 
     return noised

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -239,9 +239,7 @@ def swap_months_and_days(
         day = column.str[2:4]
         noised = day + month + year
     else:
-        raise ValueError(
-            f"Invalid date format in {dataset_name}."
-        )
+        raise ValueError(f"Invalid date format in {dataset_name}.")
 
     return noised
 

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -8,11 +8,7 @@ from vivarium.framework.randomness import RandomnessStream
 
 from pseudopeople.configuration import Keys
 from pseudopeople.constants import data_values, paths
-from pseudopeople.constants.metadata import (
-    COPY_HOUSEHOLD_MEMBER_COLS,
-    Attributes,
-    DatasetNames,
-)
+from pseudopeople.constants.metadata import COPY_HOUSEHOLD_MEMBER_COLS, DatasetNames
 from pseudopeople.data.fake_names import fake_first_names, fake_last_names
 from pseudopeople.exceptions import ConfigurationError
 from pseudopeople.noise_scaling import load_nicknames_data
@@ -151,6 +147,7 @@ def choose_wrong_options(
     data: pd.DataFrame,
     _: ConfigTree,
     randomness_stream: RandomnessStream,
+    dataset_name: str,
     column_name: str,
 ) -> pd.Series:
     """
@@ -188,6 +185,7 @@ def copy_from_household_member(
     data: pd.DataFrame,
     configuration: ConfigTree,
     randomness_stream: RandomnessStream,
+    dataset_name: str,
     column_name: str,
 ) -> pd.Series:
     """
@@ -208,6 +206,7 @@ def swap_months_and_days(
     data: pd.DataFrame,
     _: ConfigTree,
     randomness_stream: RandomnessStream,
+    dataset_name: str,
     column_name: str,
 ) -> pd.Series:
     """
@@ -219,11 +218,10 @@ def swap_months_and_days(
     :param column_name: String for column that will be noised, will be the key for RandomnessStream
     :return: Noised pd.Series where some dates have month and day swapped.
     """
-    from pseudopeople.schema_entities import COLUMNS, DATEFORMATS
+    from pseudopeople.schema_entities import DATASETS, DATEFORMATS
 
-    column_type = COLUMNS.get_column(column_name)
     try:
-        date_format = column_type.additional_attributes[Attributes.DATE_FORMAT]
+        date_format = DATASETS.get_dataset(dataset_name).date_format
     except KeyError:
         raise ConfigurationError(
             f"Error while running noise function `swap_months_and_days' on column '{column_name}'. "
@@ -241,6 +239,11 @@ def swap_months_and_days(
         month = column.str[:3]
         day = column.str[3:6]
         noised = day + month + year
+    elif date_format == DATEFORMATS.MMDDYYYY:  # MMDDYYYY
+        year = column.str[4:]
+        month = column.str[:2]
+        day = column.str[2:4]
+        noised = day + month + year
     else:
         raise ValueError(
             f"Invalid datetime format in {column.name}.  Please check input data."
@@ -253,6 +256,7 @@ def write_wrong_zipcode_digits(
     data: pd.DataFrame,
     configuration: ConfigTree,
     randomness_stream: RandomnessStream,
+    dataset_name: str,
     column_name: str,
 ) -> pd.Series:
     """
@@ -299,6 +303,7 @@ def misreport_ages(
     data: pd.DataFrame,
     configuration: ConfigTree,
     randomness_stream: RandomnessStream,
+    dataset_name: str,
     column_name: str,
 ) -> pd.Series:
     """Function to mis-write ages based on perturbation parameters included in
@@ -333,6 +338,7 @@ def write_wrong_digits(
     data: pd.DataFrame,
     configuration: ConfigTree,
     randomness_stream: RandomnessStream,
+    dataset_name: str,
     column_name: str,
 ) -> pd.Series:
     """
@@ -378,6 +384,7 @@ def use_nicknames(
     data: pd.DataFrame,
     _: ConfigTree,
     randomness_stream: RandomnessStream,
+    dataset_name: str,
     column_name: str,
 ) -> pd.Series:
     """
@@ -403,6 +410,7 @@ def use_fake_names(
     data: pd.DataFrame,
     _: ConfigTree,
     randomness_stream: RandomnessStream,
+    dataset_name: str,
     column_name: str,
 ) -> pd.Series:
     """
@@ -432,6 +440,7 @@ def make_phonetic_errors(
     data: pd.Series,
     configuration: ConfigTree,
     randomness_stream: RandomnessStream,
+    dataset_name: str,
     column_name: Any,
 ) -> pd.Series:
     """
@@ -480,6 +489,7 @@ def leave_blanks(
     data: pd.DataFrame,
     configuration: ConfigTree,
     randomness_stream: RandomnessStream,
+    dataset_name: str,
     column_name: str,
 ) -> pd.Series:
     """
@@ -497,6 +507,7 @@ def make_typos(
     data: pd.DataFrame,
     configuration: ConfigTree,
     randomness_stream: RandomnessStream,
+    dataset_name: str,
     column_name: str,
 ) -> pd.Series:
     """Function that applies noise to the string values
@@ -557,6 +568,7 @@ def make_ocr_errors(
     data: pd.DataFrame,
     configuration: ConfigTree,
     randomness_stream: RandomnessStream,
+    dataset_name: str,
     column_name: str,
 ) -> pd.Series:
     """

--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Dict, NamedTuple, Optional, Tuple
 
-from pseudopeople.constants.metadata import DATEFORMATS, Attributes, DatasetNames
+from pseudopeople.constants.metadata import DATEFORMATS, DatasetNames
 from pseudopeople.entity_types import ColumnNoiseType, RowNoiseType
 from pseudopeople.noise_entities import NOISE_TYPES
 
@@ -19,7 +19,6 @@ class Column:
     name: str
     noise_types: Tuple[ColumnNoiseType, ...] = tuple()
     dtype_name: str = DtypeNames.OBJECT  # string dtype is 'object'
-    additional_attributes: Dict = field(default_factory=dict)
 
 
 class __Columns(NamedTuple):
@@ -54,7 +53,6 @@ class __Columns(NamedTuple):
             NOISE_TYPES.make_ocr_errors,
             NOISE_TYPES.make_typos,
         ),
-        additional_attributes={Attributes.DATE_FORMAT: DATEFORMATS.MM_DD_YYYY},
     )
     employer_city: Column = Column(
         "employer_city",
@@ -270,7 +268,6 @@ class __Columns(NamedTuple):
             NOISE_TYPES.make_ocr_errors,
             NOISE_TYPES.make_typos,
         ),
-        additional_attributes={Attributes.DATE_FORMAT: DATEFORMATS.YYYYMMDD},
     )
     ssa_event_type: Column = Column(
         "event_type",
@@ -371,6 +368,7 @@ class Dataset:
     name: str
     columns: Tuple[Column, ...]  # This defines the output column order
     date_column_name: str
+    date_format: str
     state_column_name: Optional[str]
     row_noise_types: Tuple[RowNoiseType, ...]
 
@@ -405,6 +403,7 @@ class __Datasets(NamedTuple):
             NOISE_TYPES.do_not_respond,
             # NOISE_TYPES.duplication,
         ),
+        date_format=DATEFORMATS.MM_DD_YYYY,
     )
     acs: Dataset = Dataset(
         DatasetNames.ACS,
@@ -432,6 +431,7 @@ class __Datasets(NamedTuple):
             NOISE_TYPES.do_not_respond,
             # NOISE_TYPES.duplication,
         ),
+        date_format=DATEFORMATS.MM_DD_YYYY,
     )
     cps: Dataset = Dataset(
         DatasetNames.CPS,
@@ -459,6 +459,7 @@ class __Datasets(NamedTuple):
             NOISE_TYPES.do_not_respond,
             # NOISE_TYPES.duplication,
         ),
+        date_format=DATEFORMATS.MM_DD_YYYY,
     )
     wic: Dataset = Dataset(
         DatasetNames.WIC,
@@ -485,6 +486,7 @@ class __Datasets(NamedTuple):
             NOISE_TYPES.omit_row,
             # NOISE_TYPES.duplication,
         ),
+        date_format=DATEFORMATS.MMDDYYYY,
     )
     ssa: Dataset = Dataset(
         DatasetNames.SSA,
@@ -504,6 +506,7 @@ class __Datasets(NamedTuple):
             NOISE_TYPES.omit_row,
             # NOISE_TYPES.duplication,
         ),
+        date_format=DATEFORMATS.YYYYMMDD,
     )
     tax_w2_1099: Dataset = Dataset(
         DatasetNames.TAXES_W2_1099,
@@ -541,6 +544,7 @@ class __Datasets(NamedTuple):
             NOISE_TYPES.omit_row,
             # NOISE_TYPES.duplication,
         ),
+        date_format=DATEFORMATS.MM_DD_YYYY,
     )
     # tax_1040: Dataset = Dataset(
     #     Datasets.TAXES_1040,

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -174,7 +174,9 @@ def test_choose_wrong_option(dummy_dataset):
         NOISE_TYPES.choose_wrong_option.name
     ]
     data = dummy_dataset[["state"]]
-    noised_data = NOISE_TYPES.choose_wrong_option(data, config, RANDOMNESS0, "dataset", "state")
+    noised_data = NOISE_TYPES.choose_wrong_option(
+        data, config, RANDOMNESS0, "dataset", "state"
+    )
     data = data.squeeze()
     # Check for expected noise level
     expected_noise = config[Keys.CELL_PROBABILITY]
@@ -194,7 +196,9 @@ def test_generate_copy_from_household_member(dummy_dataset):
         NOISE_TYPES.copy_from_household_member.name
     ]
     data = dummy_dataset[["age", "copy_age"]]
-    noised_data = NOISE_TYPES.copy_from_household_member(data, config, RANDOMNESS0, "dataset", "age")
+    noised_data = NOISE_TYPES.copy_from_household_member(
+        data, config, RANDOMNESS0, "dataset", "age"
+    )
 
     # Check for expected noise level
     expected_noise = config[Keys.CELL_PROBABILITY]
@@ -242,7 +246,9 @@ def test_swap_months_and_days(dummy_dataset):
                 NOISE_TYPES.swap_month_and_day.name
             ]
         expected_noise = config[Keys.CELL_PROBABILITY]
-        noised_data = NOISE_TYPES.swap_month_and_day(data, config, RANDOMNESS0, DATASETS.census.name, col)
+        noised_data = NOISE_TYPES.swap_month_and_day(
+            data, config, RANDOMNESS0, DATASETS.census.name, col
+        )
 
         # Confirm missing data remains missing
         data = data.squeeze()
@@ -278,7 +284,9 @@ def test_write_wrong_zipcode_digits(dummy_dataset):
     # Get configuration values for each piece of 5 digit zipcode
     probability = config[Keys.CELL_PROBABILITY]
     data = dummy_dataset[["zipcode"]]
-    noised_data = NOISE_TYPES.write_wrong_zipcode_digits(data, config, RANDOMNESS0, "dataset", "zipcode")
+    noised_data = NOISE_TYPES.write_wrong_zipcode_digits(
+        data, config, RANDOMNESS0, "dataset", "zipcode"
+    )
 
     # Confirm missing data remains missing
     data = data.squeeze()
@@ -469,7 +477,9 @@ def test_write_wrong_digits(dummy_dataset):
     data = dummy_dataset[["street_number"]]
     # Note: I changed this column from string_series to street number. It has several string formats
     # containing both numeric and alphabetically string characters.
-    noised_data = NOISE_TYPES.write_wrong_digits(data, config, RANDOMNESS0, "dataset", "street_number")
+    noised_data = NOISE_TYPES.write_wrong_digits(
+        data, config, RANDOMNESS0, "dataset", "street_number"
+    )
 
     # Get masks for helper groups, each string in categorical string purpose is to mimic possible string types
     data = data["street_number"]
@@ -687,7 +697,9 @@ def test_generate_phonetic_errors(dummy_dataset, column):
     config = config[DATASETS.census.name][Keys.COLUMN_NOISE][column][
         NOISE_TYPES.make_phonetic_errors.name
     ]
-    noised_data = NOISE_TYPES.make_phonetic_errors(dummy_dataset, config, RANDOMNESS0, "dataset", column)
+    noised_data = NOISE_TYPES.make_phonetic_errors(
+        dummy_dataset, config, RANDOMNESS0, "dataset", column
+    )
     data = data.squeeze()
 
     # Validate we do not change any missing data
@@ -726,7 +738,9 @@ def test_phonetic_error_values():
         NOISE_TYPES.make_phonetic_errors.name
     ]
     df = pd.DataFrame({"street_name": data})
-    noised_data = NOISE_TYPES.make_phonetic_errors(df, config, RANDOMNESS0, "dataset", "street_name")
+    noised_data = NOISE_TYPES.make_phonetic_errors(
+        df, config, RANDOMNESS0, "dataset", "street_name"
+    )
 
     for key in phonetic_errors_dict.keys():
         key_idx = data.index[data == key]
@@ -817,7 +831,9 @@ def test_ocr_replacement_values():
     config = config[DATASETS.census.name][Keys.COLUMN_NOISE]["employer_name"][
         NOISE_TYPES.make_ocr_errors.name
     ]
-    noised_data = NOISE_TYPES.make_ocr_errors(df, config, RANDOMNESS0, "dataset", "employer_name")
+    noised_data = NOISE_TYPES.make_ocr_errors(
+        df, config, RANDOMNESS0, "dataset", "employer_name"
+    )
 
     for key in ocr_errors_dict.keys():
         key_idx = data.index[data == key]

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -7,7 +7,6 @@ from pseudopeople.configuration import NO_NOISE, Keys, get_configuration
 from pseudopeople.configuration.generator import DEFAULT_NOISE_VALUES
 from pseudopeople.configuration.interface import get_config
 from pseudopeople.configuration.validator import ConfigurationError
-from pseudopeople.constants.metadata import Attributes
 from pseudopeople.entity_types import ColumnNoiseType, RowNoiseType
 from pseudopeople.noise_entities import NOISE_TYPES
 from pseudopeople.schema_entities import COLUMNS, DATASETS
@@ -414,23 +413,6 @@ def test_get_config(caplog):
             column_noise_dict = column_dict[column]
             for column_noise in column_noise_dict:
                 assert column_noise_dict[column_noise][Keys.CELL_PROBABILITY] == 0.0
-
-
-def test_date_format_config():
-    # Test that columns with date format attribute are only columns with swap months and days noise type
-
-    # Columns that have additional attribute date_format
-    date_attribute_cols = set()
-    # Columns that have swap_months_days noise type
-    noise_cols = set()
-
-    for column in COLUMNS:
-        if NOISE_TYPES.swap_month_and_day in column.noise_types:
-            noise_cols.add(column.name)
-        if Attributes.DATE_FORMAT in column.additional_attributes.keys():
-            date_attribute_cols.add(column.name)
-
-    assert noise_cols.issubset(date_attribute_cols)
 
 
 def test_omit_rows_do_not_respond_mutex_default_configuration():


### PR DESCRIPTION
## Match date formats to concept model

### Description
- *Category*: bugfix
- *JIRA issue*: none, but kind of a continuation of [MIC-3962](https://jira.ihme.washington.edu/browse/MIC-3962)

As documented in the concept model, the date formats should be:
- MMDDYYYY (no slashes) in WIC
- YYYYMMDD in SSA
- MM/DD/YYYY in all other datasets

This PR brings pseudopeople into alignment with this. Previously, WIC incorrectly used the default, and SSA incorrectly used the default in the date of birth column.

This turned out to be a much more involved change than I realized: previously, date format was incorrectly modeled as an attribute of the _column_ when it is really an attribute of the _dataset_. Please let me know if I've done this wrong.

### Testing

Ran all tests, including with `--runslow`. Manually stepped through the swap month and day noise function to ensure it was handling the new date format correctly.