### PR TITLE
Hot fix: remove references to wages from noise table

### DIFF
--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -165,10 +165,10 @@ Noise types for each column
     - W-2 and 1099, SSA
     - "Borrowed" SSN, leave a field blank, write the wrong digits, make typos
     - Note that "borrowed" SSN only applies to the W-2 and 1099 dataset
-  * - Income / wages
+  * - Income 
     - W-2 and 1099
     - Leave a field blank, make typos
-    - Note that wages and income are on separate tax forms and noise is applied to each separately
+    - 
   * - Employer ID
     - W-2 and 1099
     - Leave a field blank, write the wrong digits, make typos

--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -167,7 +167,7 @@ Noise types for each column
     - Note that "borrowed" SSN only applies to the W-2 and 1099 dataset
   * - Income 
     - W-2 and 1099
-    - Leave a field blank, make typos
+    - Leave a field blank, write the wrong digits, make typos
     - 
   * - Employer ID
     - W-2 and 1099


### PR DESCRIPTION
## Title: Hot fix: remove references to wages from noise table
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: [SSCI-1417](https://jira.ihme.washington.edu/browse/SSCI-1417)

Remove any mentions of 'wages' from the noise table in pseudopeople docs
Add 'write the wrong digits' to possible noise types for income
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

