### PR TITLE
add reminder to run integration tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,4 +23,4 @@ integration test for a framework change. Consider: plots, images,
 CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
 MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
 -->
-- *Slow tests pass? (Y/N)*: <!-- `pytest --runslow`>
+- *Slow tests pass? (Y/N)*: <!-- `pytest --runslow -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,4 +23,4 @@ integration test for a framework change. Consider: plots, images,
 CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
 MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
 -->
-- *Slow tests pass? (Y/N)*: <!-- `pytest --runslow -->
+- *Slow tests pass? (Y/N)*: <!-- `pytest --runslow` -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,5 +18,9 @@ Details on how code was verified, any unit tests local for the
 repo, regression testing, etc. At a minimum, this should include an
 integration test for a framework change. Consider: plots, images,
 (small) csv file.
--->
 
+*** REMINDER ***
+CI WILL NOT RUN INTEGRATION TESTS SINCE THEY ARE CURRENTLY MARKED AS SLOW.
+MANUALLY RUN `pytest --runslow` WITH EACH PR.
+-->
+- *Integration tests pass? (Y/N)*: <!-- `pytest --runslow`>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@ integration test for a framework change. Consider: plots, images,
 (small) csv file.
 
 *** REMINDER ***
-CI WILL NOT RUN INTEGRATION TESTS SINCE THEY ARE CURRENTLY MARKED AS SLOW.
-MANUALLY RUN `pytest --runslow` WITH EACH PR.
+CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
+MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
 -->
-- *Integration tests pass? (Y/N)*: <!-- `pytest --runslow`>
+- *Slow tests pass? (Y/N)*: <!-- `pytest --runslow`>


### PR DESCRIPTION
## Reminder in PR template to run pytest --runslow
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: [MIC-4234](https://jira.ihme.washington.edu/browse/MIC-4234)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Integration tests are currently marked slow and are thus skipped by
CI. We need to remember to manually run them like `pytest --runslow`.
This just adds a reminder to the PR template to do that.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
--> na

