### PR TITLE
DOC: Add columns to decennial census and ACS

### DIFF
--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -6,10 +6,10 @@ Datasets
 
 Here we cover the realistic simulated datasets, which are analogous to "real world" administrative records such as tax documents
 and routinely generated files of social security numbers, that users can generate using Pseudopeople for developing and testing Entity
-Resolution algorithms and software. 
+Resolution algorithms and software.
 
-Each of the datasets that can be generated using Pseudopeople have "noise" added to them, thereby realistically 
-simulating how administrative records can be corrupted or distorted, which creates challenges in linking those 
+Each of the datasets that can be generated using Pseudopeople have "noise" added to them, thereby realistically
+simulating how administrative records can be corrupted or distorted, which creates challenges in linking those
 records. To read more about the different kinds of noise that can be applied to the different datasets, please see the
 :ref:`Noise page <noise_main>`.
 
@@ -30,7 +30,7 @@ US Decennial Census
 -------------------
 The Decennial Census dataset is a simulated enumeration of the US Census Bureau's Decennial Census of Population and Housing.
 To find out more about the Decennial Census, please visit the Decennial Census
-`homepage <https://www.census.gov/programs-surveys/decennial-census.html>`_.   
+`homepage <https://www.census.gov/programs-surveys/decennial-census.html>`_.
 
 It is only possible to generate Decennial Census data for decennial years -- 2020, 2030, and 2040.
 
@@ -43,60 +43,60 @@ The following columns are included in this dataset:
 
    * - Attribute Name
      - Column Name
-     - Notes    
+     - Notes
    * - Unique simulant ID
      - :code:`simulant_id`
      - Not affected by noise functions; intended use is "ground truth" for testing and validation.
    * - Unique household ID
      - :code:`household_id`
      - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
-       datasets. 
+       datasets.
    * - First name
      - :code:`first_name`
-     - 
+     -
    * - Middle initial
      - :code:`middle_initial`
-     - 
+     -
    * - Last name
      - :code:`last_name`
-     - 
+     -
    * - Age
-     - :code:`age` 
-     - Rounded down to an integer. 
+     - :code:`age`
+     - Rounded down to an integer.
    * - Date of birth
      - :code:`date_of_birth`
      - Formatted as YYYY-MM-DD.
    * - Physical address street number
      - :code:`street_number`
-     - 
+     -
    * - Physical address street name
      - :code:`street_name`
-     - 
+     -
    * - Physical address unit number
      - :code:`unit_number`
-     - 
+     -
    * - Physical address city
-     - :code:`city` 
-     -    
+     - :code:`city`
+     -
    * - Physical address state
-     - :code:`state`  
-     - 
+     - :code:`state`
+     -
    * - Physical address ZIP code
      - :code:`zipcode`
-     - 
+     -
    * - Relationship to reference person
-     - :code:`relationship_to_reference_person` 
+     - :code:`relationship_to_reference_person`
      - Possible values for this indicator include:
        Reference person; Biological child; Adopted child; Stepchild; Sibling; Parent; Grandchild; Parent-in-law; Child-in-law; Other relative;
        Roommate; Foster child; Other nonrelative; Noninstitutionalized GQ pop; and Institutionalized GQ pop.
-   * - Sex 
-     - :code:`sex`  
+   * - Sex
+     - :code:`sex`
      - Binary; "male" or "female".
    * - Race/ethnicity
-     - :code:`race_ethnicity` 
+     - :code:`race_ethnicity`
      - The exhaustive and mutually exclusive categories for the single composite "race/ethnicity" indicator are as follows:
        White; Black; Latino; American Indian and Alaskan Native (AIAN); Asian; Native Hawaiian and Other Pacific Islander (NHOPI); and
-       Multiracial or Some Other Race. 
+       Multiracial or Some Other Race.
 
 American Community Survey (ACS)
 -------------------------------
@@ -121,59 +121,59 @@ The following columns are included in this dataset:
      - Notes
    * - Unique simulant ID
      - :code:`simulant_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation. 
+     - Not affected by noise functions; intended use is "ground truth" for testing and validation.
    * - Unique household ID
      - :code:`household_id`
      - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - First name
      - :code:`first_name`
-     - 
+     -
    * - Middle initial
      - :code:`middle_initial`
-     - 
+     -
    * - Last name
      - :code:`last_name`
-     - 
+     -
    * - Age
-     - :code:`age`  
+     - :code:`age`
      - Rounded down to an integer.
    * - Date of birth
      - :code:`date_of_birth`
      - Formatted as YYYY-MM-DD.
    * - Physical address street number
      - :code:`street_number`
-     - 
+     -
    * - Physical address street name
      - :code:`street_name`
-     - 
+     -
    * - Physical address unit number
      - :code:`unit_number`
-     - 
+     -
    * - Physical address city
-     - :code:`city`    
-     - 
+     - :code:`city`
+     -
    * - Physical address state
-     - :code:`state`  
-     - 
+     - :code:`state`
+     -
    * - Physical address ZIP code
      - :code:`zipcode`
-     - 
-   * - Sex 
-     - :code:`sex`  
+     -
+   * - Sex
+     - :code:`sex`
      - Binary; "male" or "female"
    * - Race/ethnicity
-     - :code:`race_ethnicity` 
+     - :code:`race_ethnicity`
      - The exhaustive and mutually exclusive categories for the single composite "race/ethnicity" indicator are as follows:
        White; Black; Latino; American Indian and Alaskan Native (AIAN); Asian; Native Hawaiian and Other Pacific Islander (NHOPI); and
-       Multiracial or Some Other Race.  
+       Multiracial or Some Other Race.
 
 Current Population Survey (CPS)
 -------------------------------
-CPS is another household survey that can be simulated using Pseudopeople. CPS is conducted jointly by the US Census Bureau and the US 
-Bureau of Labor Statistics. CPS collects labor force data, such as annual work activity and income, veteran status, school enrollment, 
-contingent employment, worker displacement, job tenure, and more. To find out more about CPS, please visit the 
-`CPS homepage <https://www.census.gov/programs-surveys/cps.html>`_. 
+CPS is another household survey that can be simulated using Pseudopeople. CPS is conducted jointly by the US Census Bureau and the US
+Bureau of Labor Statistics. CPS collects labor force data, such as annual work activity and income, veteran status, school enrollment,
+contingent employment, worker displacement, job tenure, and more. To find out more about CPS, please visit the
+`CPS homepage <https://www.census.gov/programs-surveys/cps.html>`_.
 
 pseudopeople can generate CPS data for a user-specified year,
 which will include records from simulated surveys conducted
@@ -191,62 +191,62 @@ The following columns are included in this dataset:
      - Notes
    * - Unique simulant ID
      - :code:`simulant_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation. 
+     - Not affected by noise functions; intended use is "ground truth" for testing and validation.
    * - Unique household ID
      - :code:`household_id`
      - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - First name
      - :code:`first_name`
-     - 
+     -
    * - Middle initial
      - :code:`middle_initial`
-     - 
+     -
    * - Last name
      - :code:`last_name`
-     - 
+     -
    * - Age
-     - :code:`age`  
+     - :code:`age`
      - Rounded down to an integer.
    * - Date of birth
      - :code:`date_of_birth`
      - Formatted as YYYY-MM-DD.
    * - Physical address street number
      - :code:`street_number`
-     - 
+     -
    * - Physical address street name
      - :code:`street_name`
-     - 
+     -
    * - Physical address unit number
      - :code:`unit_number`
-     - 
+     -
    * - Physical address city
-     - :code:`city`    
-     - 
+     - :code:`city`
+     -
    * - Physical address state
-     - :code:`state`  
-     - 
+     - :code:`state`
+     -
    * - Physical address ZIP code
      - :code:`zipcode`
-     - 
-   * - Sex 
-     - :code:`sex`  
+     -
+   * - Sex
+     - :code:`sex`
      - Binary; "male" or "female"
    * - Race/ethnicity
-     - :code:`race_ethnicity` 
+     - :code:`race_ethnicity`
      - The exhaustive and mutually exclusive categories for the single composite "race/ethnicity" indicator are as follows:
        White; Black; Latino; American Indian and Alaskan Native (AIAN); Asian; Native Hawaiian and Other Pacific Islander (NHOPI); and
-       Multiracial or Some Other Race.  
+       Multiracial or Some Other Race.
 
 
 
 Women, Infants, and Children (WIC)
 ----------------------------------
 The Special Supplemental Nutrition Program for Women, Infants, and Children (WIC) is a government benefits program designed to support mothers and young
-children. The main qualifications are income and the presence of young children in the home. To find out more about this service, please visit the `WIC 
+children. The main qualifications are income and the presence of young children in the home. To find out more about this service, please visit the `WIC
 homepage <https://www.fns.usda.gov/wic>`_.
 
-pseudopeople can generate a simulated version of the administrative data that would be recorded by WIC. This is a yearly file of information about all 
+pseudopeople can generate a simulated version of the administrative data that would be recorded by WIC. This is a yearly file of information about all
 simulants enrolled in the program as of the end of that year.
 For the final year available, 2041, the file includes those enrolled as of May 1st, because this is the end of our simulated timespan.
 
@@ -262,52 +262,52 @@ The following columns are included in this dataset:
      - Notes
    * - Unique simulant ID
      - :code:`simulant_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation. 
+     - Not affected by noise functions; intended use is "ground truth" for testing and validation.
    * - Unique household ID
      - :code:`household_id`
      - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - First name
      - :code:`first_name`
-     - 
+     -
    * - Middle initial
      - :code:`middle_initial`
-     - 
+     -
    * - Last name
      - :code:`last_name`
-     - 
+     -
    * - Age
-     - :code:`age`  
+     - :code:`age`
      - Rounded down to an integer.
    * - Date of birth
      - :code:`date_of_birth`
      - Formatted as MMDDYYYY.
    * - Physical address street number
      - :code:`street_number`
-     - 
+     -
    * - Physical address street name
      - :code:`street_name`
-     - 
+     -
    * - Physical address unit number
      - :code:`unit_number`
-     - 
+     -
    * - Physical address city
-     - :code:`city`    
-     - 
+     - :code:`city`
+     -
    * - Physical address state
-     - :code:`state`  
-     - 
+     - :code:`state`
+     -
    * - Physical address ZIP code
      - :code:`zipcode`
-     - 
-   * - Sex 
-     - :code:`sex`  
+     -
+   * - Sex
+     - :code:`sex`
      - Binary; "male" or "female"
    * - Race/ethnicity
-     - :code:`race_ethnicity` 
+     - :code:`race_ethnicity`
      - The exhaustive and mutually exclusive categories for the single composite "race/ethnicity" indicator are as follows:
        White; Black; Latino; American Indian and Alaskan Native (AIAN); Asian; Native Hawaiian and Other Pacific Islander (NHOPI); and
-       Multiracial or Some Other Race.  
+       Multiracial or Some Other Race.
 
 
 Social Security Administration
@@ -336,18 +336,18 @@ The following columns are included in this dataset:
      - Notes
    * - Unique simulant ID
      - :code:`simulant_id`
-     - Not affected by noise functions; intended use is "ground truth" for PRL tracking.  
+     - Not affected by noise functions; intended use is "ground truth" for PRL tracking.
    * - First name
      - :code:`first_name`
-     - 
+     -
    * - Middle initial
      - :code:`middle_initial`
-     - 
+     -
    * - Last name
      - :code:`last_name`
-     - 
+     -
    * - Age
-     - :code:`age`  
+     - :code:`age`
      - Rounded down to an integer.
    * - Date of birth
      - :code:`date_of_birth`
@@ -358,15 +358,15 @@ The following columns are included in this dataset:
        However, it can be :ref:`configured <configuration_main>` to have noise if desired.
    * - Date of event
      - :code:`event_date`
-     - Formatted as YYYYMMDD.  
+     - Formatted as YYYYMMDD.
    * - Type of event
      - :code:`event_type`
-     - Possible values are "Creation" and "Death". 
+     - Possible values are "Creation" and "Death".
 
 
 Tax forms: W-2 & 1099
 ---------------------
-Administrative data reported in annual tax forms, such as W-2s and 1099s, can also be simulated by Pseudopeople. 1099 forms are used for independent 
+Administrative data reported in annual tax forms, such as W-2s and 1099s, can also be simulated by Pseudopeople. 1099 forms are used for independent
 contractors or self-employed individuals, while a W-2 form is used for employees (whose employer withholds payroll taxes from their earnings).
 
 pseudopeople can generate a simulated version of the data collected by W-2 and 1099 forms.
@@ -390,65 +390,65 @@ The following columns are included in these datasets:
    * - Unique household ID
      - :code:`household_id`
      - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
-       datasets. 
+       datasets.
    * - First name
      - :code:`first_name`
-     - 
+     -
    * - Middle initial
      - :code:`middle_initial`
-     - 
+     -
    * - Last name
      - :code:`last_name`
-     - 
+     -
    * - Mailing address street number
      - :code:`mailing_address_street_number`
-     - 
+     -
    * - Mailing address street name
      - :code:`mailing_address_street_name`
-     - 
+     -
    * - Mailing address unit number
      - :code:`mailing_address_unit_number`
-     - 
+     -
    * - Mailing address city
-     - :code:`mailing_address_city`    
-     - 
+     - :code:`mailing_address_city`
+     -
    * - Mailing address state
-     - :code:`mailing_address_state`  
-     - 
+     - :code:`mailing_address_state`
+     -
    * - Mailing address ZIP code
      - :code:`mailing_address_zipcode`
-     - 
-   * - Social security number 
+     -
+   * - Social security number
      - :code:`ssn`
-     - 
-   * - Income 
+     -
+   * - Income
      - :code:`income`
-     - 
-   * - Employer ID 
+     -
+   * - Employer ID
      - :code:`employer_id`
-     -  
-   * - Employer Name 
+     -
+   * - Employer Name
      - :code:`employer_name`
-     - 
+     -
    * - Employer street number
      - :code:`employer_street_number`
-     - 
+     -
    * - Employer street name
      - :code:`employer_street_name`
-     - 
+     -
    * - Employer unit number
      - :code:`employer_unit_number`
-     - 
+     -
    * - Employer city
-     - :code:`employer_city`    
-     - 
+     - :code:`employer_city`
+     -
    * - Employer state
-     - :code:`employer_state`  
-     - 
+     - :code:`employer_state`
+     -
    * - Employer ZIP code
      - :code:`employer_zipcode`
-     - 
-   * - Type of tax form 
+     -
+   * - Type of tax form
      - :code:`tax_form`
      - Possible values are "W2" or "1099".
 
@@ -476,85 +476,85 @@ The following columns are included in this dataset:
    * - Unique household ID
      - :code:`household_id`
      - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
-       datasets. 
+       datasets.
    * - First name
      - :code:`first_name`
-     - 
+     -
    * - Middle initial
      - :code:`middle_initial`
-     - 
+     -
    * - Last name
      - :code:`last_name`
-     - 
+     -
    * - Mailing address street number
      - :code:`mailing_address_street_number`
-     - 
+     -
    * - Mailing address street name
      - :code:`mailing_address_street_name`
-     - 
+     -
    * - Mailing address unit number
      - :code:`mailing_address_unit_number`
-     - 
+     -
    * - Mailing address PO box
      - :code:`mailing_address_po_box`
-     - 
+     -
    * - Mailing address city
-     - :code:`mailing_address_city`    
-     - 
+     - :code:`mailing_address_city`
+     -
    * - Mailing address state
-     - :code:`mailing_address_state`  
-     - 
+     - :code:`mailing_address_state`
+     -
    * - Mailing address ZIP code
      - :code:`mailing_address_zipcode`
-     - 
+     -
    * - Social Security Number (SSN)
      - :code:`ssn`
      - Individual Taxpayer Identification Number (ITIN) if no SSN
    * - Joint filer first name
      - :code:`spouse_first_name`
-     - 
+     -
    * - Joint filer middle initial
      - :code:`spouse_middle_initial`
-     - 
+     -
    * - Joint filer last name
      - :code:`spouse_last_name`
-     - 
+     -
    * - Joint filer social security number
      - :code:`spouse_ssn`
      - Individual Taxpayer Identification Number (ITIN) if no SSN
    * - Dependent 1 first name
      - :code:`dependent_1_first_name`
-     - 
+     -
    * - Dependent 1 last name
      - :code:`dependent_1_last_name`
-     - 
+     -
    * - Dependent 1 Social Security Number (SSN)
      - :code:`dependent_1_ssn`
-     - Individual Taxpayer Identification Number (ITIN) if no SSN 
+     - Individual Taxpayer Identification Number (ITIN) if no SSN
    * - Dependent 2 first name
      - :code:`dependent_2_first_name`
-     - 
+     -
    * - Dependent 2 last name
      - :code:`dependent_2_last_name`
-     - 
+     -
    * - Dependent 2 social security number
      - :code:`dependent_2_ssn`
-     - Individual Taxpayer Identification Number (ITIN) if no SSN 
+     - Individual Taxpayer Identification Number (ITIN) if no SSN
    * - Dependent 3 first name
      - :code:`dependent_3_first_name`
-     - 
+     -
    * - Dependent 3 last name
      - :code:`dependent_3_last_name`
-     - 
+     -
    * - Dependent 3 social security number
      - :code:`dependent_3_ssn`
-     - Individual Taxpayer Identification Number (ITIN) if no SSN 
+     - Individual Taxpayer Identification Number (ITIN) if no SSN
    * - Dependent 4 first name
      - :code:`dependent_4_first_name`
-     - 
+     -
    * - Dependent 4 last name
      - :code:`dependent_4_last_name`
-     - 
+     -
    * - Dependent 4 social security number
      - :code:`dependent_4_ssn`
-     - Individual Taxpayer Identification Number (ITIN) if no SSN 
+     - Individual Taxpayer Identification Number (ITIN) if no SSN

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -93,7 +93,7 @@ The following columns are included in this dataset:
        "College", "Military", and "Other noninstitutional".
    * - Relationship to reference person
      - :code:`relationship_to_reference_person`
-     - Possible values for this indicator include:
+     - Possible values for this field include:
        "Reference person"; "Opposite-sex spouse"; "Opposite-sex unmarried
        partner"; "Same-sex spouse"; "Same-sex unmarried partner"; "Biological
        child"; "Adopted child"; "Stepchild"; "Sibling"; "Parent"; "Grandchild";
@@ -179,7 +179,7 @@ The following columns are included in this dataset:
        "College", "Military", and "Other noninstitutional".
    * - Relationship to reference person
      - :code:`relationship_to_reference_person`
-     - Possible values for this indicator include:
+     - Possible values for this field include:
        "Reference person"; "Opposite-sex spouse"; "Opposite-sex unmarried
        partner"; "Same-sex spouse"; "Same-sex unmarried partner"; "Biological
        child"; "Adopted child"; "Stepchild"; "Sibling"; "Parent"; "Grandchild";

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -170,7 +170,7 @@ The following columns are included in this dataset:
      - :code:`housing_type`
      - Possible values for housing type are "Household" for an individual
        household, or one of six different types of group quarters. The types of
-       instiutional group quarters are "Carceral", "Nursing home", and "Other
+       institutional group quarters are "Carceral", "Nursing home", and "Other
        institutional". The types of noninstitutional group quarters are
        "College", "Military", and "Other noninstitutional".
    * - Relationship to reference person

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -88,7 +88,7 @@ The following columns are included in this dataset:
      - :code:`housing_type`
      - Possible values for housing type are "Household" for an individual
        household, or one of six different types of group quarters. The types of
-       instiutional group quarters are "Carceral", "Nursing home", and "Other
+       institutional group quarters are "Carceral", "Nursing home", and "Other
        institutional". The types of noninstitutional group quarters are
        "College", "Military", and "Other noninstitutional".
    * - Relationship to reference person

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -94,8 +94,12 @@ The following columns are included in this dataset:
    * - Relationship to reference person
      - :code:`relationship_to_reference_person`
      - Possible values for this indicator include:
-       Reference person; Biological child; Adopted child; Stepchild; Sibling; Parent; Grandchild; Parent-in-law; Child-in-law; Other relative;
-       Roommate; Foster child; Other nonrelative; Noninstitutionalized GQ pop; and Institutionalized GQ pop.
+       "Reference person"; "Opposite-sex spouse"; "Opposite-sex unmarried
+       partner"; "Same-sex spouse"; "Same-sex unmarried partner"; "Biological
+       child"; "Adopted child"; "Stepchild"; "Sibling"; "Parent"; "Grandchild";
+       "Parent-in-law"; "Child-in-law"; "Other relative"; "Roommate"; "Foster
+       child"; "Other nonrelative"; "Institutionalized group quarters
+       population"; and "Noninstitutionalized group quarters population".
    * - Sex
      - :code:`sex`
      - Binary; "male" or "female".

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -84,6 +84,13 @@ The following columns are included in this dataset:
    * - Physical address ZIP code
      - :code:`zipcode`
      -
+   * - Housing type
+     - :code:`housing_type`
+     - Possible values for housing type are "Household" for an individual
+       household, or one of six different types of group quarters. The types of
+       instiutional group quarters are "Carceral", "Nursing home", and "Other
+       institutional". The types of non-institutional group quarters are
+       "College", "Military", and "Other non-institutional".
    * - Relationship to reference person
      - :code:`relationship_to_reference_person`
      - Possible values for this indicator include:

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -97,9 +97,10 @@ The following columns are included in this dataset:
        "Reference person"; "Opposite-sex spouse"; "Opposite-sex unmarried
        partner"; "Same-sex spouse"; "Same-sex unmarried partner"; "Biological
        child"; "Adopted child"; "Stepchild"; "Sibling"; "Parent"; "Grandchild";
-       "Parent-in-law"; "Child-in-law"; "Other relative"; "Roommate"; "Foster
-       child"; "Other nonrelative"; "Institutionalized group quarters
-       population"; and "Noninstitutionalized group quarters population".
+       "Parent-in-law"; "Child-in-law"; "Other relative"; "Roommate or
+       housemate"; "Foster child"; "Other nonrelative"; "Institutionalized group
+       quarters population"; and "Noninstitutionalized group quarters
+       population".
    * - Sex
      - :code:`sex`
      - Binary; "male" or "female".
@@ -183,9 +184,10 @@ The following columns are included in this dataset:
        "Reference person"; "Opposite-sex spouse"; "Opposite-sex unmarried
        partner"; "Same-sex spouse"; "Same-sex unmarried partner"; "Biological
        child"; "Adopted child"; "Stepchild"; "Sibling"; "Parent"; "Grandchild";
-       "Parent-in-law"; "Child-in-law"; "Other relative"; "Roommate"; "Foster
-       child"; "Other nonrelative"; "Institutionalized group quarters
-       population"; and "Noninstitutionalized group quarters population".
+       "Parent-in-law"; "Child-in-law"; "Other relative"; "Roommate or
+       housemate"; "Foster child"; "Other nonrelative"; "Institutionalized group
+       quarters population"; and "Noninstitutionalized group quarters
+       population".
    * - Sex
      - :code:`sex`
      - Binary; "male" or "female"

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -89,8 +89,8 @@ The following columns are included in this dataset:
      - Possible values for housing type are "Household" for an individual
        household, or one of six different types of group quarters. The types of
        instiutional group quarters are "Carceral", "Nursing home", and "Other
-       institutional". The types of non-institutional group quarters are
-       "College", "Military", and "Other non-institutional".
+       institutional". The types of noninstitutional group quarters are
+       "College", "Military", and "Other noninstitutional".
    * - Relationship to reference person
      - :code:`relationship_to_reference_person`
      - Possible values for this indicator include:
@@ -171,8 +171,8 @@ The following columns are included in this dataset:
      - Possible values for housing type are "Household" for an individual
        household, or one of six different types of group quarters. The types of
        instiutional group quarters are "Carceral", "Nursing home", and "Other
-       institutional". The types of non-institutional group quarters are
-       "College", "Military", and "Other non-institutional".
+       institutional". The types of noninstitutional group quarters are
+       "College", "Military", and "Other noninstitutional".
    * - Relationship to reference person
      - :code:`relationship_to_reference_person`
      - Possible values for this indicator include:

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -166,6 +166,22 @@ The following columns are included in this dataset:
    * - Physical address ZIP code
      - :code:`zipcode`
      -
+   * - Housing type
+     - :code:`housing_type`
+     - Possible values for housing type are "Household" for an individual
+       household, or one of six different types of group quarters. The types of
+       instiutional group quarters are "Carceral", "Nursing home", and "Other
+       institutional". The types of non-institutional group quarters are
+       "College", "Military", and "Other non-institutional".
+   * - Relationship to reference person
+     - :code:`relationship_to_reference_person`
+     - Possible values for this indicator include:
+       "Reference person"; "Opposite-sex spouse"; "Opposite-sex unmarried
+       partner"; "Same-sex spouse"; "Same-sex unmarried partner"; "Biological
+       child"; "Adopted child"; "Stepchild"; "Sibling"; "Parent"; "Grandchild";
+       "Parent-in-law"; "Child-in-law"; "Other relative"; "Roommate"; "Foster
+       child"; "Other nonrelative"; "Institutionalized group quarters
+       population"; and "Noninstitutionalized group quarters population".
    * - Sex
      - :code:`sex`
      - Binary; "male" or "female"

--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -161,8 +161,12 @@ Noise types for each column
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099
     - Leave a field blank, write the wrong zipcode digits, make typos, make OCR errors
     -
+  * - Housing type
+    - Decennial Census, ACS
+    - Leave a field blank, choose the wrong option
+    -
   * - Relationship to reference person
-    - Decennial Census
+    - Decennial Census, ACS
     - Leave a field blank, choose the wrong option
     -
   * - Sex

--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -9,7 +9,7 @@ to add noise to the simulated data. "Noise" refers to various types of errors
 introduced into the data and may also be called "corruption" or "distortion." By
 default, pseudopeople applies noise to the simulated datasets using some
 reasonable settings. If desired, the user can change the noise settings through
-the configuration system---see the :ref:`Configuration section <configuration_main>` 
+the configuration system---see the :ref:`Configuration section <configuration_main>`
 for details.
 
 .. contents::
@@ -46,18 +46,18 @@ Noise types are applied in the order they are listed here.
 The "Config key" column shows the name of the noise type in the :ref:`configuration system <configuration_main>`.
 
 .. list-table:: Types of row-based noise (``row_noise``)
-  :widths: 1 2 5 
+  :widths: 1 2 5
   :header-rows: 1
 
   * - Noise type
-    - Config key 
+    - Config key
     - Example cause
   * - Omit a row
     - ``omit_row``
     - Neglecting to file a tax form on time
 
 .. list-table:: Types of column-based noise (``column_noise``)
-  :widths: 1 2 5 
+  :widths: 1 2 5
   :header-rows: 1
 
   * - Noise type
@@ -84,7 +84,7 @@ The "Config key" column shows the name of the noise type in the :ref:`configurat
   * - Write the wrong digits
     - ``write_wrong_digits``
     - Writing "732 Main St" as your street address instead of "932 Main St"
-  * - Write the wrong ZIP code digits 
+  * - Write the wrong ZIP code digits
     - ``write_wrong_zipcode_digits``
     - Writing ZIP code 98118 when you actually live in 98112
   * - Swap month and day
@@ -92,7 +92,7 @@ The "Config key" column shows the name of the noise type in the :ref:`configurat
     - Reporting 17/05/1976 when a survey asks for the date in MM/DD/YYYY format
   * - Make typos
     - ``make_typos``
-    - Accidentally typing an "l" instead of a "k" because they are 
+    - Accidentally typing an "l" instead of a "k" because they are
       right next to each other on a QWERTY keyboard
   * - Make Optical Character Recognition (OCR) errors
     - ``make_ocr_errors``
@@ -155,7 +155,7 @@ Noise types for each column
     - Noise for all types of addresses works in the same way
   * - State for any address (physical, mailing, or employer)
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099
-    - Leave a field blank, choose the wrong option 
+    - Leave a field blank, choose the wrong option
     - Noise for all types of addresses works in the same way
   * - ZIP code for any address (physical, mailing, or employer)
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099
@@ -184,7 +184,7 @@ Noise types for each column
   * - Employer ID
     - W-2 and 1099
     - Leave a field blank, write the wrong digits, make typos, make OCR errors
-    - 
+    -
   * - Employer name
     - W-2 and 1099
     - Leave a field blank, make typos, make OCR errors


### PR DESCRIPTION
## DOC: Add columns to decennial census and ACS
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation 
- *JIRA issue*: [SSCI-1406](https://jira.ihme.washington.edu/browse/SSCI-1406), [SSCI-1414](https://jira.ihme.washington.edu/browse/SSCI-1414)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

- Document adding "housing type" column to decennial census and ACS datasets
- Document adding "relationship to reference person" column to ACS dataset
- Edit noise table to include the new columns
- Specify desired category names for "housing type" and "relationship to reference person"

This is intended to be the official documentation for the engineers to implement these changes, as well as being the user-facing documentation.

The diff includes a bunch of whitespace deletions from my editor, so you may want to hide those.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Built docs locally

