### PR TITLE
Fix bug if string is source in fetch_dataset_filepaths

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -469,7 +469,9 @@ def validate_data_path_suffix(data_paths) -> None:
     return None
 
 
-def get_dataset_filepaths(source: Path, dataset_name: str) -> List[Path]:
+def get_dataset_filepaths(source: Union[Path, str], dataset_name: str) -> List[Path]:
+    if type(source) == str:
+        source = Path(source)
     directory = source / dataset_name
     dataset_paths = [x for x in directory.glob(f"{dataset_name}*")]
     sorted_dataset_paths = sorted(dataset_paths)


### PR DESCRIPTION
## Bugfix/mic-4364

### Fixes bug in fetch_dataset_filepaths
- *Category*: Bugfix
- *JIRA issue*: [MIC-4364](https://jira.ihme.washington.edu/browse/MIC-4364)

-handles conversion of strings to path objects

### Testing
I am able to run generate_XXX providing a string for the source argument.

