### PR TITLE
rename "user_config" arg to "overrides"

### DIFF
--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -80,9 +80,7 @@ DEFAULT_NOISE_VALUES = {
 }
 
 
-def get_configuration(
-    overrides: Optional[Union[Path, str, Dict]] = None
-) -> ConfigTree:
+def get_configuration(overrides: Optional[Union[Path, str, Dict]] = None) -> ConfigTree:
     """
     Gets a noising configuration ConfigTree, optionally overridden by a user-provided YAML.
 
@@ -170,9 +168,7 @@ def _generate_configuration(is_no_noise: bool) -> ConfigTree:
     return noising_configuration
 
 
-def add_overrides(
-    noising_configuration: ConfigTree, overrides: Dict
-) -> None:
+def add_overrides(noising_configuration: ConfigTree, overrides: Dict) -> None:
     validate_overrides(overrides, noising_configuration)
     overrides = _format_overrides(noising_configuration, overrides)
     noising_configuration.update(overrides, layer="user")

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -5,7 +5,7 @@ import yaml
 from vivarium.config_tree import ConfigTree
 
 from pseudopeople.configuration import NO_NOISE, Keys
-from pseudopeople.configuration.validator import validate_user_configuration
+from pseudopeople.configuration.validator import validate_overrides
 from pseudopeople.constants.data_values import DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY
 from pseudopeople.exceptions import ConfigurationError
 from pseudopeople.noise_entities import NOISE_TYPES
@@ -81,27 +81,27 @@ DEFAULT_NOISE_VALUES = {
 
 
 def get_configuration(
-    user_configuration: Optional[Union[Path, str, Dict]] = None
+    overrides: Optional[Union[Path, str, Dict]] = None
 ) -> ConfigTree:
     """
     Gets a noising configuration ConfigTree, optionally overridden by a user-provided YAML.
 
-    :param user_configuration: A path to the YAML file or a dictionary defining user overrides for the defaults
+    :param overrides: A path to the YAML file or a dictionary defining user overrides for the defaults
     :return: a ConfigTree object of the noising configuration
     """
 
-    if user_configuration == NO_NOISE:
+    if overrides == NO_NOISE:
         is_no_noise = True
-        user_configuration = None
-    elif isinstance(user_configuration, (Path, str)):
-        with open(user_configuration, "r") as f:
-            user_configuration = yaml.full_load(f)
+        overrides = None
+    elif isinstance(overrides, (Path, str)):
+        with open(overrides, "r") as f:
+            overrides = yaml.full_load(f)
         is_no_noise = False
     else:
         is_no_noise = False
     noising_configuration = _generate_configuration(is_no_noise)
-    if user_configuration is not None:
-        add_user_configuration(noising_configuration, user_configuration)
+    if overrides is not None:
+        add_overrides(noising_configuration, overrides)
 
     return noising_configuration
 
@@ -170,15 +170,15 @@ def _generate_configuration(is_no_noise: bool) -> ConfigTree:
     return noising_configuration
 
 
-def add_user_configuration(
-    noising_configuration: ConfigTree, user_configuration: Dict
+def add_overrides(
+    noising_configuration: ConfigTree, overrides: Dict
 ) -> None:
-    validate_user_configuration(user_configuration, noising_configuration)
-    user_configuration = _format_user_configuration(noising_configuration, user_configuration)
-    noising_configuration.update(user_configuration, layer="user")
+    validate_overrides(overrides, noising_configuration)
+    overrides = _format_overrides(noising_configuration, overrides)
+    noising_configuration.update(overrides, layer="user")
 
 
-def _format_user_configuration(default_config: ConfigTree, user_dict: Dict) -> Dict:
+def _format_overrides(default_config: ConfigTree, user_dict: Dict) -> Dict:
     """Formats the user's configuration file as necessary, so it can properly
     update noising configuration to be used
     """

--- a/src/pseudopeople/configuration/interface.py
+++ b/src/pseudopeople/configuration/interface.py
@@ -10,7 +10,7 @@ from pseudopeople.exceptions import ConfigurationError
 from pseudopeople.schema_entities import DATASETS
 
 
-def get_config(dataset_name: str = None, user_config: Union[Path, str, Dict] = None) -> Dict:
+def get_config(dataset_name: str = None, overrides: Union[Path, str, Dict] = None) -> Dict:
     """
     Function that returns the pseudopeople configuration,
     including all default values.
@@ -32,8 +32,8 @@ def get_config(dataset_name: str = None, user_config: Union[Path, str, Dict] = N
 
     .. code-block:: pycon
 
-        >>> user_config = {'decennial_census': {'row_noise': {'omit_row': {'row_probability': 0.1}}}}
-        >>> psp.get_config('decennial_census', user_config)['row_noise']['omit_row']
+        >>> overrides = {'decennial_census': {'row_noise': {'omit_row': {'row_probability': 0.1}}}}
+        >>> psp.get_config('decennial_census', overrides)['row_noise']['omit_row']
         {'row_probability': 0.1}
 
     :param dataset_name: An optional name of dataset to return the configuration
@@ -48,22 +48,22 @@ def get_config(dataset_name: str = None, user_config: Union[Path, str, Dict] = N
             - "taxes_1040"
             - "taxes_w2_and_1099"
             - "women_infants_and_children"
-    :param user_config: An optional override to the default configuration. Can be
+    :param overrides: An optional override to the default configuration. Can be
         a path to a configuration YAML file or a dictionary. Passing a sentinel value
         of psp.NO_NOISE will override default values and return a configuration
         where all noise levels are set to 0.
     :return: Dictionary of the config.
-    :raises ConfigurationError: An invalid configuration is passed with user_config.
+    :raises ConfigurationError: An invalid configuration is passed with overrides.
 
     """
-    if isinstance(user_config, (Path, str)) and user_config != NO_NOISE:
-        with open(user_config, "r") as f:
-            user_config = yaml.full_load(f)
-    if isinstance(user_config, dict) and dataset_name not in user_config.keys():
+    if isinstance(overrides, (Path, str)) and overrides != NO_NOISE:
+        with open(overrides, "r") as f:
+            overrides = yaml.full_load(f)
+    if isinstance(overrides, dict) and dataset_name not in overrides.keys():
         logger.warning(
             f"'{dataset_name}' provided but is not in the user provided configuration."
         )
-    config = get_configuration(user_config)
+    config = get_configuration(overrides)
     if dataset_name:
         if dataset_name in [dataset.name for dataset in DATASETS]:
             config = config[dataset_name]

--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -10,15 +10,15 @@ from pseudopeople.exceptions import ConfigurationError
 from pseudopeople.noise_entities import NOISE_TYPES
 
 
-def validate_user_configuration(user_config: Dict, default_config: ConfigTree) -> None:
+def validate_overrides(overrides: Dict, default_config: ConfigTree) -> None:
     """
-    Validates the user-provided configuration. Confirms that all user-provided
+    Validates the user-provided overrides. Confirms that all user-provided
     keys exist in the default configuration. Confirms that all user-provided
     values are valid for their respective noise functions.
     """
-    if not isinstance(user_config, Dict):
+    if not isinstance(overrides, Dict):
         raise ConfigurationError("Invalid configuration type provided.") from None
-    for dataset, dataset_config in user_config.items():
+    for dataset, dataset_config in overrides.items():
         default_dataset_config = _get_default_config_node(default_config, dataset, "dataset")
         for key in dataset_config:
             _get_default_config_node(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -119,7 +119,7 @@ def split_sample_data_dir_state_edit(tmpdir_factory, split_sample_data_dir):
 
 
 @pytest.fixture(scope="module")
-def user_config():
+def overrides():
     """Returns a custom configuration dict to be used in noising"""
     config = get_configuration().to_dict()  # default config
 
@@ -175,38 +175,38 @@ def formatted_1040_sample_data_state_edit(split_sample_data_dir_state_edit):
 
 # Noised sample datasets
 @pytest.fixture(scope="module")
-def noised_sample_data_decennial_census(user_config):
-    return generate_decennial_census(seed=SEED, year=None, config=user_config)
+def noised_sample_data_decennial_census(overrides):
+    return generate_decennial_census(seed=SEED, year=None, config=overrides)
 
 
 @pytest.fixture(scope="module")
-def noised_sample_data_american_community_survey(user_config):
-    return generate_american_community_survey(seed=SEED, year=None, config=user_config)
+def noised_sample_data_american_community_survey(overrides):
+    return generate_american_community_survey(seed=SEED, year=None, config=overrides)
 
 
 @pytest.fixture(scope="module")
-def noised_sample_data_current_population_survey(user_config):
-    return generate_current_population_survey(seed=SEED, year=None, config=user_config)
+def noised_sample_data_current_population_survey(overrides):
+    return generate_current_population_survey(seed=SEED, year=None, config=overrides)
 
 
 @pytest.fixture(scope="module")
-def noised_sample_data_women_infants_and_children(user_config):
-    return generate_women_infants_and_children(seed=SEED, year=None, config=user_config)
+def noised_sample_data_women_infants_and_children(overrides):
+    return generate_women_infants_and_children(seed=SEED, year=None, config=overrides)
 
 
 @pytest.fixture(scope="module")
-def noised_sample_data_social_security(user_config):
-    return generate_social_security(seed=SEED, year=None, config=user_config)
+def noised_sample_data_social_security(overrides):
+    return generate_social_security(seed=SEED, year=None, config=overrides)
 
 
 @pytest.fixture(scope="module")
-def noised_sample_data_taxes_w2_and_1099(user_config):
-    return generate_taxes_w2_and_1099(seed=SEED, year=None, config=user_config)
+def noised_sample_data_taxes_w2_and_1099(overrides):
+    return generate_taxes_w2_and_1099(seed=SEED, year=None, config=overrides)
 
 
 @pytest.fixture(scope="module")
-def noised_sample_data_taxes_1040(user_config):
-    return generate_taxes_1040(seed=SEED, year=None, config=user_config)
+def noised_sample_data_taxes_1040(overrides):
+    return generate_taxes_1040(seed=SEED, year=None, config=overrides)
 
 
 # Raw sample datasets with half from a specific state, for state filtering

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -119,7 +119,7 @@ def split_sample_data_dir_state_edit(tmpdir_factory, split_sample_data_dir):
 
 
 @pytest.fixture(scope="module")
-def overrides():
+def config():
     """Returns a custom configuration dict to be used in noising"""
     config = get_configuration().to_dict()  # default config
 
@@ -175,38 +175,38 @@ def formatted_1040_sample_data_state_edit(split_sample_data_dir_state_edit):
 
 # Noised sample datasets
 @pytest.fixture(scope="module")
-def noised_sample_data_decennial_census(overrides):
-    return generate_decennial_census(seed=SEED, year=None, config=overrides)
+def noised_sample_data_decennial_census(config):
+    return generate_decennial_census(seed=SEED, year=None, config=config)
 
 
 @pytest.fixture(scope="module")
-def noised_sample_data_american_community_survey(overrides):
-    return generate_american_community_survey(seed=SEED, year=None, config=overrides)
+def noised_sample_data_american_community_survey(config):
+    return generate_american_community_survey(seed=SEED, year=None, config=config)
 
 
 @pytest.fixture(scope="module")
-def noised_sample_data_current_population_survey(overrides):
-    return generate_current_population_survey(seed=SEED, year=None, config=overrides)
+def noised_sample_data_current_population_survey(config):
+    return generate_current_population_survey(seed=SEED, year=None, config=config)
 
 
 @pytest.fixture(scope="module")
-def noised_sample_data_women_infants_and_children(overrides):
-    return generate_women_infants_and_children(seed=SEED, year=None, config=overrides)
+def noised_sample_data_women_infants_and_children(config):
+    return generate_women_infants_and_children(seed=SEED, year=None, config=config)
 
 
 @pytest.fixture(scope="module")
-def noised_sample_data_social_security(overrides):
-    return generate_social_security(seed=SEED, year=None, config=overrides)
+def noised_sample_data_social_security(config):
+    return generate_social_security(seed=SEED, year=None, config=config)
 
 
 @pytest.fixture(scope="module")
-def noised_sample_data_taxes_w2_and_1099(overrides):
-    return generate_taxes_w2_and_1099(seed=SEED, year=None, config=overrides)
+def noised_sample_data_taxes_w2_and_1099(config):
+    return generate_taxes_w2_and_1099(seed=SEED, year=None, config=config)
 
 
 @pytest.fixture(scope="module")
-def noised_sample_data_taxes_1040(overrides):
-    return generate_taxes_1040(seed=SEED, year=None, config=overrides)
+def noised_sample_data_taxes_1040(config):
+    return generate_taxes_1040(seed=SEED, year=None, config=config)
 
 
 # Raw sample datasets with half from a specific state, for state filtering

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -51,7 +51,7 @@ DATASET_GENERATION_FUNCS = {
     ],
 )
 def test_generate_dataset_from_sample_and_source(
-    dataset_name: str, user_config, request, split_sample_data_dir
+    dataset_name: str, overrides, request, split_sample_data_dir
 ):
     """Tests that the amount of noising is approximately the same whether we
     noise a single sample dataset or we concatenate and noise multiple datasets
@@ -66,7 +66,7 @@ def test_generate_dataset_from_sample_and_source(
         seed=SEED,
         year=None,
         source=split_sample_data_dir,
-        config=user_config,
+        config=overrides,
     )
 
     # Check same order of magnitude of rows was removed
@@ -128,7 +128,7 @@ def test_generate_dataset_from_sample_and_source(
         DATASETS.tax_1040.name,
     ],
 )
-def test_seed_behavior(dataset_name: str, user_config, request):
+def test_seed_behavior(dataset_name: str, overrides, request):
     """Tests seed behavior"""
     if "TODO" in dataset_name:
         pytest.skip(reason=dataset_name)
@@ -137,9 +137,9 @@ def test_seed_behavior(dataset_name: str, user_config, request):
     noised_data = request.getfixturevalue(f"noised_sample_data_{dataset_name}")
     # Generate new (non-fixture) noised datasets with the same seed and a different
     # seed as the fixture
-    noised_data_same_seed = generation_function(seed=SEED, year=None, config=user_config)
+    noised_data_same_seed = generation_function(seed=SEED, year=None, config=overrides)
     noised_data_different_seed = generation_function(
-        seed=SEED + 1, year=None, config=user_config
+        seed=SEED + 1, year=None, config=overrides
     )
     assert not data.equals(noised_data)
     assert noised_data.equals(noised_data_same_seed)
@@ -186,7 +186,7 @@ def test_column_dtypes(dataset_name: str, request):
         DATASETS.tax_1040.name,
     ],
 )
-def test_column_noising(dataset_name: str, user_config, request):
+def test_column_noising(dataset_name: str, overrides, request):
     """Tests that columns are noised as expected"""
     if "TODO" in dataset_name:
         pytest.skip(reason=dataset_name)
@@ -195,7 +195,7 @@ def test_column_noising(dataset_name: str, user_config, request):
     check_noised, check_original, shared_idx = _get_common_datasets(
         dataset_name, data, noised_data
     )
-    config = get_configuration(user_config)
+    config = get_configuration(overrides)
     for col_name in check_noised.columns:
         col = COLUMNS.get_column(col_name)
 
@@ -246,7 +246,7 @@ def test_column_noising(dataset_name: str, user_config, request):
         DATASETS.tax_1040.name,
     ],
 )
-def test_row_noising_omit_row_or_do_not_respond(dataset_name: str, user_config, request):
+def test_row_noising_omit_row_or_do_not_respond(dataset_name: str, overrides, request):
     """Tests that omit_row and do_not_respond row noising are being applied"""
     if "TODO" in dataset_name:
         pytest.skip(reason=dataset_name)
@@ -256,7 +256,7 @@ def test_row_noising_omit_row_or_do_not_respond(dataset_name: str, user_config, 
     noised_data = request.getfixturevalue(f"noised_sample_data_{dataset_name}").set_index(
         idx_cols
     )
-    config = get_configuration(user_config)[dataset_name][Keys.ROW_NOISE]
+    config = get_configuration(overrides)[dataset_name][Keys.ROW_NOISE]
     noise_type = [
         n for n in config if n in [NOISE_TYPES.omit_row.name, NOISE_TYPES.do_not_respond.name]
     ]
@@ -282,7 +282,7 @@ def test_row_noising_omit_row_or_do_not_respond(dataset_name: str, user_config, 
         DATASETS.tax_1040.name,
     ],
 )
-def test_row_noising_duplication(dataset_name: str, user_config, request):
+def test_row_noising_duplication(dataset_name: str, overrides, request):
     """Tests that duplication row noising is being applied"""
     ...
 

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -138,9 +138,7 @@ def test_seed_behavior(dataset_name: str, config, request):
     # Generate new (non-fixture) noised datasets with the same seed and a different
     # seed as the fixture
     noised_data_same_seed = generation_function(seed=SEED, year=None, config=config)
-    noised_data_different_seed = generation_function(
-        seed=SEED + 1, year=None, config=config
-    )
+    noised_data_different_seed = generation_function(seed=SEED + 1, year=None, config=config)
     assert not data.equals(noised_data)
     assert noised_data.equals(noised_data_same_seed)
     assert not noised_data.equals(noised_data_different_seed)

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -51,7 +51,7 @@ DATASET_GENERATION_FUNCS = {
     ],
 )
 def test_generate_dataset_from_sample_and_source(
-    dataset_name: str, overrides, request, split_sample_data_dir
+    dataset_name: str, config, request, split_sample_data_dir
 ):
     """Tests that the amount of noising is approximately the same whether we
     noise a single sample dataset or we concatenate and noise multiple datasets
@@ -66,7 +66,7 @@ def test_generate_dataset_from_sample_and_source(
         seed=SEED,
         year=None,
         source=split_sample_data_dir,
-        config=overrides,
+        config=config,
     )
 
     # Check same order of magnitude of rows was removed
@@ -128,7 +128,7 @@ def test_generate_dataset_from_sample_and_source(
         DATASETS.tax_1040.name,
     ],
 )
-def test_seed_behavior(dataset_name: str, overrides, request):
+def test_seed_behavior(dataset_name: str, config, request):
     """Tests seed behavior"""
     if "TODO" in dataset_name:
         pytest.skip(reason=dataset_name)
@@ -137,9 +137,9 @@ def test_seed_behavior(dataset_name: str, overrides, request):
     noised_data = request.getfixturevalue(f"noised_sample_data_{dataset_name}")
     # Generate new (non-fixture) noised datasets with the same seed and a different
     # seed as the fixture
-    noised_data_same_seed = generation_function(seed=SEED, year=None, config=overrides)
+    noised_data_same_seed = generation_function(seed=SEED, year=None, config=config)
     noised_data_different_seed = generation_function(
-        seed=SEED + 1, year=None, config=overrides
+        seed=SEED + 1, year=None, config=config
     )
     assert not data.equals(noised_data)
     assert noised_data.equals(noised_data_same_seed)
@@ -186,7 +186,7 @@ def test_column_dtypes(dataset_name: str, request):
         DATASETS.tax_1040.name,
     ],
 )
-def test_column_noising(dataset_name: str, overrides, request):
+def test_column_noising(dataset_name: str, config, request):
     """Tests that columns are noised as expected"""
     if "TODO" in dataset_name:
         pytest.skip(reason=dataset_name)
@@ -195,7 +195,7 @@ def test_column_noising(dataset_name: str, overrides, request):
     check_noised, check_original, shared_idx = _get_common_datasets(
         dataset_name, data, noised_data
     )
-    config = get_configuration(overrides)
+    config = get_configuration(config)
     for col_name in check_noised.columns:
         col = COLUMNS.get_column(col_name)
 
@@ -246,7 +246,7 @@ def test_column_noising(dataset_name: str, overrides, request):
         DATASETS.tax_1040.name,
     ],
 )
-def test_row_noising_omit_row_or_do_not_respond(dataset_name: str, overrides, request):
+def test_row_noising_omit_row_or_do_not_respond(dataset_name: str, config, request):
     """Tests that omit_row and do_not_respond row noising are being applied"""
     if "TODO" in dataset_name:
         pytest.skip(reason=dataset_name)
@@ -256,7 +256,7 @@ def test_row_noising_omit_row_or_do_not_respond(dataset_name: str, overrides, re
     noised_data = request.getfixturevalue(f"noised_sample_data_{dataset_name}").set_index(
         idx_cols
     )
-    config = get_configuration(overrides)[dataset_name][Keys.ROW_NOISE]
+    config = get_configuration(config)[dataset_name][Keys.ROW_NOISE]
     noise_type = [
         n for n in config if n in [NOISE_TYPES.omit_row.name, NOISE_TYPES.do_not_respond.name]
     ]
@@ -282,7 +282,7 @@ def test_row_noising_omit_row_or_do_not_respond(dataset_name: str, overrides, re
         DATASETS.tax_1040.name,
     ],
 )
-def test_row_noising_duplication(dataset_name: str, overrides, request):
+def test_row_noising_duplication(dataset_name: str, config, request):
     """Tests that duplication row noising is being applied"""
     ...
 

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -132,7 +132,7 @@ def test_get_configuration_with_user_override(mocker):
 
 
 def test_loading_from_yaml(tmp_path):
-    user_config = {
+    overrides = {
         DATASETS.census.name: {
             Keys.COLUMN_NOISE: {
                 COLUMNS.age.name: {
@@ -145,7 +145,7 @@ def test_loading_from_yaml(tmp_path):
     }
     filepath = tmp_path / "user_dict.yaml"
     with open(filepath, "w") as file:
-        yaml.dump(user_config, file)
+        yaml.dump(overrides, file)
 
     default_config = get_configuration()[DATASETS.census.name][Keys.COLUMN_NOISE][
         COLUMNS.age.name
@@ -163,30 +163,30 @@ def test_loading_from_yaml(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "user_config, expected",
+    "age_differences, expected",
     [
         ([-2, -1, 2], {-2: 1 / 3, -1: 1 / 3, 1: 0, 2: 1 / 3}),
         ({-2: 0.3, 1: 0.5, 2: 0.2}, {-2: 0.3, -1: 0, 1: 0.5, 2: 0.2}),
     ],
     ids=["list", "dict"],
 )
-def test_format_miswrite_ages(user_config, expected):
+def test_format_miswrite_ages(age_differences, expected):
     """Test that user-supplied dictionary properly updates ConfigTree object.
     This includes zero-ing out default values that don't exist in the user config
     """
-    user_config = {
+    overrides = {
         DATASETS.census.name: {
             Keys.COLUMN_NOISE: {
                 COLUMNS.age.name: {
                     NOISE_TYPES.misreport_age.name: {
-                        Keys.POSSIBLE_AGE_DIFFERENCES: user_config,
+                        Keys.POSSIBLE_AGE_DIFFERENCES: age_differences,
                     },
                 },
             },
         },
     }
 
-    config = get_configuration(user_config)[DATASETS.census.name][Keys.COLUMN_NOISE][
+    config = get_configuration(overrides)[DATASETS.census.name][Keys.COLUMN_NOISE][
         COLUMNS.age.name
     ][NOISE_TYPES.misreport_age.name][Keys.POSSIBLE_AGE_DIFFERENCES].to_dict()
 
@@ -381,7 +381,7 @@ def test_validate_miswrite_zipcode_digit_probabilities_failures(probabilities, m
 
 
 def test_get_config(caplog):
-    user_config = {
+    overrides = {
         DATASETS.acs.name: {
             Keys.COLUMN_NOISE: {
                 "zipcode": {
@@ -396,14 +396,14 @@ def test_get_config(caplog):
     assert isinstance(config_1, dict)
     assert not caplog.records
 
-    config_2 = get_config("decennial_census", user_config)
+    config_2 = get_config("decennial_census", overrides)
     assert isinstance(config_2, dict)
     assert "not in the user provided configuration" in caplog.text
 
     with pytest.raises(ConfigurationError, match="bad_form_name"):
         get_config("bad_form_name")
 
-    config_3 = get_config(user_config=NO_NOISE)
+    config_3 = get_config(overrides=NO_NOISE)
     for dataset in config_3.keys():
         row_noise_dict = config_3[dataset][Keys.ROW_NOISE]
         column_dict = config_3[dataset][Keys.COLUMN_NOISE]


### PR DESCRIPTION
## Title: Rename "user_config" arg to "overrides"

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: [MIC-4376](https://jira.ihme.washington.edu/browse/MIC-4376)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
RT requested that when calling `psp.get_config()`, the user override
argument should be renamed from `user_config` to `overrides`.

### Testing
integration tests pass
