### PR TITLE
DOC: Reorder noise functions in user docs

### DIFF
--- a/docs/source/noise/column_noise.rst
+++ b/docs/source/noise/column_noise.rst
@@ -89,6 +89,36 @@ It takes one parameter:
     - The probability that, for a cell in the column being configured, the wrong option is chosen.
     - 0.01 (1%)
 
+.. _use_a_nickname:
+
+Use a nickname
+---------------
+
+Many people, when filling out forms or survey answers, choose to use nicknames instead of their legal names.
+A common example is an Alexander who chooses to go by Alex.
+
+The "Use a nickname" noise type in pseudopeople simulates these kinds of responses for first and middle names. In order
+to do this, we used a list of 1,080 names and their relevant nicknames, from a project by Old Dominion
+University's Web Science and Digital Libraries Research Group. You can read more about the list of nicknames
+in the group's `GitHub repository <https://github.com/carltonnorthern/nicknames>`_.
+
+Instead of the person's legal name, pseudopeople selects the subset of simulated individuals who are eligible
+for a nickname (i.e., those whose legal first or middle name is included in the nicknames list detailed above), then replaces
+each selected simulant's first name with any of the nicknames included in the csv file.
+
+This noise type is called :code:`use_nickname` in the configuration. It takes one parameter:
+
+.. list-table:: Parameters to the use_nickname noise type
+  :widths: 1 5 1
+  :header-rows: 1
+
+  * - Parameter
+    - Description
+    - Default
+  * - :code:`cell_probability`
+    - The probability that, for a cell in the :code:`first_name` column, a nickname is recorded.
+    - 0.01 (1%)
+
 .. _use_a_fake_name:
 
 Use a fake name
@@ -117,26 +147,17 @@ This noise type is called :code:`use_fake_name` in the configuration. It takes o
     - The probability that, for a cell in the column (either first or last name), a fake name is recorded.
     - 0.01 (1%)
 
-.. _use_a_nickname:
+Swap month and day
+------------------
 
-Use a nickname
----------------
+Swap month and day is a noise type that only applies to dates. It occurs when
+someone swaps the month and day to be in the incorrect position (e.g., December
+8, 2022 would be listed in MM/DD/YYYY format as 08/12/2022).
 
-Many people, when filling out forms or survey answers, choose to use nicknames instead of their legal names.
-A common example is an Alexander who chooses to go by Alex. 
+This noise type is called :code:`swap_month_and_day` in the configuration. It
+takes one parameter:
 
-The "Use a nickname" noise type in pseudopeople simulates these kinds of responses for first and middle names. In order
-to do this, we used a list of 1,080 names and their relevant nicknames, from a project by Old Dominion 
-University's Web Science and Digital Libraries Research Group. You can read more about the list of nicknames
-in the group's `GitHub repository <https://github.com/carltonnorthern/nicknames>`_.
-
-Instead of the person's legal name, pseudopeople selects the subset of simulated individuals who are eligible 
-for a nickname (i.e., those whose legal first or middle name is included in the nicknames list detailed above), then replaces
-each selected simulant's first name with any of the nicknames included in the csv file. 
-
-This noise type is called :code:`use_nickname` in the configuration. It takes one parameter:
-
-.. list-table:: Parameters to the use_nickname noise type
+.. list-table:: Parameters to the swap_month_and_day noise type
   :widths: 1 5 1
   :header-rows: 1
 
@@ -144,7 +165,7 @@ This noise type is called :code:`use_nickname` in the configuration. It takes on
     - Description
     - Default
   * - :code:`cell_probability`
-    - The probability that, for a cell in the :code:`first_name` column, a nickname is recorded.
+    - The probability of a cell date having its month and day swapped.
     - 0.01 (1%)
 
 Misreport age
@@ -178,7 +199,7 @@ It takes two parameters:
           the values are the probabilities of those differences.
           This is like the list option, except that it allows some age differences to be more likely than others.
           The probabilities must add up to 1.
-      
+
       Zero (no change) is not allowed as a possible difference.
     - {-2: 0.1, -1: 0.4, +1: 0.4, +2: 0.1}
 
@@ -248,14 +269,15 @@ It takes two parameters:
       The second value in the list is the corresponding probability for the second digit, and so on.
     - [0.04, 0.04, 0.20, 0.36, 0.36]
 
-Swap month and day
-------------------
+Make phonetic errors
+--------------------
+A phonetic error occurs when a character is misheard. For instance, this could happen with similar sounding letters when spoken (like ‘t’ and ‘d’) or letters that make the same sounds within a word (like ‘o’ and ‘ou’).
 
-Swap month and day is a noise type that only applies to dates. It occurs when someone swaps the month and day to be in the incorrect position (e.g., December 8, 2022 would be listed in MM/DD/YYYY format as 08/12/2022).
+pseudopeople defines the possible phonetic substitutions using `this file <https://github.com/ihmeuw/pseudopeople/blob/develop/src/pseudopeople/data/phonetic_variations.csv>`_, which was produced by the `GeCO project <https://dl.acm.org/doi/10.1145/2505515.2508207>`_.
 
-This noise type is called :code:`swap_month_and_day` in the configuration. It takes one parameter:
+This noise type is called :code:`make_phonetic_errors` in the configuration. It takes two parameters:
 
-.. list-table:: Parameters to the swap_month_and_day noise type
+.. list-table:: Parameters to the make_phonetic_errors noise type
   :widths: 1 5 1
   :header-rows: 1
 
@@ -263,9 +285,58 @@ This noise type is called :code:`swap_month_and_day` in the configuration. It ta
     - Description
     - Default
   * - :code:`cell_probability`
-    - The probability of a cell date having its month and day swapped.
+    - The probability of a cell being *considered* to have this noise type.
+      One way to think about this is the probability that a string is transcribed by an error-prone program or human transcriber.
+      Whether or not there are actually any errors depends on the next parameter.
     - 0.01 (1%)
+  * - :code:`token_probability`
+    - The probability of each corruption-eligible token being misheard
+      **given that the cell is being considered for this noise type**.
+      One way to think about this is the probability of a phonetic error on any given corruption-eligible token when the transcriber is error-prone.
+    - 0.1 (10%)
 
+Make optical character recognition (OCR) errors
+--------------------------------------------------
+
+An optical character recognition (OCR) error is when a string is misread for another string that is visually similar. Some common examples are
+‘S’ instead of ‘5’ and ‘m’ instead of ‘iii’.
+
+pseudopeople defines the possible OCR substitutions using `this CSV file <https://github.com/ihmeuw/pseudopeople/blob/develop/src/pseudopeople/data/ocr_errors.csv>`_, which was produced by the `GeCO project <https://dl.acm.org/doi/10.1145/2505515.2508207>`_. In the file, the first column is the real string (which we call a "token") and the second column is what it could be misread as (a "corruption").
+The same token can be associated with multiple corruptions.
+
+To implement this, we first select the rows to noise, as in other noise types.
+For those rows, each corruption-eligible token in the relevant string is selected to be corrupted or not,
+according to the token noise probability.
+Each token selected for corruption is replaced with its corruption according to the above CSV file
+(choosing uniformly at random in the case of multiple corruption options for a single token),
+**unless a token with any overlapping characters (in the original string) has already been corrupted**.
+
+.. note::
+  Tokens are corrupted in the order of the location of their first character in the original string, from beginning to end,
+  breaking ties (e.g. 'l' and 'l>' are both corruption-eligible tokens and may start on the same 'l') by corrupting longer tokens first.
+  Note that in an example :code:`abcd` where :code:`ab`, :code:`bc`, **and** :code:`cd` have **all** been selected to be corrupted,
+  the corruption of :code:`ab` prevents the corruption of :code:`bc` from occurring, which then allows :code:`cd` to be corrupted
+  even though it overlapped with :code:`bc`.
+
+This noise type is called :code:`make_ocr_errors` in the configuration. It takes two parameters:
+
+.. list-table:: Parameters to the make_ocr_errors noise type
+  :widths: 1 5 1
+  :header-rows: 1
+
+  * - Parameter
+    - Description
+    - Default
+  * - :code:`cell_probability`
+    - The probability of a cell being *considered* to have this noise type.
+      One way to think about this is the probability that a string is read by an inaccurate OCR program or human reader.
+      Whether or not there are actually any errors depends on the next parameter.
+    - 0.01 (1%)
+  * - :code:`token_probability`
+    - The probability of each corruption-eligible token being misread
+      **given that the cell is being considered for this noise type**.
+      One way to think about this is the probability of an OCR error on any given corruption-eligible token when a string is being read inaccurately.
+    - 0.1 (10%)
 
 Make typos
 ----------
@@ -321,74 +392,4 @@ This noise type is called :code:`make_typos` in the configuration. It takes two 
     - The probability of each character (which we call a "token") having a typo
       **given that the cell is being considered for this noise type**.
       One way to think about this is the probability of a typo on any given character when the value is being typed carelessly.
-    - 0.1 (10%)
-
-Make optical character recognition (OCR) errors
---------------------------------------------------
-
-An optical character recognition (OCR) error is when a string is misread for another string that is visually similar. Some common examples are
-‘S’ instead of ‘5’ and ‘m’ instead of ‘iii’.
-
-pseudopeople defines the possible OCR substitutions using `this CSV file <https://github.com/ihmeuw/pseudopeople/blob/develop/src/pseudopeople/data/ocr_errors.csv>`_, which was produced by the `GeCO project <https://dl.acm.org/doi/10.1145/2505515.2508207>`_. In the file, the first column is the real string (which we call a "token") and the second column is what it could be misread as (a "corruption").
-The same token can be associated with multiple corruptions.
-
-To implement this, we first select the rows to noise, as in other noise types.
-For those rows, each corruption-eligible token in the relevant string is selected to be corrupted or not,
-according to the token noise probability.
-Each token selected for corruption is replaced with its corruption according to the above CSV file
-(choosing uniformly at random in the case of multiple corruption options for a single token),
-**unless a token with any overlapping characters (in the original string) has already been corrupted**.
-
-.. note:: 
-  Tokens are corrupted in the order of the location of their first character in the original string, from beginning to end,
-  breaking ties (e.g. 'l' and 'l>' are both corruption-eligible tokens and may start on the same 'l') by corrupting longer tokens first.
-  Note that in an example :code:`abcd` where :code:`ab`, :code:`bc`, **and** :code:`cd` have **all** been selected to be corrupted,
-  the corruption of :code:`ab` prevents the corruption of :code:`bc` from occurring, which then allows :code:`cd` to be corrupted
-  even though it overlapped with :code:`bc`.
-
-This noise type is called :code:`make_ocr_errors` in the configuration. It takes two parameters:
-
-.. list-table:: Parameters to the make_ocr_errors noise type
-  :widths: 1 5 1
-  :header-rows: 1
-
-  * - Parameter
-    - Description
-    - Default
-  * - :code:`cell_probability`
-    - The probability of a cell being *considered* to have this noise type.
-      One way to think about this is the probability that a string is read by an inaccurate OCR program or human reader.
-      Whether or not there are actually any errors depends on the next parameter.
-    - 0.01 (1%)
-  * - :code:`token_probability`
-    - The probability of each corruption-eligible token being misread
-      **given that the cell is being considered for this noise type**.
-      One way to think about this is the probability of an OCR error on any given corruption-eligible token when a string is being read inaccurately.
-    - 0.1 (10%)
-
-
-Make phonetic errors
---------------------
-A phonetic error occurs when a character is misheard. For instance, this could happen with similar sounding letters when spoken (like ‘t’ and ‘d’) or letters that make the same sounds within a word (like ‘o’ and ‘ou’). 
-
-pseudopeople defines the possible phonetic substitutions using `this file <https://github.com/ihmeuw/pseudopeople/blob/develop/src/pseudopeople/data/phonetic_variations.csv>`_, which was produced by the `GeCO project <https://dl.acm.org/doi/10.1145/2505515.2508207>`_.
-
-This noise type is called :code:`make_phonetic_errors` in the configuration. It takes two parameters:
-
-.. list-table:: Parameters to the make_phonetic_errors noise type
-  :widths: 1 5 1
-  :header-rows: 1
-
-  * - Parameter
-    - Description
-    - Default
-  * - :code:`cell_probability`
-    - The probability of a cell being *considered* to have this noise type.
-      One way to think about this is the probability that a string is transcribed by an error-prone program or human transcriber.
-      Whether or not there are actually any errors depends on the next parameter.
-    - 0.01 (1%)
-  * - :code:`token_probability`
-    - The probability of each corruption-eligible token being misheard
-      **given that the cell is being considered for this noise type**.
-      One way to think about this is the probability of a phonetic error on any given corruption-eligible token when the transcriber is error-prone.
     - 0.1 (10%)

--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -72,34 +72,34 @@ The "Config key" column shows the name of the noise type in the :ref:`configurat
   * - Choose the wrong option
     - ``choose_wrong_option``
     - Marking the "Male" box when you meant "Female"
-  * - Use a fake name
-    - ``use_fake_name``
-    - Using "Mr" rather than actual first name
-  * - Use a nickname
-    - ``use_nickname``
-    - Writing 'Alex' instead of legal name 'Alexander'
+  * - Swap month and day
+    - ``swap_month_and_day``
+    - Reporting 17/05/1976 when a survey asks for the date in MM/DD/YYYY format
+  * - Write the wrong ZIP code digits
+    - ``write_wrong_zipcode_digits``
+    - Writing ZIP code 98118 when you actually live in 98112
   * - Misreport age
     - ``misreport_age``
     - Reporting that you are 28 years old when you are actually 27
   * - Write the wrong digits
     - ``write_wrong_digits``
     - Writing "732 Main St" as your street address instead of "932 Main St"
-  * - Write the wrong ZIP code digits
-    - ``write_wrong_zipcode_digits``
-    - Writing ZIP code 98118 when you actually live in 98112
-  * - Swap month and day
-    - ``swap_month_and_day``
-    - Reporting 17/05/1976 when a survey asks for the date in MM/DD/YYYY format
+  * - Use a nickname
+    - ``use_nickname``
+    - Writing 'Alex' instead of legal name 'Alexander'
+  * - Use a fake name
+    - ``use_fake_name``
+    - Using "Mr" rather than actual first name
+  * - Make phonetic errors
+    - ``make_phonetic_errors``
+    - Mishearing a 't' for a 'd'
+  * - Make Optical Character Recognition (OCR) errors
+    - ``make_ocr_errors``
+    - Misreading an 'S' instead of a '5'
   * - Make typos
     - ``make_typos``
     - Accidentally typing an "l" instead of a "k" because they are
       right next to each other on a QWERTY keyboard
-  * - Make Optical Character Recognition (OCR) errors
-    - ``make_ocr_errors``
-    - Misreading an 'S' instead of a '5'
-  * - Make phonetic errors
-    - ``make_phonetic_errors``
-    - Mishearing a 't' for a 'd'
 
 
 Noise types for each column
@@ -120,7 +120,7 @@ Noise types for each column
   * - Middle name
     - SSA
     - Leave a field blank, use a fake name, use a nickname, make typos, make OCR errors, make phonetic errors
-    - 
+    -
   * - Middle initial
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099, 1040
     - Leave a field blank, make typos, make OCR errors, make phonetic errors
@@ -186,10 +186,10 @@ Noise types for each column
     - Borrow a social security number, leave a field blank, write the wrong digits, make typos, make OCR errors
     - Note that 'borrow a social security number' only applies to the W-2 and 1099 dataset.
       In the 1040 form, the same noise types apply to the SSN columns for the joint filer and dependents
-  * - Wages 
+  * - Wages
     - W-2 and 1099
     - Leave a field blank, write the wrong digits, make typos, make OCR errors
-    - 
+    -
   * - Employer ID
     - W-2 and 1099
     - Leave a field blank, write the wrong digits, make typos, make OCR errors

--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -115,47 +115,47 @@ Noise types for each column
     - Notes
   * - First name
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099, 1040, SSA
-    - Leave a field blank, use a fake name, use a nickname, make typos, make OCR errors, make phonetic errors
+    - Leave a field blank, use a nickname, use a fake name, make phonetic errors, make OCR errors, make typos
     - In the 1040 form, the same noise types apply to the first name columns for the joint filer and dependents
   * - Middle name
     - SSA
-    - Leave a field blank, use a fake name, use a nickname, make typos, make OCR errors, make phonetic errors
+    - Leave a field blank, use a nickname, use a fake name, make phonetic errors, make OCR errors, make typos
     -
   * - Middle initial
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099, 1040
-    - Leave a field blank, make typos, make OCR errors, make phonetic errors
+    - Leave a field blank, make phonetic errors, make OCR errors, make typos
     - In the 1040 form, the same noise types apply to the middle initial columns for the joint filer and dependents
   * - Last name
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099, 1040, SSA
-    - Leave a field blank, use a fake name, make typos, make OCR errors, make phonetic errors
+    - Leave a field blank, use a fake name, make phonetic errors, make OCR errors, make typos
     - In the 1040 form, the same noise types apply to the last name columns for the joint filer and dependents
   * - Age
     - Decennial Census, ACS, CPS, W-2 and 1099
-    - Leave a field blank, misreport age, make typos, make OCR errors
+    - Leave a field blank, misreport age, make OCR errors, make typos
     -
   * - Date of birth
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099, SSA
-    - Leave a field blank, write the wrong digits, swap month and day, make typos, make OCR errors
+    - Leave a field blank, swap month and day, write the wrong digits, make OCR errors, make typos
     -
   * - Street number for any address (physical, mailing, or employer)
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099, 1040
-    - Leave a field blank, write the wrong digits, make typos, make OCR errors
+    - Leave a field blank, write the wrong digits, make OCR errors, make typos
     - Noise for all types of addresses works in the same way
   * - Street name for any address (physical, mailing, or employer)
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099, 1040
-    - Leave a field blank, make typos, make OCR errors, make phonetic errors
+    - Leave a field blank, make phonetic errors, make OCR errors, make typos
     - Noise for all types of addresses works in the same way
   * - Unit number for any address (physical, mailing, or employer)
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099, 1040
-    - Leave a field blank, write the wrong digits, make typos, make OCR errors
+    - Leave a field blank, write the wrong digits, make OCR errors, make typos
     - Noise for all types of addresses works in the same way
   * - PO Box for mailing address
     - W-2 and 1099, 1040
-    - Leave a field blank, write the wrong digits, make typos, make OCR errors
+    - Leave a field blank, write the wrong digits, make OCR errors, make typos
     -
   * - City name for any address (physical, mailing, or employer)
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099, 1040
-    - Leave a field blank, make typos, make OCR errors, make phonetic errors
+    - Leave a field blank, make phonetic errors, make OCR errors, make typos
     - Noise for all types of addresses works in the same way
   * - State for any address (physical, mailing, or employer)
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099, 1040
@@ -163,7 +163,7 @@ Noise types for each column
     - Noise for all types of addresses works in the same way
   * - ZIP code for any address (physical, mailing, or employer)
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099, 1040
-    - Leave a field blank, write the wrong zipcode digits, make typos, make OCR errors
+    - Leave a field blank, write the wrong zipcode digits, make OCR errors, make typos
     -
   * - Housing type
     - Decennial Census, ACS
@@ -183,20 +183,20 @@ Noise types for each column
     -
   * - SSN
     - W-2 and 1099, 1040, SSA
-    - Borrow a social security number, leave a field blank, write the wrong digits, make typos, make OCR errors
+    - Borrow a social security number, leave a field blank, write the wrong digits, make OCR errors, make typos
     - Note that 'borrow a social security number' only applies to the W-2 and 1099 dataset.
       In the 1040 form, the same noise types apply to the SSN columns for the joint filer and dependents
   * - Wages
     - W-2 and 1099
-    - Leave a field blank, write the wrong digits, make typos, make OCR errors
+    - Leave a field blank, write the wrong digits, make OCR errors, make typos
     -
   * - Employer ID
     - W-2 and 1099
-    - Leave a field blank, write the wrong digits, make typos, make OCR errors
+    - Leave a field blank, write the wrong digits, make OCR errors, make typos
     -
   * - Employer name
     - W-2 and 1099
-    - Leave a field blank, make typos, make OCR errors
+    - Leave a field blank, make OCR errors, make typos
     -
   * - Type of tax form
     - W-2 and 1099
@@ -208,9 +208,8 @@ Noise types for each column
     -
   * - Date of SSA event
     - SSA
-    - Leave a field blank, write the wrong digits, swap month and day, make typos, make OCR errors
+    - Leave a field blank, swap month and day, write the wrong digits, make OCR errors, make typos
     -
-
 
 .. _noise_type_details:
 

--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -72,24 +72,24 @@ The "Config key" column shows the name of the noise type in the :ref:`configurat
   * - Choose the wrong option
     - ``choose_wrong_option``
     - Marking the "Male" box when you meant "Female"
-  * - Swap month and day
-    - ``swap_month_and_day``
-    - Reporting 17/05/1976 when a survey asks for the date in MM/DD/YYYY format
-  * - Write the wrong ZIP code digits
-    - ``write_wrong_zipcode_digits``
-    - Writing ZIP code 98118 when you actually live in 98112
-  * - Misreport age
-    - ``misreport_age``
-    - Reporting that you are 28 years old when you are actually 27
-  * - Write the wrong digits
-    - ``write_wrong_digits``
-    - Writing "732 Main St" as your street address instead of "932 Main St"
   * - Use a nickname
     - ``use_nickname``
     - Writing 'Alex' instead of legal name 'Alexander'
   * - Use a fake name
     - ``use_fake_name``
     - Using "Mr" rather than actual first name
+  * - Swap month and day
+    - ``swap_month_and_day``
+    - Reporting 17/05/1976 when a survey asks for the date in MM/DD/YYYY format
+  * - Misreport age
+    - ``misreport_age``
+    - Reporting that you are 28 years old when you are actually 27
+  * - Write the wrong digits
+    - ``write_wrong_digits``
+    - Writing "732 Main St" as your street address instead of "932 Main St"
+  * - Write the wrong ZIP code digits
+    - ``write_wrong_zipcode_digits``
+    - Writing ZIP code 98118 when you actually live in 98112
   * - Make phonetic errors
     - ``make_phonetic_errors``
     - Mishearing a 't' for a 'd'

--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -110,7 +110,7 @@ Noise types for each column
   :header-rows: 1
 
   * - Column name
-    - Datasets present
+    - Applicable datasets
     - Types of noise
     - Notes
   * - First name

--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -120,7 +120,7 @@ Noise types for each column
   * - Middle name
     - SSA
     - Leave a field blank, use a nickname, use a fake name, make phonetic errors, make OCR errors, make typos
-    -
+    - Middle names use the same lists of nicknames and fake names used for first names
   * - Middle initial
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099, 1040
     - Leave a field blank, make phonetic errors, make OCR errors, make typos
@@ -128,7 +128,7 @@ Noise types for each column
   * - Last name
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099, 1040, SSA
     - Leave a field blank, use a fake name, make phonetic errors, make OCR errors, make typos
-    - In the 1040 form, the same noise types apply to the last name columns for the joint filer and dependents
+    - Last names use a different list of fake names than the list for first names. In the 1040 form, the same noise types apply to the last name columns for the joint filer and dependents
   * - Age
     - Decennial Census, ACS, CPS, W-2 and 1099
     - Leave a field blank, misreport age, make OCR errors, make typos


### PR DESCRIPTION
## Title: Re-order the noise functions on the noise page and column noise page
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> documentation
- *JIRA issue*: [SSCI-1457](https://jira.ihme.washington.edu/browse/SSCI-1457)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
-->
Edits the user docs to list the noise functions in the order in which the're applied in the code. Also makes a couple unrelated minor edits to one of the noise tables (see code comments below).

Technically, I put the noise types in an order that should be _equivalent_ to the order in which they're actually applied, but which I think will be more intuitive to a user reading the docs. I would like feedback on whether the order here looks good or whether we want to switch anything. If this ordering looks good, I'll edit the concept model accordingly and create an engineering ticket to update the code to match.

In particular, I have the following questions about what is the most logical order to try to match the actual data generation process:

1. I think it makes sense that OCR errors and typos are the last two types of noise, but I don't know which of these should come first. Is it more likely that a document is read in by OCR, and then someone types the ORC'ed data into an administrative file, or is it more likely that someone types data into a file, the file is printed, and then the printed file is read in by OCR and input directly into the administrative file?

3. I currently have nicknames applied before fake names. Does this make sense, or would it make more sense to apply fake names and then nicknames? (In practice, it probably doesn't make much difference because there are probably very few, if any, fake names that are also eligible for nicknames.)

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Built docs locally.
