### PR TITLE
inherit from Exception instead of BaseException

### DIFF
--- a/src/pseudopeople/exceptions.py
+++ b/src/pseudopeople/exceptions.py
@@ -2,14 +2,14 @@ from dataclasses import dataclass
 
 
 @dataclass
-class ConfigurationError(BaseException):
+class ConfigurationError(Exception):
     """Base class for configuration errors"""
 
     message: str
 
 
 @dataclass
-class DataSourceError(BaseException):
+class DataSourceError(Exception):
     """Base class for data source errors"""
 
     message: str


### PR DESCRIPTION
## Title: Stop inheriting from BaseException

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->other
- *JIRA issue*: na

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> Nathaniel caught that we're inheriting from BaseException in our
custom exception dataclasses when we should be using Exception.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
--> spot-tested in a try/except loop and custom error still got
raised but without the full stack trace

