### PR TITLE
Hot fix: remove age from WIC dataset in pseudopeople docs

### DIFF
--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -269,9 +269,6 @@ The following columns are included in this dataset:
    * - Last name
      - :code:`last_name`
      - 
-   * - Age
-     - :code:`age`  
-     - Rounded down to an integer.
    * - Date of birth
      - :code:`date_of_birth`
      - Formatted as MM/DD/YYYY.


### PR DESCRIPTION
## Title: Remove age from WIC dataset in pseudopeople docs
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: [SSCI-1507](https://jira.ihme.washington.edu/browse/SSCI-1507)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

