### PR TITLE
Set default noise values for W2/1099 correctly

### DIFF
--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -154,7 +154,6 @@ def _generate_configuration(is_no_noise: bool) -> ConfigTree:
     # Update configuration with non-baseline default values
     if not is_no_noise:
         noising_configuration.update(DEFAULT_NOISE_VALUES, layer="default")
-
     return noising_configuration
 
 

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -66,17 +66,6 @@ DEFAULT_NOISE_VALUES = {
             },
         },
     },
-    # No noise for date in tax w2 1099 dataset
-    DATASETS.tax_w2_1099.name: {
-        Keys.COLUMN_NOISE: {
-            COLUMNS.dob.name: {
-                noise_type.name: {
-                    Keys.CELL_PROBABILITY: 0.0,
-                }
-                for noise_type in COLUMNS.dob.noise_types
-            },
-        },
-    },
 }
 
 
@@ -165,6 +154,7 @@ def _generate_configuration(is_no_noise: bool) -> ConfigTree:
     # Update configuration with non-baseline default values
     if not is_no_noise:
         noising_configuration.update(DEFAULT_NOISE_VALUES, layer="default")
+
     return noising_configuration
 
 


### PR DESCRIPTION
## Set default noise values for W2/1099 correctly

### Description
- *Category*: bugfix
- *JIRA issue*: none

There were two problems with this:
- It set a default for date of birth in the W2/1099 dataset; that column no longer appears in that dataset at all. Adding this had strange ripple effects, such as allowing the user to configure this (meaningless) setting.
- It was a duplicate key, overwriting the defaults defined above for the same dataset.

### Testing

I ran the tests, but not the slow ones. I thought about adding an automated test that the rest of the default values are valid, but I'm not sure exactly where you would want to do this (at runtime or in a pytest) so I held off on that.