### PR TITLE
Check the length of possible_age_differences

### DIFF
--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -129,6 +129,11 @@ def _validate_possible_age_differences(
             base_error_message + f"'{parameter}' must be a Dict or List. "
             f"Provided {noise_type_config} of type {type(noise_type_config)}."
         )
+    if len(noise_type_config) == 0:
+        raise ConfigurationError(
+            base_error_message + f"'{parameter}' must not be empty. "
+            f"Provided {noise_type_config}."
+        )
     for key in noise_type_config:
         if not isinstance(key, int):
             raise ConfigurationError(


### PR DESCRIPTION
## Check the length of possible_age_differences

### Description
- *Category*: bugfix
- *JIRA issue*: none

Similar to #273, this was a place where the validator was throwing an unfriendly error message:

```pycon
>>> psp.generate_decennial_census(config={'decennial_census': {'column_noise': {'age': {'misreport_age': {'possible_age_differences': []}}}}})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/share/homes/zmbc/src/pseudopeople/src/pseudopeople/interface.py", line 169, in generate_decennial_census
    return _generate_dataset(DATASETS.census, source, seed, config, user_filters, verbose)
  File "/mnt/share/homes/zmbc/src/pseudopeople/src/pseudopeople/interface.py", line 49, in _generate_dataset
    configuration_tree = get_configuration(config)
  File "/mnt/share/homes/zmbc/src/pseudopeople/src/pseudopeople/configuration/generator.py", line 102, in get_configuration
    add_overrides(noising_configuration, overrides)
  File "/mnt/share/homes/zmbc/src/pseudopeople/src/pseudopeople/configuration/generator.py", line 174, in add_overrides
    noising_configuration.update(overrides, layer="user")
  File "/mnt/share/homes/zmbc/src/vivarium/src/vivarium/config_tree.py", line 427, in update
    self._set_with_metadata(k, v, layer, source)
  File "/mnt/share/homes/zmbc/src/vivarium/src/vivarium/config_tree.py", line 512, in _set_with_metadata
    self._children[name].update(value, layer, source)
  File "/mnt/share/homes/zmbc/src/vivarium/src/vivarium/config_tree.py", line 427, in update
    self._set_with_metadata(k, v, layer, source)
  File "/mnt/share/homes/zmbc/src/vivarium/src/vivarium/config_tree.py", line 512, in _set_with_metadata
    self._children[name].update(value, layer, source)
  File "/mnt/share/homes/zmbc/src/vivarium/src/vivarium/config_tree.py", line 427, in update
    self._set_with_metadata(k, v, layer, source)
  File "/mnt/share/homes/zmbc/src/vivarium/src/vivarium/config_tree.py", line 512, in _set_with_metadata
    self._children[name].update(value, layer, source)
  File "/mnt/share/homes/zmbc/src/vivarium/src/vivarium/config_tree.py", line 427, in update
    self._set_with_metadata(k, v, layer, source)
  File "/mnt/share/homes/zmbc/src/vivarium/src/vivarium/config_tree.py", line 512, in _set_with_metadata
    self._children[name].update(value, layer, source)
  File "/mnt/share/homes/zmbc/src/vivarium/src/vivarium/config_tree.py", line 427, in update
    self._set_with_metadata(k, v, layer, source)
  File "/mnt/share/homes/zmbc/src/vivarium/src/vivarium/config_tree.py", line 510, in _set_with_metadata
    raise ConfigurationError(f"Can't assign a value to a ConfigTree.", name)
vivarium.config_tree.ConfigurationError: Can't assign a value to a ConfigTree.
```

### Testing

```pycon
>>> psp.generate_decennial_census(config={'decennial_census': {'column_noise': {'age': {'misreport_age': {'possible_age_differences': []}}}}})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/share/homes/zmbc/src/pseudopeople/src/pseudopeople/interface.py", line 169, in generate_decennial_census
    return _generate_dataset(DATASETS.census, source, seed, config, user_filters, verbose)
  File "/mnt/share/homes/zmbc/src/pseudopeople/src/pseudopeople/interface.py", line 49, in _generate_dataset
    configuration_tree = get_configuration(config)
  File "/mnt/share/homes/zmbc/src/pseudopeople/src/pseudopeople/configuration/generator.py", line 102, in get_configuration
    add_overrides(noising_configuration, overrides)
  File "/mnt/share/homes/zmbc/src/pseudopeople/src/pseudopeople/configuration/generator.py", line 172, in add_overrides
    validate_overrides(overrides, noising_configuration)
  File "/mnt/share/homes/zmbc/src/pseudopeople/src/pseudopeople/configuration/validator.py", line 56, in validate_overrides
    _validate_noise_type_config(
  File "/mnt/share/homes/zmbc/src/pseudopeople/src/pseudopeople/configuration/validator.py", line 90, in _validate_noise_type_config
    parameter_config_validator(parameter_config, parameter, base_error_message)
  File "/mnt/share/homes/zmbc/src/pseudopeople/src/pseudopeople/configuration/validator.py", line 133, in _validate_possible_age_differences
    raise ConfigurationError(
pseudopeople.exceptions.ConfigurationError: Invalid 'possible_age_differences' provided for dataset 'decennial_census' for column 'age' and noise type 'misreport_age'. 'possible_age_differences' must not be empty. Provided [].
```