### PR TITLE
Improve nicknames maximum warning message

### DIFF
--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -199,8 +199,9 @@ def _validate_nickname_probability(
     if noise_type_config > metadata.NICKNAMES_PROPORTION:
         logger.warning(
             base_error_message
-            + f"Maximum configuration value is {1/metadata.NICKNAMES_PROPORTION}. "
-            f"Noise level has been adjusted to {1/metadata.NICKNAMES_PROPORTION}."
+            + f"The configured '{parameter}' is {noise_type_config}, but only approximately "
+            f"{metadata.NICKNAMES_PROPORTION:.2%} of names have a nickname. "
+            f"Replacing as many names with nicknames as possible."
         )
 
 

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -451,7 +451,7 @@ def test_validate_nickname_configuration(caplog):
         if config_value == 0.45:
             assert not caplog.records
         else:
-            assert "Noise level has been adjusted" in caplog.text
+            assert "Replacing as many names with nicknames as possible" in caplog.text
 
 
 def test_no_noise():


### PR DESCRIPTION
## Improve nicknames maximum warning message

### Description
- *Category*: bugfix/feature
- *JIRA issue*: none

I swear we had a Slack conversation and/or JIRA ticket about this, but I can't find it. There were two issues here:
- The warning message used the reciprocal when it shouldn't have (?)
- The warning message sounded far too authoritative/certain relative to what actually triggers it.

Hoping to get @NathanielBlairStahn to review this new wording. Note: I don't love the word "Invalid" still being present, but that would be more of a hassle to change.

### Testing

```pycon
>>> psp.generate_decennial_census(config={'decennial_census': {'column_noise': {'first_name': {'use_nickname': {'cell_probability': 0.7}}}}})
2023-08-30 11:22:39.297 | pseudopeople.configuration.validator:_validate_nickname_probability:200 - Invalid 'cell_probability' provided for dataset 'decennial_census' for column 'first_name' and noise type 'use_nickname'. The configured 'cell_probability' is 0.7, but only approximately 55.22% of names have a nickname. Replacing as many names with nicknames as possible.
```