### PR TITLE
Warn when choose_wrong_option target is impossible

### DIFF
--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -8,6 +8,7 @@ from pseudopeople.configuration import Keys
 from pseudopeople.constants import metadata
 from pseudopeople.exceptions import ConfigurationError
 from pseudopeople.noise_entities import NOISE_TYPES
+from pseudopeople.noise_scaling import get_options_for_column
 
 
 def validate_overrides(overrides: Dict, default_config: ConfigTree) -> None:
@@ -51,7 +52,12 @@ def validate_overrides(overrides: Dict, default_config: ConfigTree) -> None:
                 parameter_config_validator_map = {
                     NOISE_TYPES.use_nickname.name: {
                         Keys.CELL_PROBABILITY: _validate_nickname_probability
-                    }
+                    },
+                    NOISE_TYPES.choose_wrong_option.name: {
+                        Keys.CELL_PROBABILITY: lambda *args, **kwargs: _validate_choose_wrong_option_probability(
+                            *args, **kwargs, column=column
+                        )
+                    },
                 }.get(noise_type, DEFAULT_PARAMETER_CONFIG_VALIDATOR_MAP)
                 _validate_noise_type_config(
                     noise_type_config,
@@ -201,6 +207,24 @@ def _validate_nickname_probability(
             base_error_message
             + f"Maximum configuration value is {1/metadata.NICKNAMES_PROPORTION}. "
             f"Noise level has been adjusted to {1/metadata.NICKNAMES_PROPORTION}."
+        )
+
+
+def _validate_choose_wrong_option_probability(
+    noise_type_config: Union[int, float], parameter: str, base_error_message: str, column: str
+):
+    _validate_probability(noise_type_config, parameter, base_error_message)
+    num_options = len(get_options_for_column(column))
+    # The maximum: if the cell *selection* probability were set to 1, and every cell
+    # selected an option uniformly at random, how many cells would actually change?
+    # Each cell would have a 1 / num_options chance of staying the same.
+    maximum_noise_probability = 1 - (1 / num_options)
+    if noise_type_config > maximum_noise_probability:
+        logger.warning(
+            base_error_message
+            + f"The configured '{parameter}' is {noise_type_config}, but pseudopeople "
+            f"can only choose the wrong option with a maximum of {maximum_noise_probability:.5f} probability. "
+            f"This maximum will be used instead of the configured value."
         )
 
 

--- a/src/pseudopeople/noise_scaling.py
+++ b/src/pseudopeople/noise_scaling.py
@@ -9,17 +9,10 @@ def scale_choose_wrong_option(data: pd.DataFrame, column_name: str) -> float:
     Function to scale noising for choose_wrong_option to adjust for the possibility
     of noising with the original values.
     """
-    from pseudopeople.schema_entities import COLUMNS
 
-    selection_type = {
-        COLUMNS.employer_state.name: COLUMNS.state.name,
-        COLUMNS.mailing_state.name: COLUMNS.state.name,
-    }.get(column_name, column_name)
-
-    selection_options = pd.read_csv(paths.INCORRECT_SELECT_NOISE_OPTIONS_DATA)
     # Get possible noise values
     # todo: Update with exclusive resampling when vectorized_choice is improved
-    options = selection_options.loc[selection_options[selection_type].notna(), selection_type]
+    options = get_options_for_column(column_name)
 
     # Scale to adjust for possibility of noising with original value
     noise_scaling_value = 1 / (1 - 1 / len(options))
@@ -58,3 +51,21 @@ def load_nicknames_data():
     nicknames = nicknames.apply(lambda x: x.astype(str).str.title()).set_index("name")
     nicknames = nicknames.replace("Nan", np.nan)
     return nicknames
+
+
+def get_options_for_column(column_name: str) -> pd.Series:
+    """
+    For a column that has a set list of options, returns that set of options as
+    a Series.
+    Should only be passed a column that has options (i.e. should not be a free-form
+    string column such as first name, or a numeric column), or it will error.
+    """
+    from pseudopeople.schema_entities import COLUMNS
+
+    selection_type = {
+        COLUMNS.employer_state.name: COLUMNS.state.name,
+        COLUMNS.mailing_state.name: COLUMNS.state.name,
+    }.get(column_name, column_name)
+
+    selection_options = pd.read_csv(paths.INCORRECT_SELECT_NOISE_OPTIONS_DATA)
+    return selection_options.loc[selection_options[selection_type].notna(), selection_type]

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -435,6 +435,7 @@ def test_validate_nickname_configuration(caplog):
     """
     config_values = [0.45, 0.65]
     for config_value in config_values:
+        caplog.clear()
         get_configuration(
             {
                 DATASETS.census.name: {
@@ -452,6 +453,40 @@ def test_validate_nickname_configuration(caplog):
             assert not caplog.records
         else:
             assert "Noise level has been adjusted" in caplog.text
+
+
+def test_validate_choose_wrong_option_configuration(caplog):
+    """
+    Tests that warning is thrown if cell probability is higher than possible given the
+    number of options.
+    """
+    column_maximums = {
+        "sex": 1 / 2,  # even if you noise all of the cells, only 1 / 2 will actually be wrong
+        "state": 50 / 51,  # likewise, but with many more categories (51)
+    }
+    config_values = [0.1, 0.4, 0.5, 0.6, 1]
+    for column, maximum in column_maximums.items():
+        caplog.clear()
+        for config_value in config_values:
+            get_configuration(
+                {
+                    DATASETS.census.name: {
+                        Keys.COLUMN_NOISE: {
+                            column: {
+                                NOISE_TYPES.choose_wrong_option.name: {
+                                    Keys.CELL_PROBABILITY: config_value,
+                                },
+                            },
+                        },
+                    },
+                },
+            )
+            if config_value <= maximum:
+                assert not caplog.records
+            else:
+                assert (
+                    "This maximum will be used instead of the configured value" in caplog.text
+                )
 
 
 def test_no_noise():


### PR DESCRIPTION
## Warn when choose_wrong_option target is impossible

### Description
- *Category*: feature
- *JIRA issue*: none, I think?

Adding a warning analogous to what we do for nicknames when the user's configured value is not possible. Note that in this case it is impossible because of a limitation of pseudopeople, which could be fixed in the future, rather than an inherent limitation.

See Slack conversation at https://ihme.slack.com/archives/C02KUQ9LX32/p1693420562792379

Hoping to get @NathanielBlairStahn to review the language here. The warning looks like:

```pycon
>>> psp.configuration.get_configuration({'decennial_census': {'column_noise': {'state': {'choose_wrong_option': {'cell_probability': 0.99}}}}})
2023-08-30 21:19:45.827 | WARNING  | pseudopeople.configuration.validator:_validate_choose_wrong_option_probability:223 - Invalid 'cell_probability' provided for dataset 'decennial_census' for column 'state' and noise type 'choose_wrong_option'. The configured 'cell_probability' is 0.99, but pseudopeople can only choose the wrong option with a maximum of 0.98039 probability. This maximum will be used instead of the configured value.
```

### Testing

Added an automated test.