### PR TITLE
Mic-4466/add US to state filter

### DIFF
--- a/src/pseudopeople/constants/metadata.py
+++ b/src/pseudopeople/constants/metadata.py
@@ -79,6 +79,8 @@ US_STATE_ABBRV_MAP = {
     "WISCONSIN": "WI",
     "WYOMING": "WY",
     "DISTRICT OF COLUMBIA": "DC",
+    # US for sample data
+    "United State": "US",
     # "PUERTO RICO": "PR",
 }
 


### PR DESCRIPTION
## Mic-4466/add US to state filter

### Adds United States (US) to potential state filters for sample data.
- *Category*: Bugfix
- *JIRA issue*: [MIC-4466](https://jira.ihme.washington.edu/browse/MIC-4466)

-adds US to states that users can filter to for sample data

### Testing
Manually tested and am now able to pass "US" as filter in generate_XXX

