### PR TITLE
Fix do_not_respond age intervals

### DIFF
--- a/src/pseudopeople/constants/data_values.py
+++ b/src/pseudopeople/constants/data_values.py
@@ -18,12 +18,13 @@ DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_RACE: Dict[str, float] = {
 }
 
 DO_NOT_RESPOND_AGE_INTERVALS: List[pd.Interval] = [
-    pd.Interval(0, 4),
-    pd.Interval(5, 9),
-    pd.Interval(10, 17),
-    pd.Interval(18, 29),
-    pd.Interval(30, 49),
-    pd.Interval(50, 125),
+    # Intervals should include their lower bound
+    pd.Interval(0, 5, closed="left"),
+    pd.Interval(5, 10, closed="left"),
+    pd.Interval(10, 18, closed="left"),
+    pd.Interval(18, 30, closed="left"),
+    pd.Interval(30, 50, closed="left"),
+    pd.Interval(50, 125, closed="left"),
 ]
 
 DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_SEX_AGE: Dict[str, pd.Series] = {


### PR DESCRIPTION
## Fix do_not_respond age intervals

### Description
- *Category*: bugfix
- *JIRA issue*: none

The age intervals [in the documentation](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#id111) are listed as 0-4, 5-9, etc (inclusive, obviously, and after flooring age). These were copied exactly into pseudopeople, except that the intervals were only closed on the right. Some simulants therefore had NaN probabilities.

I think the 0-4, 5-9 notation is inherently confusing (because with that, it matters whether age is an integer or an exact decimal value), so I've opted for intervals closed on the left only here. Happy to change if people feel strongly.

### Testing

Verified that after this change, there were no NaN probabilities.