### PR TITLE
Use different seed for each shard and noise type

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -75,7 +75,7 @@ def _generate_dataset(
         data = _coerce_dtypes(data, dataset)
         # Use a different seed for each data file/shard, otherwise the randomness will duplicate
         # and the Nth row in each shard will get the same noise
-        data_path_seed = seed + data_path_index
+        data_path_seed = f"{seed}_{data_path_index}"
         noised_data = noise_dataset(dataset, data, configuration_tree, data_path_seed)
         noised_data = _extract_columns(dataset.columns, noised_data)
         noised_dataset.append(noised_data)

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -66,14 +66,17 @@ def _generate_dataset(
         else data_paths
     )
 
-    for data_path in iterator:
+    for data_path_index, data_path in enumerate(iterator):
         logger.debug(f"Loading data from {data_path}.")
         data = _load_data_from_path(data_path, user_filters)
         if data.empty:
             continue
         data = _reformat_dates_for_noising(data, dataset)
         data = _coerce_dtypes(data, dataset)
-        noised_data = noise_dataset(dataset, data, configuration_tree, seed)
+        # Use a different seed for each data file/shard, otherwise the randomness will duplicate
+        # and the Nth row in each shard will get the same noise
+        data_path_seed = seed + data_path_index
+        noised_data = noise_dataset(dataset, data, configuration_tree, data_path_seed)
         noised_data = _extract_columns(dataset.columns, noised_data)
         noised_dataset.append(noised_data)
 

--- a/src/pseudopeople/noise.py
+++ b/src/pseudopeople/noise.py
@@ -12,6 +12,7 @@ rows in each columns changed to null values.  Then, the dataset data will be noi
 by column and row for each type of additional noise type.
 """
 from typing import Any
+
 import pandas as pd
 from tqdm import tqdm
 from vivarium import ConfigTree

--- a/src/pseudopeople/noise.py
+++ b/src/pseudopeople/noise.py
@@ -11,6 +11,7 @@ provided by the user.  First, the Dataset will be noised for missing data and ha
 rows in each columns changed to null values.  Then, the dataset data will be noised
 by column and row for each type of additional noise type.
 """
+from typing import Any
 import pandas as pd
 from tqdm import tqdm
 from vivarium import ConfigTree
@@ -26,7 +27,7 @@ def noise_dataset(
     dataset: Dataset,
     dataset_data: pd.DataFrame,
     configuration: ConfigTree,
-    seed: int,
+    seed: Any,
 ) -> pd.DataFrame:
     """
     Adds noise to the input dataset data. Noise functions are executed in the order

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import yaml
 from vivarium import ConfigTree
-from vivarium.framework.randomness import get_hash, RandomnessStream
+from vivarium.framework.randomness import RandomnessStream, get_hash
 
 from pseudopeople.configuration import Keys
 from pseudopeople.constants import data_values, paths

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import yaml
 from vivarium import ConfigTree
-from vivarium.framework.randomness import RandomnessStream
+from vivarium.framework.randomness import get_hash, RandomnessStream
 
 from pseudopeople.configuration import Keys
 from pseudopeople.constants import data_values, paths
@@ -267,7 +267,9 @@ def write_wrong_zipcode_digits(
             "Zipcode data contains zipcodes that are not 5 digits long. Please check input data."
         )
 
-    rng = np.random.default_rng(randomness_stream.seed)
+    rng = np.random.default_rng(
+        get_hash(f"{randomness_stream.seed}_write_wrong_zipcode_digits")
+    )
     shape = (len(column), 5)
 
     # todo: Update when vectorized choice is improved
@@ -347,7 +349,7 @@ def write_wrong_digits(
         return column
     # This is a fix to not replacing the original token for noise options
     token_noise_level = configuration[Keys.TOKEN_PROBABILITY] / 0.9
-    rng = np.random.default_rng(randomness_stream.seed)
+    rng = np.random.default_rng(get_hash(f"{randomness_stream.seed}_write_wrong_digits"))
     column = column.astype(str)
     max_str_length = column.str.len().max()
     same_len_col = column.str.pad(max_str_length, side="right")
@@ -477,7 +479,9 @@ def make_phonetic_errors(
         return err
 
     token_noise_level = configuration[Keys.TOKEN_PROBABILITY]
-    rng = np.random.default_rng(seed=randomness_stream.seed)
+    rng = np.random.default_rng(
+        seed=get_hash(f"{randomness_stream.seed}_make_phonetic_errors")
+    )
     column = data[column_name]
     column = column.astype(str)
     for idx in column.index:
@@ -534,7 +538,7 @@ def make_typos(
     token_noise_level = configuration[Keys.TOKEN_PROBABILITY]
     # TODO: remove this hard-coding
     include_token_probability_level = 0.1
-    rng = np.random.default_rng(seed=randomness_stream.seed)
+    rng = np.random.default_rng(seed=get_hash(f"{randomness_stream.seed}_make_typos"))
 
     # Make all strings the same length by padding with spaces
     max_str_length = column.str.len().max()
@@ -607,7 +611,7 @@ def make_ocr_errors(
 
     # Apply keyboard corrupt for OCR to column
     token_noise_level = configuration[Keys.TOKEN_PROBABILITY]
-    rng = np.random.default_rng(seed=randomness_stream.seed)
+    rng = np.random.default_rng(seed=get_hash(f"{randomness_stream.seed}_make_ocr_errors"))
     column = data[column_name]
     column = column.astype(str)
     for idx in column.index:

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -10,7 +10,7 @@ from vivarium.framework.randomness.index_map import IndexMap
 from pseudopeople.constants import metadata, paths
 
 
-def get_randomness_stream(dataset_name: str, seed: int, index: pd.Index) -> RandomnessStream:
+def get_randomness_stream(dataset_name: str, seed: Any, index: pd.Index) -> RandomnessStream:
     map_size = max(1_000_000, max(index) * 2)
     return RandomnessStream(
         key=dataset_name,

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import warnings
+from pathlib import Path
 
 import numpy as np
 import pandas as pd

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -104,10 +105,18 @@ def test_generate_dataset_from_sample_and_source(
             check_original.loc[compare_dataset_idx, col].values
             != check_noised_dataset.loc[compare_dataset_idx, col].values
         ).mean()
-        # we special-case a few sparse columns that have larger differences
-        if dataset_name == DATASETS.cps.name and col == COLUMNS.unit_number.name:
-            rtol = 0.30
-        elif dataset_name == DATASETS.acs.name and col == COLUMNS.unit_number.name:
+        # If the dataset is very small and/or missingness is very high, we can't
+        # meaningfully compare because the stochastic variation is so great
+        # As of 8/31/2023, this only skips unit_number (very missing) in the
+        # ACS and CPS datasets (very small)
+        if len(compare_sample_idx) < 30 or len(compare_dataset_idx) < 30:
+            warnings.warn(
+                f"Noise levels in {col} of {dataset_name} were not compared because the numbers of rows eligible "
+                f"for noise were only {len(compare_sample_idx)} and {len(compare_dataset_idx)}"
+            )
+            continue
+        if dataset_name == DATASETS.acs.name or dataset_name == DATASETS.cps.name:
+            # Smaller datasets
             rtol = 0.25
         # 1040 has several columns that will have a high percentage of nans
         elif dataset_name == DATASETS.tax_1040.name:

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -68,9 +68,11 @@ def test_generate_dataset_from_sample_and_source(
         config=config,
     )
 
-    # Check same order of magnitude of rows was removed
+    # Check same order of magnitude of rows was removed -- we don't know the
+    # full data size (we would need unnoised data for that), so we just check
+    # for similar lengths
+    assert 0.9 <= (len(noised_dataset) / len(noised_sample)) <= 1.1
     # Check that columns are identical
-    assert np.isclose(len(noised_dataset), len(noised_sample), rtol=0.01)
     assert noised_dataset.columns.equals(noised_sample.columns)
 
     # Check that each columns level of noising are similar

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -900,7 +900,7 @@ def test_make_typos(dummy_dataset, column):
     p_strings_increase_length = 1 - p_strings_do_not_increase_length  # pd.Series
     expected_changed_length = p_row_noise * p_strings_increase_length.mean()
     actual_changed_length = (check_noised.str.len() != check_original.str.len()).mean()
-    is_close_wrapper(actual_changed_length, expected_changed_length, 0.01)
+    is_close_wrapper(actual_changed_length, expected_changed_length, 0.05)
 
     # Check that we did not touch the missing data
     assert (


### PR DESCRIPTION
## Use different seed to noise each shard

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-4276](https://jira.ihme.washington.edu/browse/MIC-4276)

Previously, we used the same seed in each shard. This lead to weird levels of noise correlation between shards, particularly when the shards were small (especially noticeable in survey datasets).

### Testing

I verified that after this change, the ACS and CPS do_not_respond rates were well-calibrated in the RI data, and in the sample data (run across many overall seeds to get a good sample size).