### PR TITLE
Mic-4382/lint-before-tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .[dev]
+      - name: Lint
+        run: |
+          pip install black==22.3.0 isort
+          black . --check --diff
+          isort . --check --verbose --only-modified --diff
       - name: Test
         run: |
           pytest ./tests
@@ -36,8 +41,3 @@ jobs:
       - name: Doctest
         run: |
           make doctest -C docs/
-      - name: Lint
-        run: |
-          pip install black==22.3.0 isort
-          black . --check --diff
-          isort . --check --verbose --only-modified --diff


### PR DESCRIPTION
## Mic-4382/lint-before-tests

### Moves linting before tests in builds.
- *Category*: Other
- *JIRA issue*: [MIC-4382](https://jira.ihme.washington.edu/browse/MIC-4382)

-swaps order or linting and tests for builds.

### Testing
All tests pass

