### PR TITLE
Document copy from household member noise

### DIFF
--- a/docs/source/noise/column_noise.rst
+++ b/docs/source/noise/column_noise.rst
@@ -118,6 +118,12 @@ This noise type is called :code:`copy_from_household_member` in the configuratio
     - The probability that, for a cell in the column being configured, the cell's value is replaced by the corresponding value from a household member.
     - 0.01 (1%)
 
+**Note:** The default value of 0.01 applies to most datasets. However, the
+default value is 0.0 for the SSN column in the W2 & 1099 dataset since SSNs are
+already subject to "borrow a social security number" noise in that dataset, and
+is also 0.0 for the SSN column in the SSA dataset because that column has no
+noise by default.
+
 .. _use_a_nickname:
 
 Use a nickname

--- a/docs/source/noise/column_noise.rst
+++ b/docs/source/noise/column_noise.rst
@@ -92,10 +92,10 @@ It takes one parameter:
 Copy from household member
 --------------------------
 
-When responding to a survey or filling out a form, someone might accidentally
-answer a question about one household member with information about a different
-household member. To capture this type of error, pseudopeople can fill in
-certain fields about a simulant with values from a different member of the
+When responding to a survey or filling out a form, someone might accidentally or
+purposely answer a question about one household member with information about a
+different household member. To capture this type of error, pseudopeople can fill
+in certain fields about a simulant with values from a different member of the
 simulant's household, chosen at random. This type of noise can be applied to
 ages, dates of birth, and social security numbers.
 

--- a/docs/source/noise/column_noise.rst
+++ b/docs/source/noise/column_noise.rst
@@ -101,7 +101,7 @@ ages, dates of birth, and social security numbers.
 
 This noise type is called :code:`copy_from_household_member` in the configuration. It takes one parameter:
 
-.. list-table:: Parameters to the use_nickname noise type
+.. list-table:: Parameters to the copy_from_household_member noise type
   :widths: 1 5 1
   :header-rows: 1
 
@@ -111,6 +111,12 @@ This noise type is called :code:`copy_from_household_member` in the configuratio
   * - :code:`cell_probability`
     - The probability that, for a cell in the column being configured, the cell's value is replaced by the corresponding value from a household member.
     - 0.01 (1%)
+
+Note that simulants who live in group quarters or who live alone are not
+eligible for this type of noise, so for each dataset, there is some maximum
+fraction of rows to which "copy from household member" noise can be applied. If
+the user requests a cell probability that is larger than what's possible,
+pseudopeople will add noise to the maximum possible number of rows.
 
 .. _use_a_nickname:
 

--- a/docs/source/noise/column_noise.rst
+++ b/docs/source/noise/column_noise.rst
@@ -92,12 +92,18 @@ It takes one parameter:
 Copy from household member
 --------------------------
 
-When responding to a questionnaire, someone might accidentally answer with
-information about one household member in a section that was asking about a
-different household member. To capture this type of error, pseudopeopld can fill
-in certain fields about a simulant with values from a different member of the
+When responding to a survey or filling out a form, someone might accidentally
+answer a question about one household member with information about a different
+household member. To capture this type of error, pseudopeople can fill in
+certain fields about a simulant with values from a different member of the
 simulant's household, chosen at random. This type of noise can be applied to
 ages, dates of birth, and social security numbers.
+
+Note that simulants who live in group quarters or who live alone are not
+eligible for this type of noise, so for each dataset, there is some maximum
+fraction of rows to which "copy from household member" noise can be applied. If
+the user requests a cell probability that is larger than what's possible,
+pseudopeople will add noise to the maximum possible number of rows.
 
 This noise type is called :code:`copy_from_household_member` in the configuration. It takes one parameter:
 
@@ -111,12 +117,6 @@ This noise type is called :code:`copy_from_household_member` in the configuratio
   * - :code:`cell_probability`
     - The probability that, for a cell in the column being configured, the cell's value is replaced by the corresponding value from a household member.
     - 0.01 (1%)
-
-Note that simulants who live in group quarters or who live alone are not
-eligible for this type of noise, so for each dataset, there is some maximum
-fraction of rows to which "copy from household member" noise can be applied. If
-the user requests a cell probability that is larger than what's possible,
-pseudopeople will add noise to the maximum possible number of rows.
 
 .. _use_a_nickname:
 

--- a/docs/source/noise/column_noise.rst
+++ b/docs/source/noise/column_noise.rst
@@ -89,6 +89,29 @@ It takes one parameter:
     - The probability that, for a cell in the column being configured, the wrong option is chosen.
     - 0.01 (1%)
 
+Copy from household member
+--------------------------
+
+When responding to a questionnaire, someone might accidentally answer with
+information about one household member in a section that was asking about a
+different household member. To capture this type of error, pseudopeopld can fill
+in certain fields about a simulant with values from a different member of the
+simulant's household, chosen at random. This type of noise can be applied to
+ages, dates of birth, and social security numbers.
+
+This noise type is called :code:`copy_from_household_member` in the configuration. It takes one parameter:
+
+.. list-table:: Parameters to the use_nickname noise type
+  :widths: 1 5 1
+  :header-rows: 1
+
+  * - Parameter
+    - Description
+    - Default
+  * - :code:`cell_probability`
+    - The probability that, for a cell in the column being configured, the cell's value is replaced by the corresponding value from a household member.
+    - 0.01 (1%)
+
 .. _use_a_nickname:
 
 Use a nickname

--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -190,8 +190,9 @@ Noise types for each column
   * - SSN
     - W-2 and 1099, 1040, SSA
     - Borrow a social security number, leave a field blank, copy from household member, write the wrong digits, make OCR errors, make typos
-    - Note that 'borrow a social security number' only applies to the W-2 and 1099 dataset.
-      In the 1040 form, the same noise types apply to the SSN columns for the joint filer and dependents
+    - Note that "borrow a social security number" only applies to the W-2 and 1099 dataset, and by default, "copy from household member" noise is turned off in this dataset (but can be turned on if desired).
+      In the SSA dataset, the SSN column has no column-based noise by default (but can be configured to have noise if desired).
+      In the 1040 form, the same noise types apply to the SSN columns for the joint filer and dependents.
   * - Wages
     - W-2 and 1099
     - Leave a field blank, write the wrong digits, make OCR errors, make typos

--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -75,6 +75,9 @@ The "Config key" column shows the name of the noise type in the :ref:`configurat
   * - Choose the wrong option
     - ``choose_wrong_option``
     - Marking the "Male" box when you meant "Female"
+  * - Copy from household member
+    - ``copy_from_household_member``
+    - Accidentally writing your daughter's age in a box that asked about your son's age on a survey questionnaire
   * - Use a nickname
     - ``use_nickname``
     - Writing 'Alex' instead of legal name 'Alexander'

--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -137,11 +137,11 @@ Noise types for each column
     - Last names use a different list of fake names than the list for first names. In the 1040 form, the same noise types apply to the last name columns for the joint filer and dependents
   * - Age
     - Decennial Census, ACS, CPS
-    - Leave a field blank, misreport age, make OCR errors, make typos
+    - Leave a field blank, copy from household member, misreport age, make OCR errors, make typos
     -
   * - Date of birth
     - Decennial Census, ACS, CPS, WIC, SSA
-    - Leave a field blank, swap month and day, write the wrong digits, make OCR errors, make typos
+    - Leave a field blank, copy from household member, swap month and day, write the wrong digits, make OCR errors, make typos
     -
   * - Street number for any address (physical, mailing, or employer)
     - Decennial Census, ACS, CPS, WIC, W-2 and 1099, 1040
@@ -189,7 +189,7 @@ Noise types for each column
     -
   * - SSN
     - W-2 and 1099, 1040, SSA
-    - Borrow a social security number, leave a field blank, write the wrong digits, make OCR errors, make typos
+    - Borrow a social security number, leave a field blank, copy from household member, write the wrong digits, make OCR errors, make typos
     - Note that 'borrow a social security number' only applies to the W-2 and 1099 dataset.
       In the 1040 form, the same noise types apply to the SSN columns for the joint filer and dependents
   * - Wages


### PR DESCRIPTION
## Document copy from household member noise
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation
- *JIRA issue*: [SSCI-1401](https://jira.ihme.washington.edu/browse/SSCI-1401)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

This noise type was implemented in [MIC-4041](https://jira.ihme.washington.edu/browse/MIC-4041) and is documented in the concept model [here](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_census_synthdata/concept_model.html#noise-functions:~:text=digits%20of%20zip.-,Copy%20from%20within%20Household,-To%20allow%20for).

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Built docs locally.

