### PR TITLE
Change configuration example

### DIFF
--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -64,14 +64,14 @@ Here are the configurations to do this in Python and YAML, respectively:
                     cell_probability: 0.05 # Parameter (and value)
 
 Row-based noise is similar, except that there is no key to specify the column, since it is not column-specific.
-For example to change the probability of row omission in the Decennial Census, the configuration would be:
+For example to change the probability of :ref:`nonresponse <do_not_respond>` in the Decennial Census, the configuration would be:
 
 .. code-block:: python
 
     config = {
         'decennial_census': { # Dataset
             'row_noise': { # "Omit a row" is in the row-based noise category
-                'omit_row': { # Noise type
+                'do_not_respond': { # Noise type
                     'row_probability': 0.05, # Parameter (and value)
                 },
             },
@@ -82,7 +82,7 @@ For example to change the probability of row omission in the Decennial Census, t
 
     decennial_census: # Dataset
         row_noise: # "Omit a row" is in the row-based noise category
-            omit_row: # Noise type
+            do_not_respond: # Noise type
                 row_probability: 0.05 # Parameter (and value)
 
 How to pass configuration to pseudopeople

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -12,6 +12,8 @@ Types of row-based noise:
 .. contents::
    :local:
 
+.. _do_not_respond:
+
 Do not respond
 --------------
 


### PR DESCRIPTION
## Change configuration example

### Description
- *Category*: documentation
- *JIRA issue*: none

Our previous example no longer works, since we removed `omit_row` as a noise type from the Decennial.

### Testing

Built locally.