### PR TITLE
Change input data -> simulated population in docstrings

### DIFF
--- a/docs/source/api_reference/noising/index.rst
+++ b/docs/source/api_reference/noising/index.rst
@@ -11,7 +11,7 @@ For example, :func:`pseudopeople.generate_decennial_census` generates the Decenn
 All of the dataset generation functions have the same (optional) parameters.
 Notable parameters include:
 
-    - a `source` path to the root directory of pseudopeople input data (defaults to using the sample dataset included with pseudopeople).
+    - a `source` path to the root directory of :ref:`pseudopeople simulated population data <simulated_populations_main>` (defaults to using the sample dataset included with pseudopeople).
     - a `config` path to a YAML file, a Python dictionary, or the special value :code:`pseudopeople.NO_NOISE`, to :ref:`override the default configuration <configuration_main>`.
     - a `year` (defaults to 2020).
 

--- a/docs/source/api_reference/noising/index.rst
+++ b/docs/source/api_reference/noising/index.rst
@@ -11,7 +11,7 @@ For example, :func:`pseudopeople.generate_decennial_census` generates the Decenn
 All of the dataset generation functions have the same (optional) parameters.
 Notable parameters include:
 
-    - a `source` path to the root directory of :ref:`pseudopeople simulated population data <simulated_populations_main>` (defaults to using the sample dataset included with pseudopeople).
+    - a `source` path to the root directory of :ref:`pseudopeople simulated population data <simulated_populations_main>` (defaults to using the sample population included with pseudopeople).
     - a `config` path to a YAML file, a Python dictionary, or the special value :code:`pseudopeople.NO_NOISE`, to :ref:`override the default configuration <configuration_main>`.
     - a `year` (defaults to 2020).
 

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -150,7 +150,7 @@ def generate_decennial_census(
     Generates a pseudopeople decennial census dataset which represents simulated
     responses to the US Census Bureau's Census of Population and Housing.
 
-    :param source: The root directory containing pseudopeople input data. Defaults
+    :param source: The root directory containing pseudopeople simulated population data. Defaults
         to the pseudopeople sample datasets directory.
     :param seed: An integer seed for randomness.
     :param config: An optional override to the default configuration. Can be a path
@@ -166,7 +166,7 @@ def generate_decennial_census(
     :param verbose: Log with verbosity if True.
     :return: A pd.DataFrame of simulated decennial census data.
     :raises ConfigurationError: An incorrect config is provided.
-    :raises DataSourceError: An incorrect pseudopeople input data source is provided.
+    :raises DataSourceError: An incorrect pseudopeople simulated population data source is provided.
     """
     user_filters = []
     if year is not None:
@@ -196,7 +196,7 @@ def generate_american_community_survey(
     citizenship, education, income, language proficiency, migration, employment,
     disability, and housing characteristics.
 
-    :param source: The root directory containing pseudopeople input data. Defaults
+    :param source: The root directory containing pseudopeople simulated population data. Defaults
         to the pseudopeople sample datasets directory.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
@@ -211,7 +211,7 @@ def generate_american_community_survey(
     :param verbose: Log with verbosity if True.
     :return: A pd.DataFrame of simulated ACS data.
     :raises ConfigurationError: An incorrect config is provided.
-    :raises DataSourceError: An incorrect pseudopeople input data source is provided.
+    :raises DataSourceError: An incorrect pseudopeople simulated population data source is provided.
     """
     user_filters = []
     if year is not None:
@@ -259,7 +259,7 @@ def generate_current_population_survey(
     activity and income, veteran status, school enrollment, contingent employment,
     worker displacement, job tenure, and more.
 
-    :param source: The root directory containing pseudopeople input data. Defaults
+    :param source: The root directory containing pseudopeople simulated population data. Defaults
         to the pseudopeople sample datasets directory.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
@@ -274,7 +274,7 @@ def generate_current_population_survey(
     :param verbose: Log with verbosity if True.
     :return: A pd.DataFrame of simulated CPS data.
     :raises ConfigurationError: An incorrect config is provided.
-    :raises DataSourceError: An incorrect pseudopeople input data source is provided.
+    :raises DataSourceError: An incorrect pseudopeople simulated population data source is provided.
     """
     user_filters = []
     if year is not None:
@@ -315,7 +315,7 @@ def generate_taxes_w2_and_1099(
     Generates a pseudopeople W2 and 1099 tax dataset which represents simulated
     tax form data.
 
-    :param source: The root directory containing pseudopeople input data. Defaults
+    :param source: The root directory containing pseudopeople simulated population data. Defaults
         to the pseudopeople sample datasets directory.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
@@ -330,7 +330,7 @@ def generate_taxes_w2_and_1099(
     :param verbose: Log with verbosity if True.
     :return: A pd.DataFrame of simulated W2 and 1099 tax data.
     :raises ConfigurationError: An incorrect config is provided.
-    :raises DataSourceError: An incorrect pseudopeople input data source is provided.
+    :raises DataSourceError: An incorrect pseudopeople simulated population data source is provided.
     """
     user_filters = []
     if year is not None:
@@ -362,7 +362,7 @@ def generate_women_infants_and_children(
     is a government benefits program designed to support mothers and young children.
     The main qualifications are income and the presence of young children in the home.
 
-    :param source: The root directory containing pseudopeople input data. Defaults
+    :param source: The root directory containing pseudopeople simulated population data. Defaults
         to the pseudopeople sample datasets directory.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
@@ -377,7 +377,7 @@ def generate_women_infants_and_children(
     :param verbose: Log with verbosity if True.
     :return: A pd.DataFrame of simulated WIC data.
     :raises ConfigurationError: An incorrect config is provided.
-    :raises DataSourceError: An incorrect pseudopeople input data source is provided.
+    :raises DataSourceError: An incorrect pseudopeople simulated population data source is provided.
     """
     user_filters = []
     if year is not None:
@@ -401,7 +401,7 @@ def generate_social_security(
     Generates a pseudopeople SSA dataset which represents simulated Social Security
     Administration (SSA) data.
 
-    :param source: The root directory containing pseudopeople input data. Defaults
+    :param source: The root directory containing pseudopeople simulated population data. Defaults
         to the pseudopeople sample datasets directory.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
@@ -412,7 +412,7 @@ def generate_social_security(
     :param verbose: Log with verbosity if True.
     :return: A pd.DataFrame of simulated SSA data.
     :raises ConfigurationError: An incorrect config is provided.
-    :raises DataSourceError: An incorrect pseudopeople input data source is provided.
+    :raises DataSourceError: An incorrect pseudopeople simulated population data source is provided.
     """
     user_filters = []
     if year is not None:
@@ -442,7 +442,7 @@ def generate_taxes_1040(
     Generates a pseudopeople 1040 tax dataset which represents simulated
     tax form data.
 
-    :param source: The root directory containing pseudopeople input data. Defaults
+    :param source: The root directory containing pseudopeople simulated population data. Defaults
         to the pseudopeople sample datasets directory.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
@@ -457,7 +457,7 @@ def generate_taxes_1040(
     :param verbose: Log with verbosity if True.
     :return: A pd.DataFrame of simulated 1040 tax data.
     :raises ConfigurationError: An incorrect config is provided.
-    :raises DataSourceError: An incorrect pseudopeople input data source is provided.
+    :raises DataSourceError: An incorrect pseudopeople simulated population data source is provided.
     """
     user_filters = []
     if year is not None:

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -151,7 +151,7 @@ def generate_decennial_census(
     responses to the US Census Bureau's Census of Population and Housing.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to the pseudopeople sample population directory.
+        to using the pseudopeople sample population.
     :param seed: An integer seed for randomness.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -151,7 +151,7 @@ def generate_decennial_census(
     responses to the US Census Bureau's Census of Population and Housing.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to using the pseudopeople sample population.
+        to using the included sample population.
     :param seed: An integer seed for randomness.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -197,7 +197,7 @@ def generate_american_community_survey(
     disability, and housing characteristics.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to the pseudopeople sample population directory.
+        to using the included sample population.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -260,7 +260,7 @@ def generate_current_population_survey(
     worker displacement, job tenure, and more.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to the pseudopeople sample population directory.
+        to using the included sample population.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -316,7 +316,7 @@ def generate_taxes_w2_and_1099(
     tax form data.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to the pseudopeople sample population directory.
+        to using the included sample population.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -363,7 +363,7 @@ def generate_women_infants_and_children(
     The main qualifications are income and the presence of young children in the home.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to the pseudopeople sample population directory.
+        to using the included sample population.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -402,7 +402,7 @@ def generate_social_security(
     Administration (SSA) data.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to the pseudopeople sample population directory.
+        to using the included sample population.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -443,7 +443,7 @@ def generate_taxes_1040(
     tax form data.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to the pseudopeople sample population directory.
+        to using the included sample population.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -151,7 +151,7 @@ def generate_decennial_census(
     responses to the US Census Bureau's Census of Population and Housing.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to using the included sample population.
+        to using the included sample population when source is `None`.
     :param seed: An integer seed for randomness.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -197,7 +197,7 @@ def generate_american_community_survey(
     disability, and housing characteristics.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to using the included sample population.
+        to using the included sample population when source is `None`.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -260,7 +260,7 @@ def generate_current_population_survey(
     worker displacement, job tenure, and more.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to using the included sample population.
+        to using the included sample population when source is `None`.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -316,7 +316,7 @@ def generate_taxes_w2_and_1099(
     tax form data.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to using the included sample population.
+        to using the included sample population when source is `None`.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -363,7 +363,7 @@ def generate_women_infants_and_children(
     The main qualifications are income and the presence of young children in the home.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to using the included sample population.
+        to using the included sample population when source is `None`.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -402,7 +402,7 @@ def generate_social_security(
     Administration (SSA) data.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to using the included sample population.
+        to using the included sample population when source is `None`.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -443,7 +443,7 @@ def generate_taxes_1040(
     tax form data.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to using the included sample population.
+        to using the included sample population when source is `None`.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -151,7 +151,7 @@ def generate_decennial_census(
     responses to the US Census Bureau's Census of Population and Housing.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to the pseudopeople sample datasets directory.
+        to the pseudopeople sample population directory.
     :param seed: An integer seed for randomness.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -197,7 +197,7 @@ def generate_american_community_survey(
     disability, and housing characteristics.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to the pseudopeople sample datasets directory.
+        to the pseudopeople sample population directory.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -260,7 +260,7 @@ def generate_current_population_survey(
     worker displacement, job tenure, and more.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to the pseudopeople sample datasets directory.
+        to the pseudopeople sample population directory.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -316,7 +316,7 @@ def generate_taxes_w2_and_1099(
     tax form data.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to the pseudopeople sample datasets directory.
+        to the pseudopeople sample population directory.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -363,7 +363,7 @@ def generate_women_infants_and_children(
     The main qualifications are income and the presence of young children in the home.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to the pseudopeople sample datasets directory.
+        to the pseudopeople sample population directory.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -402,7 +402,7 @@ def generate_social_security(
     Administration (SSA) data.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to the pseudopeople sample datasets directory.
+        to the pseudopeople sample population directory.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.
@@ -443,7 +443,7 @@ def generate_taxes_1040(
     tax form data.
 
     :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to the pseudopeople sample datasets directory.
+        to the pseudopeople sample population directory.
     :param seed: An integer seed for randomness. Defaults to 0.
     :param config: An optional override to the default configuration. Can be a path
         to a configuration YAML file or a dictionary.


### PR DESCRIPTION
## Change input data -> simulated population in docstrings
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation
- *JIRA issue*: [SSCI-1523](https://jira.ihme.washington.edu/browse/SSCI-1523)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
-->

In the API Reference, changes all references to "pseudopeople input data" to "pseudopeople simulated population data," and changes "sample dataset" or "sample datasets" to "sample population". Also adds a link back to the Simulated populations page from the main Dataset Generation Functions page.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Built docs locally.
