### PR TITLE
Docs: Clean up `generate_x` docstrings

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -178,46 +178,59 @@ def generate_decennial_census(
     verbose: bool = False,
 ) -> pd.DataFrame:
     """
-    Generates a pseudopeople decennial census dataset which represents simulated
-    responses to the US Census Bureau's Census of Population and Housing.
+    Generates a pseudopeople decennial census dataset which represents
+    simulated responses to the US Census Bureau's Census of Population
+    and Housing.
 
     :param source:
-        The root directory containing pseudopeople simulated population data.
-        Defaults to using the included sample population when source is `None`.
+
+        The root directory containing pseudopeople simulated population
+        data. Defaults to using the included sample population when
+        source is `None`.
 
     :param seed:
+
         An integer seed for randomness. Defaults to 0.
 
     :param config:
-        An optional override to the default configuration. Can be a path to a
-        configuration YAML file, a configuration dictionary, or the sentinel
-        value `pseudopeople.NO_NOISE`, which will generate a dataset without any
-        configurable noise.
+
+        An optional override to the default configuration. Can be a path
+        to a configuration YAML file, a configuration dictionary, or the
+        sentinel value `pseudopeople.NO_NOISE`, which will generate a
+        dataset without any configurable noise.
 
     :param year:
-        The year for which to generate a simulated decennial census of the
-        simulated population (format YYYY, e.g., 2030). Must be a decennial year
-        (e.g., 2020, 2030, 2040). Will raise a `ValueError` if there is no data
-        for the specified year. Default is 2020. If `None` is passed instead,
-        data for all available years are included in the returned dataset.
+
+        The year for which to generate a simulated decennial census of
+        the simulated population (format YYYY, e.g., 2030). Must be a
+        decennial year (e.g., 2020, 2030, 2040). Will raise a
+        `ValueError` if there is no data for the specified year. Default
+        is 2020. If `None` is passed instead, data for all available
+        years are included in the returned dataset.
 
     :param state:
+
         The state string to include in the dataset. Either full name or
-        abbreviation (e.g., "Ohio" or "OH"). Will raise a ValueError if there is
-        no data for this state. If None is provided, data for all locations are
-        included in the dataset.
+        abbreviation (e.g., "Ohio" or "OH"). Will raise a ValueError if
+        there is no data for this state. If None is provided, data for
+        all locations are included in the dataset.
 
     :param verbose:
+
         Log with verbosity if `True`. Default is `False`.
 
     :return:
+
         A `pandas.DataFrame` of simulated decennial census data.
 
     :raises ConfigurationError:
+
         An incorrect config is provided.
 
     :raises DataSourceError:
-        An incorrect pseudopeople simulated population data source is provided.
+
+        An incorrect pseudopeople simulated population data source is
+        provided.
     """
     user_filters = []
     if year is not None:
@@ -238,53 +251,66 @@ def generate_american_community_survey(
     verbose: bool = False,
 ) -> pd.DataFrame:
     """
-    Generates a pseudopeople ACS dataset which represents simulated responses to
-    the ACS survey.
+    Generates a pseudopeople ACS dataset which represents simulated
+    responses to the ACS survey.
 
-    The American Community Survey (ACS) is an ongoing household survey conducted by
-    the US Census Bureau that gathers information on a rolling basis about
-    American community populations. Information collected includes ancestry,
-    citizenship, education, income, language proficiency, migration, employment,
-    disability, and housing characteristics.
+    The American Community Survey (ACS) is an ongoing household survey
+    conducted by the US Census Bureau that gathers information on a
+    rolling basis about American community populations. Information
+    collected includes ancestry, citizenship, education, income,
+    language proficiency, migration, employment, disability, and housing
+    characteristics.
 
     :param source:
-        The root directory containing pseudopeople simulated population data.
-        Defaults to using the included sample population when source is `None`.
+
+        The root directory containing pseudopeople simulated population
+        data. Defaults to using the included sample population when
+        source is `None`.
 
     :param seed:
+
         An integer seed for randomness. Defaults to 0.
 
     :param config:
-        An optional override to the default configuration. Can be a path to a
-        configuration YAML file, a configuration dictionary, or the sentinel
-        value `pseudopeople.NO_NOISE`, which will generate a dataset without any
-        configurable noise.
+
+        An optional override to the default configuration. Can be a path
+        to a configuration YAML file, a configuration dictionary, or the
+        sentinel value `pseudopeople.NO_NOISE`, which will generate a
+        dataset without any configurable noise.
 
     :param year:
-        The year for which to generate simulated American Community Surveys of
-        the simulated population (format YYYY, e.g., 2036); the simulated
-        dataset will contain records for surveys conducted on any date in the
-        specified year. Will raise a `ValueError` if there is no data for this
-        year. Default is 2020. If `None` is passed instead, data for all
-        available years are included in the returned dataset.
+
+        The year for which to generate simulated American Community
+        Surveys of the simulated population (format YYYY, e.g., 2036);
+        the simulated dataset will contain records for surveys conducted
+        on any date in the specified year. Will raise a `ValueError` if
+        there is no data for this year. Default is 2020. If `None` is
+        passed instead, data for all available years are included in the
+        returned dataset.
 
     :param state:
+
         The state string to include in the dataset. Either full name or
-        abbreviation (e.g., "Ohio" or "OH"). Will raise a ValueError if there is
-        no data for this state. If None is provided, data from all locations are
-        included in the dataset.
+        abbreviation (e.g., "Ohio" or "OH"). Will raise a ValueError if
+        there is no data for this state. If None is provided, data from
+        all locations are included in the dataset.
 
     :param verbose:
+
         Log with verbosity if `True`. Default is `False`.
 
     :return:
+
         A `pandas.DataFrame` of simulated ACS data.
 
     :raises ConfigurationError:
+
         An incorrect config is provided.
 
     :raises DataSourceError:
-        An incorrect pseudopeople simulated population data source is provided.
+
+        An incorrect pseudopeople simulated population data source is
+        provided.
     """
     user_filters = []
     if year is not None:
@@ -322,36 +348,69 @@ def generate_current_population_survey(
     verbose: bool = False,
 ) -> pd.DataFrame:
     """
-    Generates a pseudopeople CPS dataset which represents simulated responses to
-    the CPS survey.
 
-    The Current Population Survey (CPS) is a household survey conducted by the
-    US Census Bureau and the US Bureau of Labor Statistics. This survey is administered
-    by Census Bureau field representatives across the country through both personal
-    and telephone interviews. CPS collects labor force data, such as annual work
-    activity and income, veteran status, school enrollment, contingent employment,
-    worker displacement, job tenure, and more.
+    Generates a pseudopeople CPS dataset which represents simulated
+    responses to the CPS survey.
 
-    :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to using the included sample population when source is `None`.
-    :param seed: An integer seed for randomness. Defaults to 0.
-    :param config: An optional override to the default configuration. Can be a path
-        to a configuration YAML file, a configuration dictionary,
-        or the sentinel value `pseudopeople.NO_NOISE`, which will generate a
+    The Current Population Survey (CPS) is a household survey conducted
+    by the US Census Bureau and the US Bureau of Labor Statistics. This
+    survey is administered by Census Bureau field representatives across
+    the country through both personal and telephone interviews. CPS
+    collects labor force data, such as annual work activity and income,
+    veteran status, school enrollment, contingent employment, worker
+    displacement, job tenure, and more.
+
+    :param source:
+
+        The root directory containing pseudopeople simulated population
+        data. Defaults to using the included sample population when
+        source is `None`.
+
+    :param seed:
+
+        An integer seed for randomness. Defaults to 0.
+
+    :param config:
+
+        An optional override to the default configuration. Can be a path
+        to a configuration YAML file, a configuration dictionary, or the
+        sentinel value `pseudopeople.NO_NOISE`, which will generate a
         dataset without any configurable noise.
-    :param year: The year for which to generate simulated Current Population Surveys of the simulated population (format YYYY, e.g., 2036);
-        the simulated dataset will contain records for surveys conducted on any date in the specified year.
-        Will
-        raise a `ValueError` if there is no data for this year. Default is 2020. If `None` is passed instead, data for all available years are
-        included in the returned dataset.
-    :param state: The state string to include in the dataset. Either full name or
-        abbreviation (e.g., "Ohio" or "OH"). Will raise a ValueError if there is
-        no data for this state. If None is provided, data from all locations are
-        included in the dataset.
-    :param verbose: Log with verbosity if `True`. Default is `False`.
-    :return: A `pandas.DataFrame` of simulated CPS data.
-    :raises ConfigurationError: An incorrect config is provided.
-    :raises DataSourceError: An incorrect pseudopeople simulated population data source is provided.
+
+    :param year:
+
+        The year for which to generate simulated Current Population
+        Surveys of the simulated population (format YYYY, e.g., 2036);
+        the simulated dataset will contain records for surveys conducted
+        on any date in the specified year. Will raise a `ValueError` if
+        there is no data for this year. Default is 2020. If `None` is
+        passed instead, data for all available years are included in the
+        returned dataset.
+
+    :param state:
+
+        The state string to include in the dataset. Either full name or
+        abbreviation (e.g., "Ohio" or "OH"). Will raise a ValueError if
+        there is no data for this state. If None is provided, data from
+        all locations are included in the dataset.
+
+    :param verbose:
+
+        Log with verbosity if `True`. Default is `False`.
+
+    :return:
+
+        A `pandas.DataFrame` of simulated CPS data.
+
+    :raises ConfigurationError:
+
+        An incorrect config is provided.
+
+    :raises DataSourceError:
+
+        An incorrect pseudopeople simulated population data source is
+        provided.
+
     """
     user_filters = []
     if year is not None:

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -348,7 +348,6 @@ def generate_current_population_survey(
     verbose: bool = False,
 ) -> pd.DataFrame:
     """
-
     Generates a pseudopeople CPS dataset which represents simulated
     responses to the CPS survey.
 
@@ -410,7 +409,6 @@ def generate_current_population_survey(
 
         An incorrect pseudopeople simulated population data source is
         provided.
-
     """
     user_filters = []
     if year is not None:
@@ -448,29 +446,58 @@ def generate_taxes_w2_and_1099(
     verbose: bool = False,
 ) -> pd.DataFrame:
     """
-    Generates a pseudopeople W2 and 1099 tax dataset which represents simulated
-    tax form data.
+    Generates a pseudopeople W2 and 1099 tax dataset which represents
+    simulated tax form data.
 
-    :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to using the included sample population when source is `None`.
-    :param seed: An integer seed for randomness. Defaults to 0.
-    :param config: An optional override to the default configuration. Can be a path
-        to a configuration YAML file, a configuration dictionary,
-        or the sentinel value `pseudopeople.NO_NOISE`, which will generate a
+    :param source:
+
+        The root directory containing pseudopeople simulated population
+        data. Defaults to using the included sample population when
+        source is `None`.
+
+    :param seed:
+
+        An integer seed for randomness. Defaults to 0.
+
+    :param config:
+
+        An optional override to the default configuration. Can be a path
+        to a configuration YAML file, a configuration dictionary, or the
+        sentinel value `pseudopeople.NO_NOISE`, which will generate a
         dataset without any configurable noise.
-    :param year: The tax year for which to generate records (format YYYY, e.g., 2036);
-        the simulated dataset will contain the W2 & 1099 tax forms filed by simulated employers for the specified year.
-        Will raise
-        a `ValueError` if there is no data for this year. Default is 2020. If `None` is passed instead, data for all available years are
-        included in the returned dataset.
-    :param state: The state string to include in the dataset. Either full name or
-        abbreviation (e.g., "Ohio" or "OH"). Will raise a ValueError if there is
-        no data for this state. If None is provided, data from all locations are
-        included in the dataset.
-    :param verbose: Log with verbosity if `True`. Default is `False`.
-    :return: A `pandas.DataFrame` of simulated W2 and 1099 tax data.
-    :raises ConfigurationError: An incorrect config is provided.
-    :raises DataSourceError: An incorrect pseudopeople simulated population data source is provided.
+
+    :param year:
+
+        The tax year for which to generate records (format YYYY, e.g.,
+        2036); the simulated dataset will contain the W2 & 1099 tax
+        forms filed by simulated employers for the specified year. Will
+        raise a `ValueError` if there is no data for this year. Default
+        is 2020. If `None` is passed instead, data for all available
+        years are included in the returned dataset.
+
+    :param state:
+
+        The state string to include in the dataset. Either full name or
+        abbreviation (e.g., "Ohio" or "OH"). Will raise a ValueError if
+        there is no data for this state. If None is provided, data from
+        all locations are included in the dataset.
+
+    :param verbose:
+
+        Log with verbosity if `True`. Default is `False`.
+
+    :return:
+
+        A `pandas.DataFrame` of simulated W2 and 1099 tax data.
+
+    :raises ConfigurationError:
+
+        An incorrect config is provided.
+
+    :raises DataSourceError:
+
+        An incorrect pseudopeople simulated population data source is
+        provided.
     """
     user_filters = []
     if year is not None:
@@ -494,34 +521,66 @@ def generate_women_infants_and_children(
     verbose: bool = False,
 ) -> pd.DataFrame:
     """
-    Generates a pseudopeople WIC dataset which represents a simulated version of
-    the administrative data that would be recorded by WIC. This is a yearly file
-    of information about all simulants enrolled in the program as of the end of that year.
+    Generates a pseudopeople WIC dataset which represents a simulated
+    version of the administrative data that would be recorded by WIC.
+    This is a yearly file of information about all simulants enrolled in
+    the program as of the end of that year.
 
-    The Special Supplemental Nutrition Program for Women, Infants, and Children (WIC)
-    is a government benefits program designed to support mothers and young children.
-    The main qualifications are income and the presence of young children in the home.
+    The Special Supplemental Nutrition Program for Women, Infants, and
+    Children (WIC) is a government benefits program designed to support
+    mothers and young children. The main qualifications are income and
+    the presence of young children in the home.
 
-    :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to using the included sample population when source is `None`.
-    :param seed: An integer seed for randomness. Defaults to 0.
-    :param config: An optional override to the default configuration. Can be a path
-        to a configuration YAML file, a configuration dictionary,
-        or the sentinel value `pseudopeople.NO_NOISE`, which will generate a
+    :param source:
+
+        The root directory containing pseudopeople simulated population
+        data. Defaults to using the included sample population when
+        source is `None`.
+
+    :param seed:
+
+        An integer seed for randomness. Defaults to 0.
+
+    :param config:
+
+        An optional override to the default configuration. Can be a path
+        to a configuration YAML file, a configuration dictionary, or the
+        sentinel value `pseudopeople.NO_NOISE`, which will generate a
         dataset without any configurable noise.
-    :param year: The year for which to generate WIC administrative records (format YYYY, e.g., 2036);
-        the simulated dataset will contain records for simulants enrolled in WIC at the end of the specified year (or on May 1, 2041 if `year=2041` since that is the end date of the simulation).
-        Will raise a
-        `ValueError` if there is no data for this year. Default is 2020. If `None` is passed instead, data for all available years are
-        included in the returned dataset.
-    :param state: The state string to include in the dataset. Either full name or
-        abbreviation (e.g., "Ohio" or "OH"). Will raise a ValueError if there is
-        no data for this state. If None is provided, data from all locations are
-        included in the dataset.
-    :param verbose: Log with verbosity if `True`. Default is `False`.
-    :return: A `pandas.DataFrame` of simulated WIC data.
-    :raises ConfigurationError: An incorrect config is provided.
-    :raises DataSourceError: An incorrect pseudopeople simulated population data source is provided.
+
+    :param year:
+
+        The year for which to generate WIC administrative records
+        (format YYYY, e.g., 2036); the simulated dataset will contain
+        records for simulants enrolled in WIC at the end of the
+        specified year (or on May 1, 2041 if `year=2041` since that is
+        the end date of the simulation). Will raise a `ValueError` if
+        there is no data for this year. Default is 2020. If `None` is
+        passed instead, data for all available years are included in the
+        returned dataset.
+
+    :param state:
+
+        The state string to include in the dataset. Either full name or
+        abbreviation (e.g., "Ohio" or "OH"). Will raise a ValueError if
+        there is no data for this state. If None is provided, data from
+        all locations are included in the dataset.
+
+    :param verbose:
+
+        Log with verbosity if `True`. Default is `False`.
+    :return:
+
+        A `pandas.DataFrame` of simulated WIC data.
+
+    :raises ConfigurationError:
+
+        An incorrect config is provided.
+
+    :raises DataSourceError:
+
+        An incorrect pseudopeople simulated population data source is
+        provided.
     """
     user_filters = []
     if year is not None:
@@ -542,24 +601,51 @@ def generate_social_security(
     verbose: bool = False,
 ) -> pd.DataFrame:
     """
-    Generates a pseudopeople SSA dataset which represents simulated Social Security
-    Administration (SSA) data.
+    Generates a pseudopeople SSA dataset which represents simulated
+    Social Security Administration (SSA) data.
 
-    :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to using the included sample population when source is `None`.
-    :param seed: An integer seed for randomness. Defaults to 0.
-    :param config: An optional override to the default configuration. Can be a path
-        to a configuration YAML file, a configuration dictionary,
-        or the sentinel value `pseudopeople.NO_NOISE`, which will generate a
+    :param source:
+
+        The root directory containing pseudopeople simulated population
+        data. Defaults to using the included sample population when
+        source is `None`.
+
+    :param seed:
+
+        An integer seed for randomness. Defaults to 0.
+
+    :param config:
+
+        An optional override to the default configuration. Can be a path
+        to a configuration YAML file, a configuration dictionary, or the
+        sentinel value `pseudopeople.NO_NOISE`, which will generate a
         dataset without any configurable noise.
-    :param year: The final year of simulated social security records to include in the dataset (format YYYY, e.g., 2036); will also
-        include records from all previous years. Will raise a `ValueError` if there is no data for
-        the specified year or any prior years. Default is 2020. If `None` is passed instead, data for all available years are
-        included in the returned dataset.
-    :param verbose: Log with verbosity if `True`. Default is `False`.
-    :return: A `pandas.DataFrame` of simulated SSA data.
-    :raises ConfigurationError: An incorrect config is provided.
-    :raises DataSourceError: An incorrect pseudopeople simulated population data source is provided.
+
+    :param year:
+
+        The final year of simulated social security records to include
+        in the dataset (format YYYY, e.g., 2036); will also include
+        records from all previous years. Will raise a `ValueError` if
+        there is no data for the specified year or any prior years.
+        Default is 2020. If `None` is passed instead, data for all
+        available years are included in the returned dataset.
+
+    :param verbose:
+
+        Log with verbosity if `True`. Default is `False`.
+
+    :return:
+
+        A `pandas.DataFrame` of simulated SSA data.
+
+    :raises ConfigurationError:
+
+        An incorrect config is provided.
+
+    :raises DataSourceError:
+
+        An incorrect pseudopeople simulated population data source is
+        provided.
     """
     user_filters = []
     if year is not None:
@@ -589,25 +675,55 @@ def generate_taxes_1040(
     Generates a pseudopeople 1040 tax dataset which represents simulated
     tax form data.
 
-    :param source: The root directory containing pseudopeople simulated population data. Defaults
-        to using the included sample population when source is `None`.
-    :param seed: An integer seed for randomness. Defaults to 0.
-    :param config: An optional override to the default configuration. Can be a path
-        to a configuration YAML file, a configuration dictionary,
-        or the sentinel value `pseudopeople.NO_NOISE`, which will generate a
+    :param source:
+
+        The root directory containing pseudopeople simulated population
+        data. Defaults to using the included sample population when
+        source is `None`.
+
+    :param seed:
+
+        An integer seed for randomness. Defaults to 0.
+
+    :param config:
+
+        An optional override to the default configuration. Can be a path
+        to a configuration YAML file, a configuration dictionary, or the
+        sentinel value `pseudopeople.NO_NOISE`, which will generate a
         dataset without any configurable noise.
-    :param year: The tax year for which to generate records (format YYYY, e.g., 2036);
-        the simulated dataset will contain the 1040 tax forms filed by simulants for the specified year. Will raise
-        a `ValueError` if there is no data for this year. Default is 2020. If `None` is passed instead, data for all available years are
+
+    :param year:
+
+        The tax year for which to generate records (format YYYY, e.g.,
+        2036); the simulated dataset will contain the 1040 tax forms
+        filed by simulants for the specified year. Will raise a
+        `ValueError` if there is no data for this year. Default is 2020.
+        If `None` is passed instead, data for all available years are
         included in the returned dataset.
-    :param state: The state string to include in the dataset. Either full name or
-        abbreviation (e.g., "Ohio" or "OH"). Will raise a ValueError if there is
-        no data with this state. If None is provided, data from all locations are
-        included in the dataset.
-    :param verbose: Log with verbosity if `True`. Default is `False`.
-    :return: A `pandas.DataFrame` of simulated 1040 tax data.
-    :raises ConfigurationError: An incorrect config is provided.
-    :raises DataSourceError: An incorrect pseudopeople simulated population data source is provided.
+
+    :param state:
+
+        The state string to include in the dataset. Either full name or
+        abbreviation (e.g., "Ohio" or "OH"). Will raise a ValueError if
+        there is no data with this state. If None is provided, data from
+        all locations are included in the dataset.
+
+    :param verbose:
+
+        Log with verbosity if `True`. Default is `False`.
+
+    :return:
+
+        A `pandas.DataFrame` of simulated 1040 tax data.
+
+    :raises ConfigurationError:
+
+        An incorrect config is provided.
+
+    :raises DataSourceError:
+
+        An incorrect pseudopeople simulated population data source is
+        provided.
     """
     user_filters = []
     if year is not None:


### PR DESCRIPTION
## Docs: Clean up `generate_x` docstrings
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation
- *JIRA issue*: [SSCI-1520](https://jira.ihme.washington.edu/browse/SSCI-1520)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Wrap docstrings for `generate_x` functions at 72 chars, as per [PEP-8](https://peps.python.org/pep-0008/#maximum-line-length), and add whitespace for readability.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [ ] all tests pass (`pytest --runslow`)

Built docs locally
