### PR TITLE
Docsrings: Add ValueError to :raises:

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -226,11 +226,11 @@ def generate_decennial_census(
 
     :raises ConfigurationError:
 
-        An incorrect config is provided.
+        An invalid config is provided.
 
     :raises DataSourceError:
 
-        An incorrect pseudopeople simulated population data source is
+        An invalid pseudopeople simulated population data source is
         provided.
 
     :raises ValueError:
@@ -312,11 +312,11 @@ def generate_american_community_survey(
 
     :raises ConfigurationError:
 
-        An incorrect config is provided.
+        An invalid config is provided.
 
     :raises DataSourceError:
 
-        An incorrect pseudopeople simulated population data source is
+        An invalid pseudopeople simulated population data source is
         provided.
 
     :raises ValueError:
@@ -416,11 +416,11 @@ def generate_current_population_survey(
 
     :raises ConfigurationError:
 
-        An incorrect config is provided.
+        An invalid config is provided.
 
     :raises DataSourceError:
 
-        An incorrect pseudopeople simulated population data source is
+        An invalid pseudopeople simulated population data source is
         provided.
 
     :raises ValueError:
@@ -511,11 +511,11 @@ def generate_taxes_w2_and_1099(
 
     :raises ConfigurationError:
 
-        An incorrect config is provided.
+        An invalid config is provided.
 
     :raises DataSourceError:
 
-        An incorrect pseudopeople simulated population data source is
+        An invalid pseudopeople simulated population data source is
         provided.
 
     :raises ValueError:
@@ -602,11 +602,11 @@ def generate_women_infants_and_children(
 
     :raises ConfigurationError:
 
-        An incorrect config is provided.
+        An invalid config is provided.
 
     :raises DataSourceError:
 
-        An incorrect pseudopeople simulated population data source is
+        An invalid pseudopeople simulated population data source is
         provided.
 
     :raises ValueError:
@@ -671,11 +671,11 @@ def generate_social_security(
 
     :raises ConfigurationError:
 
-        An incorrect config is provided.
+        An invalid config is provided.
 
     :raises DataSourceError:
 
-        An incorrect pseudopeople simulated population data source is
+        An invalid pseudopeople simulated population data source is
         provided.
 
     :raises ValueError:
@@ -755,11 +755,11 @@ def generate_taxes_1040(
 
     :raises ConfigurationError:
 
-        An incorrect config is provided.
+        An invalid config is provided.
 
     :raises DataSourceError:
 
-        An incorrect pseudopeople simulated population data source is
+        An invalid pseudopeople simulated population data source is
         provided.
 
     :raises ValueError:

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -226,7 +226,7 @@ def generate_decennial_census(
 
     :raises ConfigurationError:
 
-        An invalid config is provided.
+        An invalid `config` is provided.
 
     :raises DataSourceError:
 
@@ -312,7 +312,7 @@ def generate_american_community_survey(
 
     :raises ConfigurationError:
 
-        An invalid config is provided.
+        An invalid `config` is provided.
 
     :raises DataSourceError:
 
@@ -416,7 +416,7 @@ def generate_current_population_survey(
 
     :raises ConfigurationError:
 
-        An invalid config is provided.
+        An invalid `config` is provided.
 
     :raises DataSourceError:
 
@@ -511,7 +511,7 @@ def generate_taxes_w2_and_1099(
 
     :raises ConfigurationError:
 
-        An invalid config is provided.
+        An invalid `config` is provided.
 
     :raises DataSourceError:
 
@@ -602,7 +602,7 @@ def generate_women_infants_and_children(
 
     :raises ConfigurationError:
 
-        An invalid config is provided.
+        An invalid `config` is provided.
 
     :raises DataSourceError:
 
@@ -671,7 +671,7 @@ def generate_social_security(
 
     :raises ConfigurationError:
 
-        An invalid config is provided.
+        An invalid `config` is provided.
 
     :raises DataSourceError:
 
@@ -755,7 +755,7 @@ def generate_taxes_1040(
 
     :raises ConfigurationError:
 
-        An invalid config is provided.
+        An invalid `config` is provided.
 
     :raises DataSourceError:
 

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -234,6 +234,10 @@ def generate_decennial_census(
 
         An incorrect pseudopeople simulated population data source is
         provided.
+
+    :raises ValueError:
+
+        There is no data for the specified year or state.
     """
     user_filters = []
     if year is not None:
@@ -317,6 +321,10 @@ def generate_american_community_survey(
 
         An incorrect pseudopeople simulated population data source is
         provided.
+
+    :raises ValueError:
+
+        There is no data for the specified year or state.
     """
     user_filters = []
     if year is not None:
@@ -418,6 +426,10 @@ def generate_current_population_survey(
 
         An incorrect pseudopeople simulated population data source is
         provided.
+
+    :raises ValueError:
+
+        There is no data for the specified year or state.
     """
     user_filters = []
     if year is not None:
@@ -510,6 +522,10 @@ def generate_taxes_w2_and_1099(
 
         An incorrect pseudopeople simulated population data source is
         provided.
+
+    :raises ValueError:
+
+        There is no data for the specified year or state.
     """
     user_filters = []
     if year is not None:
@@ -598,6 +614,10 @@ def generate_women_infants_and_children(
 
         An incorrect pseudopeople simulated population data source is
         provided.
+
+    :raises ValueError:
+
+        There is no data for the specified year or state.
     """
     user_filters = []
     if year is not None:
@@ -663,6 +683,10 @@ def generate_social_security(
 
         An incorrect pseudopeople simulated population data source is
         provided.
+
+    :raises ValueError:
+
+        There is no data for the specified year or any prior years.
     """
     user_filters = []
     if year is not None:
@@ -744,6 +768,10 @@ def generate_taxes_1040(
 
         An incorrect pseudopeople simulated population data source is
         provided.
+
+    :raises ValueError:
+
+        There is no data for the specified year or state.
     """
     user_filters = []
     if year is not None:

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -235,8 +235,8 @@ def generate_decennial_census(
 
     :raises ValueError:
 
-        The simulated population has no data for this dataset in the specified year or
-        state.
+        The simulated population has no data for this dataset in the
+        specified year or state.
     """
     user_filters = []
     if year is not None:
@@ -321,8 +321,8 @@ def generate_american_community_survey(
 
     :raises ValueError:
 
-        The simulated population has no data for the specified year or
-        state.
+        The simulated population has no data for this dataset in the
+        specified year or state.
     """
     user_filters = []
     if year is not None:
@@ -425,8 +425,8 @@ def generate_current_population_survey(
 
     :raises ValueError:
 
-        The simulated population has no data for the specified year or
-        state.
+        The simulated population has no data for this dataset in the
+        specified year or state.
     """
     user_filters = []
     if year is not None:
@@ -520,8 +520,8 @@ def generate_taxes_w2_and_1099(
 
     :raises ValueError:
 
-        The simulated population has no data for the specified year or
-        state.
+        The simulated population has no data for this dataset in the
+        specified year or state.
     """
     user_filters = []
     if year is not None:
@@ -611,8 +611,8 @@ def generate_women_infants_and_children(
 
     :raises ValueError:
 
-        The simulated population has no data for the specified year or
-        state.
+        The simulated population has no data for this dataset in the
+        specified year or state.
     """
     user_filters = []
     if year is not None:
@@ -680,8 +680,8 @@ def generate_social_security(
 
     :raises ValueError:
 
-        The simulated population has no data for the specified year or
-        any prior years.
+        The simulated population has no data for this dataset in the
+        specified year or any prior years.
     """
     user_filters = []
     if year is not None:
@@ -764,8 +764,8 @@ def generate_taxes_1040(
 
     :raises ValueError:
 
-        The simulated population has no data for the specified year or
-        state.
+        The simulated population has no data for this dataset in the
+        specified year or state.
     """
     user_filters = []
     if year is not None:

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -203,10 +203,9 @@ def generate_decennial_census(
 
         The year for which to generate a simulated decennial census of
         the simulated population (format YYYY, e.g., 2030). Must be a
-        decennial year (e.g., 2020, 2030, 2040). Will raise a
-        `ValueError` if there is no data for the specified year. Default
-        is 2020. If `None` is passed instead, data for all available
-        years are included in the returned dataset.
+        decennial year (e.g., 2020, 2030, 2040). Default is 2020. If
+        `None` is passed instead, data for all available years are
+        included in the returned dataset.
 
     :param state:
 
@@ -215,8 +214,7 @@ def generate_decennial_census(
         all available US states. The returned dataset will contain data
         for simulants living in the specified state on Census Day (April
         1) of the specified year. Can be a full state name or a state
-        abbreviation (e.g., "Ohio" or "OH"). Will raise a `ValueError`
-        if there is no data for this state.
+        abbreviation (e.g., "Ohio" or "OH").
 
     :param verbose:
 
@@ -290,8 +288,7 @@ def generate_american_community_survey(
         The year for which to generate simulated American Community
         Surveys of the simulated population (format YYYY, e.g., 2036);
         the simulated dataset will contain records for surveys conducted
-        on any date in the specified year. Will raise a `ValueError` if
-        there is no data for this year. Default is 2020. If `None` is
+        on any date in the specified year. Default is 2020. If `None` is
         passed instead, data for all available years are included in the
         returned dataset.
 
@@ -302,8 +299,7 @@ def generate_american_community_survey(
         generate data for all available US states. The returned dataset
         will contain survey data for simulants living in the specified
         state during the specified year. Can be a full state name or a
-        state abbreviation (e.g., "Ohio" or "OH"). Will raise a
-        `ValueError` if there is no data for this state.
+        state abbreviation (e.g., "Ohio" or "OH").
 
     :param verbose:
 
@@ -395,8 +391,7 @@ def generate_current_population_survey(
         The year for which to generate simulated Current Population
         Surveys of the simulated population (format YYYY, e.g., 2036);
         the simulated dataset will contain records for surveys conducted
-        on any date in the specified year. Will raise a `ValueError` if
-        there is no data for this year. Default is 2020. If `None` is
+        on any date in the specified year. Default is 2020. If `None` is
         passed instead, data for all available years are included in the
         returned dataset.
 
@@ -407,8 +402,7 @@ def generate_current_population_survey(
         generate data for all available US states. The returned dataset
         will contain survey data for simulants living in the specified
         state during the specified year. Can be a full state name or a
-        state abbreviation (e.g., "Ohio" or "OH"). Will raise a
-        `ValueError` if there is no data for this state.
+        state abbreviation (e.g., "Ohio" or "OH").
 
     :param verbose:
 
@@ -491,10 +485,9 @@ def generate_taxes_w2_and_1099(
 
         The tax year for which to generate records (format YYYY, e.g.,
         2036); the simulated dataset will contain the W2 & 1099 tax
-        forms filed by simulated employers for the specified year. Will
-        raise a `ValueError` if there is no data for this year. Default
-        is 2020. If `None` is passed instead, data for all available
-        years are included in the returned dataset.
+        forms filed by simulated employers for the specified year.
+        Default is 2020. If `None` is passed instead, data for all
+        available years are included in the returned dataset.
 
     :param state:
 
@@ -503,8 +496,7 @@ def generate_taxes_w2_and_1099(
         all available US states. The returned dataset will contain W2 &
         1099 tax forms filed for simulants living in the specified state
         during the specified tax year. Can be a full state name or a
-        state abbreviation (e.g., "Ohio" or "OH"). Will raise a
-        `ValueError` if there is no data for this state.
+        state abbreviation (e.g., "Ohio" or "OH").
 
     :param verbose:
 
@@ -582,8 +574,7 @@ def generate_women_infants_and_children(
         (format YYYY, e.g., 2036); the simulated dataset will contain
         records for simulants enrolled in WIC at the end of the
         specified year (or on May 1, 2041 if `year=2041` since that is
-        the end date of the simulation). Will raise a `ValueError` if
-        there is no data for this year. Default is 2020. If `None` is
+        the end date of the simulation). Default is 2020. If `None` is
         passed instead, data for all available years are included in the
         returned dataset.
 
@@ -596,8 +587,7 @@ def generate_women_infants_and_children(
         state at the end of the specified year (or on May 1, 2041 if
         `year=2041` since that is the end date of the simulation). Can
         be a full state name or a state abbreviation (e.g., "Ohio" or
-        "OH"). Will raise a `ValueError` if there is no data for this
-        state.
+        "OH").
 
     :param verbose:
 
@@ -662,10 +652,9 @@ def generate_social_security(
 
         The final year of simulated social security records to include
         in the dataset (format YYYY, e.g., 2036); will also include
-        records from all previous years. Will raise a `ValueError` if
-        there is no data for the specified year or any prior years.
-        Default is 2020. If `None` is passed instead, data for all
-        available years are included in the returned dataset.
+        records from all previous years. Default is 2020. If `None` is
+        passed instead, data for all available years are included in the
+        returned dataset.
 
     :param verbose:
 
@@ -737,9 +726,8 @@ def generate_taxes_1040(
 
         The tax year for which to generate records (format YYYY, e.g.,
         2036); the simulated dataset will contain the 1040 tax forms
-        filed by simulants for the specified year. Will raise a
-        `ValueError` if there is no data for this year. Default is 2020.
-        If `None` is passed instead, data for all available years are
+        filed by simulants for the specified year. Default is 2020. If
+        `None` is passed instead, data for all available years are
         included in the returned dataset.
 
     :param state:
@@ -749,8 +737,7 @@ def generate_taxes_1040(
         all available US states. The returned dataset will contain 1040
         tax forms filed by simulants living in the specified state
         during the specified tax year. Can be a full state name or a
-        state abbreviation (e.g., "Ohio" or "OH"). Will raise a
-        `ValueError` if there is no data for this state.
+        state abbreviation (e.g., "Ohio" or "OH").
 
     :param verbose:
 

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -235,7 +235,8 @@ def generate_decennial_census(
 
     :raises ValueError:
 
-        There is no data for the specified year or state.
+        The simulated population has no data for the specified year or
+        state.
     """
     user_filters = []
     if year is not None:
@@ -320,7 +321,8 @@ def generate_american_community_survey(
 
     :raises ValueError:
 
-        There is no data for the specified year or state.
+        The simulated population has no data for the specified year or
+        state.
     """
     user_filters = []
     if year is not None:
@@ -423,7 +425,8 @@ def generate_current_population_survey(
 
     :raises ValueError:
 
-        There is no data for the specified year or state.
+        The simulated population has no data for the specified year or
+        state.
     """
     user_filters = []
     if year is not None:
@@ -517,7 +520,8 @@ def generate_taxes_w2_and_1099(
 
     :raises ValueError:
 
-        There is no data for the specified year or state.
+        The simulated population has no data for the specified year or
+        state.
     """
     user_filters = []
     if year is not None:
@@ -607,7 +611,8 @@ def generate_women_infants_and_children(
 
     :raises ValueError:
 
-        There is no data for the specified year or state.
+        The simulated population has no data for the specified year or
+        state.
     """
     user_filters = []
     if year is not None:
@@ -675,7 +680,8 @@ def generate_social_security(
 
     :raises ValueError:
 
-        There is no data for the specified year or any prior years.
+        The simulated population has no data for the specified year or
+        any prior years.
     """
     user_filters = []
     if year is not None:
@@ -758,7 +764,8 @@ def generate_taxes_1040(
 
     :raises ValueError:
 
-        There is no data for the specified year or state.
+        The simulated population has no data for the specified year or
+        state.
     """
     user_filters = []
     if year is not None:

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -235,7 +235,7 @@ def generate_decennial_census(
 
     :raises ValueError:
 
-        The simulated population has no data for the specified year or
+        The simulated population has no data for this dataset in the specified year or
         state.
     """
     user_filters = []


### PR DESCRIPTION
## Docsrings: Add ValueError to :raises:
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation
- *JIRA issue*: [SSCI-1520](https://jira.ihme.washington.edu/browse/SSCI-1520)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

Adds `ValueError` to the `:raises:` block of the `generate_x` docstrings, and removes it from the descriptions of the `year` and `state` parameters. Also changes wording for `ConfigurationError` and `DataSourceError` from "incorrect" to "invalid."

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [ ] all tests pass (`pytest --runslow`)

Built docs locally.