### PR TITLE
Edit `get_config` docstring

### DIFF
--- a/docs/source/api_reference/configuration/index.rst
+++ b/docs/source/api_reference/configuration/index.rst
@@ -8,7 +8,7 @@ The pseudopeople :ref:`configuration <configuration_main>` contains a very large
 It may be easier in some situations to interact with the configuration programmatically in Python,
 rather than by creating a configuration dictionary or YAML file by hand.
 For example, if you wanted to double the cell probability parameter of every noise type in every column,
-or set all noise types to zero to get a perfectly recorded dataset,
+or set all noise types to zero except one to isolate the effect of a specific type of noise,
 it would be easier to access the defaults as a data structure in Python and modify them that way.
 
 We currently have one function that facilitates this kind of use of the configuration, shown below.

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -25,6 +25,8 @@ from occurring at all.
 To learn more about the default settings, see :ref:`Noise Type Details <noise_type_details>`.
 You can access the defaults from your Python code by calling the :func:`pseudopeople.get_config` function.
 
+.. _configuration_structure:
+
 Configuration structure
 -----------------------
 

--- a/src/pseudopeople/configuration/interface.py
+++ b/src/pseudopeople/configuration/interface.py
@@ -27,12 +27,14 @@ def get_config(overrides: Union[Path, str, Dict] = None) -> Dict:
 
     :param overrides:
 
-        An optional override to the default configuration. Can be a
-        Python dictionary, a path to a YAML file, or the special
-        sentinel value `pseudopeople.NO_NOISE`, which will return a
-        configuration specifying that all configurable noise is turned
-        off. When passing a dictionary or YAML file, it is not necessary
-        to provide a complete configuration; any configuration
+        An optional set of overrides to the default configuration. Can
+        be a (nested) Python dictionary mapping noise type parameters to
+        the desired override values, a path to a YAML file with the same
+        :ref:`nested structure <configuration_structure>`, or the
+        special sentinel value `pseudopeople.NO_NOISE`, which will
+        return a configuration in which all configurable noise is set to
+        zero. When passing a dictionary or YAML file, it is not
+        necessary to provide a complete configuration; any configuration
         parameters not specified in `overrides` will be filled in with
         the default values.
 
@@ -42,7 +44,7 @@ def get_config(overrides: Union[Path, str, Dict] = None) -> Dict:
 
     :raises ConfigurationError:
 
-        An invalid configuration is passed with overrides.
+        An invalid configuration is passed with `overrides`.
 
     """
     return get_configuration(overrides).to_dict()

--- a/src/pseudopeople/configuration/interface.py
+++ b/src/pseudopeople/configuration/interface.py
@@ -6,8 +6,9 @@ from pseudopeople.configuration.generator import get_configuration
 
 def get_config(overrides: Union[Path, str, Dict] = None) -> Dict:
     """
-    Function that returns the pseudopeople configuration including all default values.
-    To get the default probability of nonresponse in the Decennial Census dataset:
+    Function that returns the pseudopeople configuration including all
+    default values. To get the default probability of nonresponse in the
+    Decennial Census dataset:
 
     .. code-block:: pycon
 
@@ -15,7 +16,8 @@ def get_config(overrides: Union[Path, str, Dict] = None) -> Dict:
         >>> psp.get_config()['decennial_census']['row_noise']['do_not_respond']
         {'row_probability': 0.0145}
 
-    To view that same part of the configuration after applying a user override:
+    To view that same part of the configuration after applying a user
+    override:
 
     .. code-block:: pycon
 
@@ -23,12 +25,24 @@ def get_config(overrides: Union[Path, str, Dict] = None) -> Dict:
         >>> psp.get_config(overrides)['decenial_census']['row_noise']['do_not_respond']
         {'row_probability': 0.1}
 
-    :param overrides: An optional override to the default configuration. Can be
-        a path to a configuration YAML file or a dictionary. Passing a sentinel value
-        of psp.NO_NOISE will override default values and return a configuration
-        where all noise levels are set to 0.
-    :return: Dictionary of the config.
-    :raises ConfigurationError: An invalid configuration is passed with overrides.
+    :param overrides:
+
+        An optional override to the default configuration. Can be a
+        Python dictionary, a path to a YAML file, or the special
+        sentinel value `pseudopeople.NO_NOISE`, which will return a
+        configuration where all configurable noise levels are set to 0.
+        When passing a configuration dictionary or YAML configuration
+        file, it is not necessary to provide a complete configuration;
+        any configuration parameters not specified in `overrides` will
+        be filled in with the default values.
+
+    :return:
+
+        Dictionary representing the configuration.
+
+    :raises ConfigurationError:
+
+        An invalid configuration is passed with overrides.
 
     """
     return get_configuration(overrides).to_dict()

--- a/src/pseudopeople/configuration/interface.py
+++ b/src/pseudopeople/configuration/interface.py
@@ -6,7 +6,7 @@ from pseudopeople.configuration.generator import get_configuration
 
 def get_config(overrides: Union[Path, str, Dict] = None) -> Dict:
     """
-    Function that returns the pseudopeople configuration including all
+    Function that returns the pseudopeople configuration containing all
     default values. To get the default probability of nonresponse in the
     Decennial Census dataset:
 
@@ -30,15 +30,15 @@ def get_config(overrides: Union[Path, str, Dict] = None) -> Dict:
         An optional override to the default configuration. Can be a
         Python dictionary, a path to a YAML file, or the special
         sentinel value `pseudopeople.NO_NOISE`, which will return a
-        configuration where all configurable noise levels are set to 0.
-        When passing a configuration dictionary or YAML configuration
-        file, it is not necessary to provide a complete configuration;
-        any configuration parameters not specified in `overrides` will
-        be filled in with the default values.
+        configuration specifying that all configurable noise is turned
+        off. When passing a dictionary or YAML file, it is not necessary
+        to provide a complete configuration; any configuration
+        parameters not specified in `overrides` will be filled in with
+        the default values.
 
     :return:
 
-        Dictionary representing the configuration.
+        A complete configuration dictionary.
 
     :raises ConfigurationError:
 


### PR DESCRIPTION
## Edit `get_config` docstring
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation
- *JIRA issue*: [SSCI-1520](https://jira.ihme.washington.edu/browse/SSCI-1520)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

Changes:

- Edit `get_config` docstring
- Edit the example of setting all noise levels to zero in the "Working with the Configuration" section since we now have `NO_NOISE` to do that for us

I was struggling a bit with the wording throughout this page, so any suggestions to make things clearer are welcome!

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [ ] all tests pass (`pytest --runslow`)

Built docs locally