### PR TITLE
add data version tests

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -102,12 +102,10 @@ def _generate_dataset(
 
 
 def validate_source_compatibility(source: Path):
-    # TODO: Clean this up w/ metadata
+    # TODO [MIC-4546]: Clean this up w/ metadata and update test_interface.py tests to be generic
     changelog = source / "CHANGELOG.rst"
     if changelog.exists():
-        with open(changelog, "r") as file:
-            first_line = file.readline()
-        version = parse(first_line.split("**")[1].split("-")[0].strip())
+        version = _get_data_changelog_version(changelog)
         if version > parse("1.4.2"):
             raise DataSourceError(
                 f"The provided simulated population data is incompatible with this version of pseudopeople ({psp_version}).\n"
@@ -126,6 +124,13 @@ def validate_source_compatibility(source: Path):
             "An older version of simulated population data has been provided.\n"
             "Please either request updated simulated population data or downgrade the pseudopeople package."
         )
+
+
+def _get_data_changelog_version(changelog):
+    with open(changelog, "r") as file:
+        first_line = file.readline()
+    version = parse(first_line.split("**")[1].split("-")[0].strip())
+    return version
 
 
 def _coerce_dtypes(

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -26,7 +26,7 @@ def vectorized_choice(
     randomness_stream: RandomnessStream,
     weights: Union[list, pd.Series] = None,
     additional_key: Any = None,
-):
+) -> pd.Series:
     """
     Function that takes a list of options and uses Vivarium common random numbers framework to make a given number
     of random choice selections.
@@ -54,7 +54,7 @@ def vectorized_choice(
 
     # for each p_i in probs, count how many elements of cdf for which p_i >= cdf_i
     chosen_indices = np.searchsorted(cdf, probs, side="right")
-    return np.take(options, chosen_indices)
+    return np.take(options, chosen_indices, axis=0)
 
 
 def get_index_to_noise(

--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -1,8 +1,80 @@
+from pathlib import Path
+
 import pytest
+from packaging.version import parse
 
-from pseudopeople.interface import validate_source_compatibility
+from pseudopeople.exceptions import DataSourceError
+from pseudopeople.interface import (
+    _get_data_changelog_version,
+    validate_source_compatibility,
+)
 
 
-@pytest.mark.skip(reason="TODO")
-def test_validate_source_compatibility():
-    pass
+# TODO [MIC-4546]: stop hardcoding the data version number
+@pytest.fixture()
+def simulated_data_changelog_path(tmpdir_factory):
+    """Returns the path to where simualted data would live alongside their
+    respective CHANGELOG.rst. This fixture creates the changelog but does
+    not actually contain any simulated data.
+    """
+    tmp_path = str(tmpdir_factory.getbasetemp())
+    filepath = f"{tmp_path}/CHANGELOG.rst"
+    changelog_content = (
+        "**1.4.2 - some other date**"
+        "\n\n"
+        " - Did some other things"
+        "\n\n"
+        "**1.4.1 - some date**"
+        "\n\n"
+        " - Did some things"
+        "\n"
+    )
+    with open(filepath, "w") as file:
+        file.write(changelog_content)
+
+    # Create a dir with no changelog
+    tmpdir_factory.mktemp("no_changelog_dir")
+
+    return Path(tmp_path)
+
+
+def test__get_data_changelog_version(simulated_data_changelog_path):
+    """Test that the data version is extracted from the CHANGELOG correctly"""
+    assert _get_data_changelog_version(
+        simulated_data_changelog_path / "CHANGELOG.rst"
+    ) == parse("1.4.2")
+
+
+def mock_data_version(version, mocker):
+    mocker.patch(
+        "pseudopeople.interface._get_data_changelog_version", return_value=parse(version)
+    )
+
+
+def test_validate_source_compatibility_passes(simulated_data_changelog_path):
+    """Baseline test for validate_source_compatibility function"""
+    validate_source_compatibility(simulated_data_changelog_path)
+
+
+def test_validate_source_compatibility_no_changelog_error(simulated_data_changelog_path):
+    with pytest.raises(
+        DataSourceError,
+        match="An older version of simulated population data has been provided.",
+    ):
+        validate_source_compatibility(simulated_data_changelog_path / "no_changelog_dir")
+
+
+@pytest.mark.parametrize(
+    "version, match",
+    [
+        ("1.4.1", "The simulated population data has been corrupted."),
+        ("1.4.3", "A newer version of simulated population data has been provided."),
+        ("1.4.12", "A newer version of simulated population data has been provided."),
+    ],
+)
+def test_validate_source_compatibility_bad_version_errors(
+    version, match, simulated_data_changelog_path, mocker
+):
+    mock_data_version(version, mocker)
+    with pytest.raises(DataSourceError, match=match):
+        validate_source_compatibility(simulated_data_changelog_path)


### PR DESCRIPTION
## Title: Add tests for data version validation
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> test
- *JIRA issue*: na

There is probably a better way to do this than mocking the version extractor function
since that can cover bugs, but I did add a direct test on that so maybe it's fine.
Another approach could be to create multiple changelogs with different versions
to test against - happy to do that if that's better.

Note that these will all need to change with MIC-4546 but this at least gets the
validation wrapped in something that will break in the event that we don't get around
to that ticket and we try and update source data.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [x] all tests pass (`pytest --runslow`)
