### PR TITLE
specify np.take axis

### DIFF
--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -26,7 +26,7 @@ def vectorized_choice(
     randomness_stream: RandomnessStream,
     weights: Union[list, pd.Series] = None,
     additional_key: Any = None,
-):
+) -> pd.Series:
     """
     Function that takes a list of options and uses Vivarium common random numbers framework to make a given number
     of random choice selections.
@@ -54,7 +54,7 @@ def vectorized_choice(
 
     # for each p_i in probs, count how many elements of cdf for which p_i >= cdf_i
     chosen_indices = np.searchsorted(cdf, probs, side="right")
-    return np.take(options, chosen_indices)
+    return np.take(options, chosen_indices, axis=0)
 
 
 def get_index_to_noise(


### PR DESCRIPTION
## Title: Bugfix np.take
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: na

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> git builds suddenly started failing for two pytests.
Turns out both tests us vectorized_choice and are breaking on the returned
np.take. Adding axis=0 seems to have fixed it, though I don't totally
understand why the default of None stopped working.

I did notice that python 3.8 built fine. When I installed 3.9 on my laptop
I see that numpy version is 1.26 which was just released two days ago -
 so maybe there's a bug in there or a breaking change? It's just odd that
the tests this morning and then suddenly stopped building 20 minutes
later.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [ ] all tests pass (`pytest --runslow`)
