### PR TITLE
Remove references to noise functions on datasets page

### DIFF
--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -54,11 +54,11 @@ The following columns are included in this dataset:
      - Notes
    * - Unique simulant ID
      - :code:`simulant_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
+     - Not affected by noise; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - Unique household ID
      - :code:`household_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
+     - Not affected by noise; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - First name
      - :code:`first_name`
@@ -120,7 +120,7 @@ The following columns are included in this dataset:
        "Multiracial or Some Other Race".
    * - Year
      - :code:`year`
-     - Year in which data were collected; metadata that would not be collected directly; not affected by noise functions.
+     - Year in which data were collected; metadata that would not be collected directly; not affected by noise .
 
 American Community Survey (ACS)
 -------------------------------
@@ -145,15 +145,15 @@ The following columns are included in this dataset:
      - Notes
    * - Unique simulant ID
      - :code:`simulant_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
+     - Not affected by noise; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - Unique household ID
      - :code:`household_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
+     - Not affected by noise; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - Survey date
      - :code:`survey_date`
-     - Date on which the survey was conducted; metadata that would not be collected directly; not affected by noise functions.
+     - Date on which the survey was conducted; metadata that would not be collected directly; not affected by noise .
        Stored as a ``pandas.Timestamp``, which displays in YYYY-MM-DD format by default.
    * - First name
      - :code:`first_name`
@@ -237,15 +237,15 @@ The following columns are included in this dataset:
      - Notes
    * - Unique simulant ID
      - :code:`simulant_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
+     - Not affected by noise; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - Unique household ID
      - :code:`household_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
+     - Not affected by noise; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - Survey date
      - :code:`survey_date`
-     - Date on which the survey was conducted; metadata that would not be collected directly; not affected by noise functions.
+     - Date on which the survey was conducted; metadata that would not be collected directly; not affected by noise .
        Stored as a ``pandas.Timestamp``, which displays in YYYY-MM-DD format by default.
    * - First name
      - :code:`first_name`
@@ -313,11 +313,11 @@ The following columns are included in this dataset:
      - Notes
    * - Unique simulant ID
      - :code:`simulant_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
+     - Not affected by noise; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - Unique household ID
      - :code:`household_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
+     - Not affected by noise; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - First name
      - :code:`first_name`
@@ -359,7 +359,7 @@ The following columns are included in this dataset:
        "Multiracial or Some Other Race".
    * - Year
      - :code:`year`
-     - Year in which benefits were received; metadata that would not be collected directly; not affected by noise functions.
+     - Year in which benefits were received; metadata that would not be collected directly; not affected by noise .
 
 
 Social Security Administration
@@ -388,7 +388,7 @@ The following columns are included in this dataset:
      - Notes
    * - Unique simulant ID
      - :code:`simulant_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
+     - Not affected by noise; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - Social security number
      - :code:`ssn`
@@ -439,11 +439,11 @@ The following columns are included in these datasets:
      - Notes
    * - Unique simulant ID
      - :code:`simulant_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
+     - Not affected by noise; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - Unique household ID
      - :code:`household_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
+     - Not affected by noise; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - Employer ID
      - :code:`employer_id`
@@ -510,7 +510,7 @@ The following columns are included in these datasets:
      - Possible values are "W2" or "1099".
    * - Tax year
      - :code:`tax_year`
-     - Year for which tax data were collected; metadata that would not be collected directly; not affected by noise functions.
+     - Year for which tax data were collected; metadata that would not be collected directly; not affected by noise .
 
 
 Tax form: 1040
@@ -559,11 +559,11 @@ The following columns are included in this dataset:
      - Notes
    * - Unique simulant ID
      - :code:`simulant_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
+     - Not affected by noise; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - Unique household ID
      - :code:`household_id`
-     - Not affected by noise functions; intended use is "ground truth" for testing and validation; consistent across all
+     - Not affected by noise; intended use is "ground truth" for testing and validation; consistent across all
        datasets.
    * - First name
      - :code:`first_name`
@@ -648,4 +648,4 @@ The following columns are included in this dataset:
      - Individual Taxpayer Identification Number (ITIN) if no SSN
    * - Tax year
      - :code:`tax_year`
-     - Year for which tax data were collected; metadata that would not be collected directly; not affected by noise functions.
+     - Year for which tax data were collected; metadata that would not be collected directly; not affected by noise .

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -120,7 +120,7 @@ The following columns are included in this dataset:
        "Multiracial or Some Other Race".
    * - Year
      - :code:`year`
-     - Year in which data were collected; metadata that would not be collected directly; not affected by noise .
+     - Year in which data were collected; metadata that would not be collected directly; not affected by noise.
 
 American Community Survey (ACS)
 -------------------------------
@@ -153,7 +153,7 @@ The following columns are included in this dataset:
        datasets.
    * - Survey date
      - :code:`survey_date`
-     - Date on which the survey was conducted; metadata that would not be collected directly; not affected by noise .
+     - Date on which the survey was conducted; metadata that would not be collected directly; not affected by noise.
        Stored as a ``pandas.Timestamp``, which displays in YYYY-MM-DD format by default.
    * - First name
      - :code:`first_name`
@@ -245,7 +245,7 @@ The following columns are included in this dataset:
        datasets.
    * - Survey date
      - :code:`survey_date`
-     - Date on which the survey was conducted; metadata that would not be collected directly; not affected by noise .
+     - Date on which the survey was conducted; metadata that would not be collected directly; not affected by noise.
        Stored as a ``pandas.Timestamp``, which displays in YYYY-MM-DD format by default.
    * - First name
      - :code:`first_name`
@@ -359,7 +359,7 @@ The following columns are included in this dataset:
        "Multiracial or Some Other Race".
    * - Year
      - :code:`year`
-     - Year in which benefits were received; metadata that would not be collected directly; not affected by noise .
+     - Year in which benefits were received; metadata that would not be collected directly; not affected by noise.
 
 
 Social Security Administration
@@ -510,7 +510,7 @@ The following columns are included in these datasets:
      - Possible values are "W2" or "1099".
    * - Tax year
      - :code:`tax_year`
-     - Year for which tax data were collected; metadata that would not be collected directly; not affected by noise .
+     - Year for which tax data were collected; metadata that would not be collected directly; not affected by noise.
 
 
 Tax form: 1040
@@ -648,4 +648,4 @@ The following columns are included in this dataset:
      - Individual Taxpayer Identification Number (ITIN) if no SSN
    * - Tax year
      - :code:`tax_year`
-     - Year for which tax data were collected; metadata that would not be collected directly; not affected by noise .
+     - Year for which tax data were collected; metadata that would not be collected directly; not affected by noise.


### PR DESCRIPTION
## Title: Remove references to noise functions on datasets page
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: [SSCI-1539](https://jira.ihme.washington.edu/browse/SSCI-1539)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [ ] all tests pass (`pytest --runslow`)
