### PR TITLE
Add missingness descriptions to datasets and noises pages

### DIFF
--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -27,7 +27,7 @@ which may be different -- for example, a PO box.
 Mailing addresses, not physical addresses, are recorded in tax filings.
 
 Some columns in the generated data may contain missing values, even if no noise has been added to 
-the data. These missing values are represented by :code:`np.nan`.
+the data. These missing values are represented by :code:`numpy.nan`.
 
 The datasets that can be generated are listed below.
 

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -26,6 +26,9 @@ A **mailing address** represents the address a simulant uses to receive mail,
 which may be different -- for example, a PO box.
 Mailing addresses, not physical addresses, are recorded in tax filings.
 
+Some columns in the generated data may contain missing values, even if no noise has been added to 
+the data. These missing values are represented by :code:`np.nan`.
+
 The datasets that can be generated are listed below.
 
 .. contents::

--- a/docs/source/noise/column_noise.rst
+++ b/docs/source/noise/column_noise.rst
@@ -47,7 +47,9 @@ Often some of the data in certain columns of a dataset will be missing.
 This could be because the input for that field was left blank, an answer was refused,
 or the answer was illegible or unintelligible.
 To simulate this type of noise, pseudopeople will replace the value in the relevant cell with
-:code:`numpy.nan` to indicate that the value is missing.
+:code:`numpy.nan` to indicate that the value is missing. It is important to note, however, that 
+some columns in the generated data may contain missing values, even if no noise has been added to the data.
+In these cases of "valid missingness", missing values are also represented by :code:`numpy.nan`.
 
 This noise type is called :code:`leave_blank` in the configuration. It takes one parameter:
 


### PR DESCRIPTION
## Title: Add missingness descriptions to datasets and noises pages
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation<!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: [SSCI-1518](https://jira.ihme.washington.edu/browse/SSCI-1518)

The descriptions of missingness across the two pages are repetitive and somewhat vague, but not sure how to improve this. Lmk what you think! 
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [x] all tests pass (`pytest --runslow`)
