### PR TITLE
Mic 4563/update for slow tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           if github.event_name == 'schedule'; then
             pytest --runslow ./tests
           else
-            pytest ./tests
+            pytest --limit=1 ./tests
           fi
       - name: Doc build
         run: |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ def pytest_addoption(parser):
         action="store",
         default=-1,
         type=int,
-        help="Maximum number of parametrized tests to run",
+        help="Maximum number of parameterized tests to run",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,13 @@ from loguru import logger
 
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
+    parser.addoption(
+        "--limit",
+        action="store",
+        default=-1,
+        type=int,
+        help="Maximum number of permutations of parametrised tests to run",
+    )
 
 
 def pytest_configure(config):
@@ -24,6 +31,18 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(pytest.mark.slow)
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
+
+    # Limit the number of permutations of parametrised tests to run.
+    limit = config.getoption("--limit")
+    if limit > 0:
+        tests_by_name = {item.name: item for item in items}
+        # Add the name of parametrize base tests to this list.
+        tests_to_skip_parametrize = ["test_noise_order"]
+
+        for base_name in tests_to_skip_parametrize:
+            to_skip = [t for n, t in tests_by_name.items() if base_name in n][limit:]
+            for t in to_skip:
+                t.add_marker("skip")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ def pytest_addoption(parser):
         action="store",
         default=-1,
         type=int,
-        help="Maximum number of permutations of parametrised tests to run",
+        help="Maximum number of parametrized tests to run",
     )
 
 
@@ -36,7 +36,7 @@ def pytest_collection_modifyitems(config, items):
     limit = config.getoption("--limit")
     if limit > 0:
         tests_by_name = {item.name: item for item in items}
-        # Add the name of parametrize base tests to this list.
+        # Add the name of parametrized base tests to this list.
         tests_to_skip_parametrize = ["test_noise_order"]
 
         for base_name in tests_to_skip_parametrize:

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -559,8 +559,8 @@ def test_write_wrong_digits_robust(dummy_dataset):
 
 
 def test_write_wrong_digits(dummy_dataset):
-    # This is a quicker (less robust) version of the test above to run on push and pull
-    # requests. It only checks that numeric characters are noised at the correct level as
+    # This is a quicker (less robust) version of the test above.
+    # It only checks that numeric characters are noised at the correct level as
     # a sanity check our noise is of the right magnitude
     config = get_configuration()
     config.update(


### PR DESCRIPTION
## Mic-4563/update for slow tests

### Adds --limit flag to limit number of parametrize iterations run on a test function
- *Category*: Test
- *JIRA issue*: [MIC-4563](https://jira.ihme.washington.edu/browse/MIC-4563)

-adds --limit flag in confest test along with tests to use this flag on. Currently only test_noise_order
-adds a new test for write_wrong_digits which is an accuracy test for magnitude and marks old more robust test as slow

### Testing
All tests pass. Limit flag works as intended.
