### PR TITLE
Add write_wrong_digits to age column in noise table

### DIFF
--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -137,7 +137,7 @@ Noise types for each column
     - Last names use a different list of fake names than the list for first names. In the 1040 form, the same noise types apply to the last name columns for the joint filer and dependents
   * - Age
     - Decennial Census, ACS, CPS
-    - Leave a field blank, copy from household member, misreport age, make OCR errors, make typos
+    - Leave a field blank, copy from household member, misreport age, write the wrong digits, make OCR errors, make typos
     -
   * - Date of birth
     - Decennial Census, ACS, CPS, WIC, SSA


### PR DESCRIPTION
## Title: Add write_wrong_digits to age column in noise table
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: docuentation <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: [SSCI-1396](https://jira.ihme.washington.edu/browse/SSCI-1396)

Added this edit to the vivarium_research docs too ([in this PR](https://github.com/ihmeuw/vivarium_research/pull/1345))

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [ ] all tests pass (`pytest --runslow`)
