### PR TITLE
Scale copy-from noise with correct denominator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 **0.7.2 - 10/16/23**
  - Drop support for python 3.8
  - Fix bug in "Choose the wrong option" noise type
+ - Fixed minor bug in copy_from_household_member noise type
 
 **0.7.1 - 09/18/23**
  - Improved configuration validation

--- a/src/pseudopeople/noise_scaling.py
+++ b/src/pseudopeople/noise_scaling.py
@@ -32,9 +32,11 @@ def scale_nicknames(data: pd.DataFrame, column_name: str) -> float:
 
 
 def scale_copy_from_household_member(data: pd.DataFrame, column_name: str) -> float:
+    original_column = data[column_name]
     copy_column = data[metadata.COPY_HOUSEHOLD_MEMBER_COLS[column_name]]
-    eligible_idx = copy_column.index[(copy_column != "") & (copy_column.notna())]
-    proportion_eligible = len(eligible_idx) / len(data)
+    original_column_not_missing = (original_column != "") & (original_column.notna())
+    eligible = (copy_column != "") & (copy_column.notna()) & original_column_not_missing
+    proportion_eligible = eligible.sum() / original_column_not_missing.sum()
     if proportion_eligible == 0.0:
         return 0.0
     return 1 / proportion_eligible


### PR DESCRIPTION
## Scale copy-from noise with correct denominator

### Description
- *Category*: bugfix
- *JIRA issue*: None

This is a minor bug, but unlike the other noise scaling, this one was not taking into account which simulants were even eligible to be noised on that column.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [x] all tests pass (`pytest --runslow`)
