### PR TITLE
Mic 4617/drop 3.8 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,6 @@
+**0.7.2 - 10/16/23**
+ - Drop support for python 3.8
+
 **0.7.1 - 09/18/23**
  - Improved configuration validation
  - Security patch for configuration file loading

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-min_version, max_version = ((3, 8), "3.8"), ((3, 11), "3.11")
+min_version, max_version = ((3, 9), "3.9"), ((3, 11), "3.11")
 
 if not (min_version[0] <= sys.version_info[:2] <= max_version[0]):
     # Python 3.5 does not support f-strings


### PR DESCRIPTION
## Mic 4617/drop 3.8 support

### Drop support for python 3.8
- *Category*: CI
- *JIRA issue*: [MIC-4617](https://jira.ihme.washington.edu/browse/MIC-4617)

-drops support for python 3.8

### Testing
All tests pass.