### PR TITLE
Read parquet asynchronously with Modin

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -118,8 +118,8 @@ def _generate_dataset(
         # NOTE: This is only necessary because Modin happens to use .dtypes as
         # its way to wait for partitions when not in async mode!
         # Workaround for https://github.com/modin-project/modin/issues/5944
-        # NOTE: Is our use of pandas categories as a "dictionary encoding" even necessary,
-        # given we compress our parquet files?
+        # TODO: Investigate whether our use of pandas categories as a "dictionary encoding"
+        # is even necessary/working, given that we compress our parquet files.
         modin_cfg.AsyncReadMode.put(True)
 
         # Let modin deal with how to partition the shards -- the data path is the

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -109,7 +109,18 @@ def _generate_dataset(
         # again after concat (https://github.com/pandas-dev/pandas/issues/51362)
         noised_dataset = _coerce_dtypes(noised_dataset, dataset, cleanse_int_cols=True)
     else:
+        import modin.config as modin_cfg
         import modin.pandas as mpd
+
+        previous_async_read_mode = modin_cfg.AsyncReadMode.get()
+        # We need to change the categorical columns to strings before ever materializing
+        # data.dtypes, since that will try to collect all the categories in memory in one node
+        # NOTE: This is only necessary because Modin happens to use .dtypes as
+        # its way to wait for partitions when not in async mode!
+        # Workaround for https://github.com/modin-project/modin/issues/5944
+        # NOTE: Is our use of pandas categories as a "dictionary encoding" even necessary,
+        # given we compress our parquet files?
+        modin_cfg.AsyncReadMode.put(True)
 
         # Let modin deal with how to partition the shards -- the data path is the
         # entire directory containing the parquet files
@@ -139,6 +150,8 @@ def _generate_dataset(
                 )
             )
         )
+
+        modin_cfg.AsyncReadMode.put(previous_async_read_mode)
 
     logger.debug("*** Finished ***")
 


### PR DESCRIPTION
## Read parquet asynchronously with Modin

### Description
- *Category*: bugfix
- *JIRA issue*: None

I was seeing crashes on the full USA data using the `epic/modin` branch. The root cause turned out to be the representation of some high-information columns such as simulant_id as pandas Categoricals in our Parquet outputs. This meant that the dtype of the column was holding a substantial amount of the data in that column, and Modin by default tries to materialize that dtype on a single node (see https://github.com/modin-project/modin/issues/5944#issuecomment-1758055361), which would OOM.

Note: I doubt we are getting any benefit by encoding as Categoricals, at least for these columns. This is a change we should consider making on the simulation/post-processing side.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [x] all tests pass (`pytest --runslow`)
