### PR TITLE
Noise data in-place

### DIFF
--- a/src/pseudopeople/noise.py
+++ b/src/pseudopeople/noise.py
@@ -29,7 +29,7 @@ def noise_dataset(
     dataset_data: pd.DataFrame,
     configuration: ConfigTree,
     seed: Any,
-) -> pd.DataFrame:
+) -> None:
     """
     Adds noise to the input dataset data. Noise functions are executed in the order
     defined by :py:const: `.NOISE_TYPES`. Row noise functions are applied to the
@@ -45,8 +45,6 @@ def noise_dataset(
         Object to configure noise levels
     :param seed:
         Seed for controlling randomness
-    :return:
-        Noised dataset data
     """
     randomness = get_randomness_stream(dataset.name, seed, dataset_data.index)
 
@@ -58,7 +56,7 @@ def noise_dataset(
                 and noise_type.name in noise_configuration.row_noise
             ):
                 # Apply row noise
-                dataset_data = noise_type(
+                noise_type(
                     dataset.name,
                     dataset_data,
                     noise_configuration[Keys.ROW_NOISE][noise_type.name],
@@ -76,17 +74,16 @@ def noise_dataset(
                 # Apply column noise to each column as appropriate
                 for column in columns_to_noise:
                     required_cols = [column] + noise_type.additional_column_getter(column)
-                    dataset_data[column] = noise_type(
-                        dataset_data[required_cols],
+                    noise_type(
+                        dataset_data,
                         noise_configuration.column_noise[column][noise_type.name],
                         randomness,
                         dataset.name,
                         column,
+                        required_cols=required_cols,
                     )
         else:
             raise TypeError(
                 f"Invalid noise type. Allowed types are {RowNoiseType} and "
                 f"{ColumnNoiseType}. Provided {type(noise_type)}."
             )
-
-    return dataset_data

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -62,15 +62,18 @@ def get_index_to_noise(
     noise_level: float,
     randomness_stream: RandomnessStream,
     additional_key: Any,
-    is_column_noise: bool = False,
+    ignore_rows_missing_columns: str = None,
 ) -> pd.Index:
     """
     Function that takes a series and returns a pd.Index that chosen by Vivarium Common Random Number to be noised.
     """
 
     # Get rows to noise
-    if is_column_noise:
-        missing_idx = data.index[(data.isna().any(axis=1)) | (data.isin([""]).any(axis=1))]
+    if ignore_rows_missing_columns is not None:
+        missing_idx = data.index[
+            data[ignore_rows_missing_columns].isna().any(axis=1)
+            | (data[ignore_rows_missing_columns] == "").any(axis=1)
+        ]
         eligible_for_noise_idx = data.index.difference(missing_idx)
     else:
         # Any index can be noised for row noise

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -242,7 +242,7 @@ def sample_data_taxes_w2_and_1099_state_edit():
 def _load_sample_data(dataset, request):
     if dataset == DatasetNames.TAXES_1040:
         # We need to get formatted 1040 data that is not noised to get the expected columns
-        data = request.getfixturevalue("formatted_1040_sample_data")
+        data = request.getfixturevalue("formatted_1040_sample_data").copy()
     else:
         data_path = paths.SAMPLE_DATA_ROOT / dataset / f"{dataset}.parquet"
         data = pd.read_parquet(data_path)
@@ -257,7 +257,9 @@ def _get_common_datasets(dataset_name, data, noised_data):
     """
     idx_cols = IDX_COLS.get(dataset_name)
     dataset = DATASETS.get_dataset(dataset_name)
-    check_original = _reformat_dates_for_noising(data, dataset).set_index(idx_cols)
+    check_original = data.copy()
+    _reformat_dates_for_noising(check_original, dataset)
+    check_original = check_original.set_index(idx_cols)
     check_noised = noised_data.set_index(idx_cols)
     # Ensure the idx_cols are unique
     assert check_original.index.duplicated().sum() == 0

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -98,14 +98,16 @@ def test_generate_dataset_from_sample_and_source(
         ].intersection(original_missing_idx)
         compare_sample_idx = shared_idx_sample.difference(both_missing_sample_idx)
         compare_dataset_idx = shared_idx_dataset.difference(both_missing_dataset_idx)
-        noise_level_single_dataset = (
+        noised_single_dataset = (
             check_original.loc[compare_sample_idx, col].values
             != check_noised_sample.loc[compare_sample_idx, col].values
-        ).mean()
-        noise_level_full_dataset = (
+        )
+        noise_level_single_dataset = noised_single_dataset.mean()
+        noised_full_dataset = (
             check_original.loc[compare_dataset_idx, col].values
             != check_noised_dataset.loc[compare_dataset_idx, col].values
-        ).mean()
+        )
+        noise_level_full_dataset = noised_full_dataset.mean()
         # If the dataset is very small and/or missingness is very high, we can't
         # meaningfully compare because the stochastic variation is so great
         # As of 8/31/2023, this only skips unit_number (very missing) in the
@@ -578,5 +580,5 @@ def _mock_noise_dataset(
     configuration,
     seed: int,
 ):
-    """Mock noise_dataset that just returns unnoised data"""
-    return dataset_data
+    """Mock noise_dataset that does nothing"""
+    return

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -150,10 +150,12 @@ def test_leave_blank(dummy_dataset):
         }
     )
     data = dummy_dataset[["numbers"]]
-    noised_data = NOISE_TYPES.leave_blank(data, config, RANDOMNESS0, "dataset", "numbers")
+    noised_data = data.copy()
+    NOISE_TYPES.leave_blank(noised_data, config, RANDOMNESS0, "dataset", "numbers")
 
     # Calculate newly missing data, ie data that didn't come in as already missing
     data = data.squeeze()
+    noised_data = noised_data.squeeze()
     orig_non_missing_idx = data.index[(data.notna()) & (data != "")]
     newly_missing_idx = noised_data.index[
         (noised_data.index.isin(orig_non_missing_idx)) & (noised_data.isna())
@@ -174,10 +176,10 @@ def test_choose_wrong_option(dummy_dataset):
         NOISE_TYPES.choose_wrong_option.name
     ]
     data = dummy_dataset[["state"]]
-    noised_data = NOISE_TYPES.choose_wrong_option(
-        data, config, RANDOMNESS0, "dataset", "state"
-    )
+    noised_data = data.copy()
+    NOISE_TYPES.choose_wrong_option(noised_data, config, RANDOMNESS0, "dataset", "state")
     data = data.squeeze()
+    noised_data = noised_data.squeeze()
     # Check for expected noise level
     expected_noise = config[Keys.CELL_PROBABILITY]
     # todo: Update when choose_wrong_options uses exclusive resampling
@@ -196,8 +198,9 @@ def test_generate_copy_from_household_member(dummy_dataset):
         NOISE_TYPES.copy_from_household_member.name
     ]
     data = dummy_dataset[["age", "copy_age"]]
-    noised_data = NOISE_TYPES.copy_from_household_member(
-        data, config, RANDOMNESS0, "dataset", "age"
+    noised_data = data.copy()
+    NOISE_TYPES.copy_from_household_member(
+        noised_data, config, RANDOMNESS0, "dataset", "age", required_cols=["age", "copy_age"]
     )
 
     # Check for expected noise level
@@ -205,6 +208,7 @@ def test_generate_copy_from_household_member(dummy_dataset):
     original_missing_idx = data.index[data["age"] == ""]
     eligible_for_noise_idx = data.index.difference(original_missing_idx)
     data = data["age"]
+    noised_data = noised_data["age"]
     actual_noise = (
         noised_data[eligible_for_noise_idx] != data[eligible_for_noise_idx]
     ).mean()
@@ -246,12 +250,14 @@ def test_swap_months_and_days(dummy_dataset):
                 NOISE_TYPES.swap_month_and_day.name
             ]
         expected_noise = config[Keys.CELL_PROBABILITY]
-        noised_data = NOISE_TYPES.swap_month_and_day(
-            data, config, RANDOMNESS0, DATASETS.census.name, col
+        noised_data = data.copy()
+        NOISE_TYPES.swap_month_and_day(
+            noised_data, config, RANDOMNESS0, DATASETS.census.name, col
         )
 
         # Confirm missing data remains missing
         data = data.squeeze()
+        noised_data = noised_data.squeeze()
         orig_missing = data.isna()
         assert (noised_data[orig_missing].isna()).all()
 
@@ -284,12 +290,15 @@ def test_write_wrong_zipcode_digits(dummy_dataset):
     # Get configuration values for each piece of 5 digit zipcode
     probability = config[Keys.CELL_PROBABILITY]
     data = dummy_dataset[["zipcode"]]
-    noised_data = NOISE_TYPES.write_wrong_zipcode_digits(
-        data, config, RANDOMNESS0, "dataset", "zipcode"
+    noised_data = data.copy()
+    NOISE_TYPES.write_wrong_zipcode_digits(
+        noised_data, config, RANDOMNESS0, "dataset", "zipcode"
     )
 
     # Confirm missing data remains missing
     data = data.squeeze()
+    noised_data = noised_data.squeeze()
+
     orig_missing = data == ""
     assert (noised_data[orig_missing] == "").all()
     # Check noise for each digits position matches expected noise
@@ -310,8 +319,10 @@ def test_miswrite_ages_default_config(dummy_dataset):
         NOISE_TYPES.misreport_age.name
     ]
     data = dummy_dataset[["age"]]
-    noised_data = NOISE_TYPES.misreport_age(data, config, RANDOMNESS0, "dataset", "age")
+    noised_data = data.copy()
+    NOISE_TYPES.misreport_age(noised_data, config, RANDOMNESS0, "dataset", "age")
     data = data.squeeze()
+    noised_data = noised_data.squeeze()
 
     # Check for expected noise level
     not_missing_idx = data.index[data != ""]
@@ -353,7 +364,8 @@ def test_miswrite_ages_uniform_probabilities():
 
     data = pd.Series([str(original_age)] * num_rows, name="age")
     df = pd.DataFrame({"age": data})
-    noised_data = NOISE_TYPES.misreport_age(df, config, RANDOMNESS0, "dataset", "age")
+    noised_data = df.copy()
+    NOISE_TYPES.misreport_age(noised_data, config, RANDOMNESS0, "dataset", "age")
     expected_noise = 1 / len(perturbations)
     for perturbation in perturbations:
         actual_noise = (noised_data.astype(int) - original_age == perturbation).mean()
@@ -383,7 +395,8 @@ def test_miswrite_ages_provided_probabilities():
 
     data = pd.Series([str(original_age)] * num_rows, name="age")
     df = pd.DataFrame({"age": data})
-    noised_data = NOISE_TYPES.misreport_age(df, config, RANDOMNESS0, "dataset", "age")
+    noised_data = df.copy()
+    NOISE_TYPES.misreport_age(noised_data, config, RANDOMNESS0, "dataset", "age")
     for perturbation in perturbations:
         expected_noise = perturbations[perturbation]
         actual_noise = (noised_data.astype(int) - original_age == perturbation).mean()
@@ -417,9 +430,10 @@ def test_miswrite_ages_handles_perturbation_to_same_age():
 
     data = pd.Series([str(age)] * num_rows, name="age")
     df = pd.DataFrame({"age": data})
-    noised_data = NOISE_TYPES.misreport_age(df, config, RANDOMNESS0, "dataset", "age")
+    noised_data = df.copy()
+    NOISE_TYPES.misreport_age(noised_data, config, RANDOMNESS0, "dataset", "age")
 
-    assert (noised_data == 0).all()
+    assert (noised_data["age"] == 0).all()
 
 
 def test_miswrite_ages_flips_negative_to_positive():
@@ -445,9 +459,10 @@ def test_miswrite_ages_flips_negative_to_positive():
 
     data = pd.Series([str(age)] * num_rows, name="age")
     df = pd.DataFrame({"age": data})
-    noised_data = NOISE_TYPES.misreport_age(df, config, RANDOMNESS0, "dataset", "age")
+    noised_data = df.copy()
+    NOISE_TYPES.misreport_age(noised_data, config, RANDOMNESS0, "dataset", "age")
 
-    assert (noised_data == 4).all()
+    assert (noised_data["age"] == 4).all()
 
 
 @pytest.mark.slow
@@ -480,12 +495,14 @@ def test_write_wrong_digits_robust(dummy_dataset):
     data = dummy_dataset[["street_number"]]
     # Note: I changed this column from string_series to street number. It has several string formats
     # containing both numeric and alphabetically string characters.
-    noised_data = NOISE_TYPES.write_wrong_digits(
-        data, config, RANDOMNESS0, "dataset", "street_number"
+    noised_data = data.copy()
+    NOISE_TYPES.write_wrong_digits(
+        noised_data, config, RANDOMNESS0, "dataset", "street_number"
     )
 
     # Get masks for helper groups, each string in categorical string purpose is to mimic possible string types
     data = data["street_number"]
+    noised_data = noised_data["street_number"]
     empty_str = data == ""
     ambig_str = data.str.len() == 3
     unit_number = data == "Unit 1A"
@@ -585,12 +602,14 @@ def test_write_wrong_digits(dummy_dataset):
     data = dummy_dataset[["street_number"]]
     # Note: I changed this column from string_series to street number. It has several string formats
     # containing both numeric and alphabetically string characters.
-    noised_data = NOISE_TYPES.write_wrong_digits(
-        data, config, RANDOMNESS0, "dataset", "street_number"
+    noised_data = data.copy()
+    NOISE_TYPES.write_wrong_digits(
+        noised_data, config, RANDOMNESS0, "dataset", "street_number"
     )
 
     # Validate we do not change any missing data
     data = data.squeeze()
+    noised_data = noised_data.squeeze()
     missing_mask = data == ""
     assert (noised_data[missing_mask] == "").all()
 
@@ -609,8 +628,10 @@ def test_use_nickname(dummy_dataset):
     ]
     expected_noise = config[Keys.CELL_PROBABILITY]
     data = dummy_dataset[["first_name"]]
-    noised_data = NOISE_TYPES.use_nickname(data, config, RANDOMNESS0, "dataset", "first_name")
+    noised_data = data.copy()
+    NOISE_TYPES.use_nickname(noised_data, config, RANDOMNESS0, "dataset", "first_name")
     data = data.squeeze()
+    noised_data = noised_data.squeeze()
 
     # Validate missing stays missing
     orig_missing = data.isna()
@@ -681,14 +702,18 @@ def test_use_fake_name(dummy_dataset):
     # This will help demonstrate that the additional key is working correctly
     first_name_data = dummy_dataset[["first_name"]]
     last_name_data = dummy_dataset[["last_name"]]
-    noised_first_names = NOISE_TYPES.use_fake_name(
-        first_name_data, first_name_config, RANDOMNESS0, "dataset", "first_name"
+    noised_first_names = first_name_data.copy()
+    NOISE_TYPES.use_fake_name(
+        noised_first_names, first_name_config, RANDOMNESS0, "dataset", "first_name"
     )
-    noised_last_names = NOISE_TYPES.use_fake_name(
-        last_name_data, last_name_config, RANDOMNESS0, "dataset", "last_name"
+    noised_last_names = last_name_data.copy()
+    NOISE_TYPES.use_fake_name(
+        noised_last_names, last_name_config, RANDOMNESS0, "dataset", "last_name"
     )
     first_name_data = first_name_data.squeeze()
+    noised_first_names = noised_first_names.squeeze()
     last_name_data = last_name_data.squeeze()
+    noised_last_names = noised_last_names.squeeze()
 
     # Check missing are unchanged
     orig_missing = first_name_data == ""
@@ -745,10 +770,10 @@ def test_generate_phonetic_errors(dummy_dataset, column):
     config = config[DATASETS.census.name][Keys.COLUMN_NOISE][column][
         NOISE_TYPES.make_phonetic_errors.name
     ]
-    noised_data = NOISE_TYPES.make_phonetic_errors(
-        dummy_dataset, config, RANDOMNESS0, "dataset", column
-    )
+    noised_data = data.copy()
+    NOISE_TYPES.make_phonetic_errors(noised_data, config, RANDOMNESS0, "dataset", column)
     data = data.squeeze()
+    noised_data = noised_data.squeeze()
 
     # Validate we do not change any missing data
     missing_mask = data.isna()
@@ -786,9 +811,11 @@ def test_phonetic_error_values():
         NOISE_TYPES.make_phonetic_errors.name
     ]
     df = pd.DataFrame({"street_name": data})
-    noised_data = NOISE_TYPES.make_phonetic_errors(
-        df, config, RANDOMNESS0, "dataset", "street_name"
+    noised_data = df.copy()
+    NOISE_TYPES.make_phonetic_errors(
+        noised_data, config, RANDOMNESS0, "dataset", "street_name"
     )
+    noised_data = noised_data["street_name"]
 
     for key in phonetic_errors_dict.keys():
         key_idx = data.index[data == key]
@@ -827,8 +854,10 @@ def test_generate_ocr_errors(dummy_dataset, column):
         NOISE_TYPES.make_ocr_errors.name
     ]
     data = dummy_dataset[[column]]
-    noised_data = NOISE_TYPES.make_ocr_errors(data, config, RANDOMNESS0, "dataset", column)
+    noised_data = data.copy()
+    NOISE_TYPES.make_ocr_errors(noised_data, config, RANDOMNESS0, "dataset", column)
     data = data.squeeze()
+    noised_data = noised_data.squeeze()
 
     # Validate we do not change any missing data
     missing_mask = data == ""
@@ -879,9 +908,9 @@ def test_ocr_replacement_values():
     config = config[DATASETS.census.name][Keys.COLUMN_NOISE]["employer_name"][
         NOISE_TYPES.make_ocr_errors.name
     ]
-    noised_data = NOISE_TYPES.make_ocr_errors(
-        df, config, RANDOMNESS0, "dataset", "employer_name"
-    )
+    noised_data = df.copy()
+    NOISE_TYPES.make_ocr_errors(noised_data, config, RANDOMNESS0, "dataset", "employer_name")
+    noised_data = noised_data["employer_name"]
 
     for key in ocr_errors_dict.keys():
         key_idx = data.index[data == key]
@@ -919,8 +948,10 @@ def test_make_typos(dummy_dataset, column):
         NOISE_TYPES.make_typos.name
     ]
     data = dummy_dataset[[column]]
-    noised_data = NOISE_TYPES.make_typos(data, config, RANDOMNESS0, "dataset", column)
+    noised_data = data.copy()
+    NOISE_TYPES.make_typos(noised_data, config, RANDOMNESS0, "dataset", column)
     data = data.squeeze()
+    noised_data = noised_data.squeeze()
 
     not_missing_idx = data.index[(data.notna()) & (data != "")]
     check_original = data.loc[not_missing_idx]
@@ -994,10 +1025,16 @@ def test_seeds_behave_as_expected(noise_type, data_col, dataset, dataset_col, du
     else:
         data = dummy_dataset[[data_col]]
 
-    noised_data = noise_type(data, config, RANDOMNESS0, dataset, data_col)
-    noised_data_same_seed = noise_type(data, config, RANDOMNESS0, dataset, data_col)
-    noised_data_different_seed = noise_type(data, config, RANDOMNESS1, dataset, data_col)
+    noised_data = data.copy()
+    noise_type(noised_data, config, RANDOMNESS0, dataset, data_col)
+    noised_data_same_seed = data.copy()
+    noise_type(noised_data_same_seed, config, RANDOMNESS0, dataset, data_col)
+    noised_data_different_seed = data.copy()
+    noise_type(noised_data_different_seed, config, RANDOMNESS1, dataset, data_col)
     data = data[data_col]
+    noised_data = noised_data[data_col]
+    noised_data_same_seed = noised_data_same_seed[data_col]
+    noised_data_different_seed = noised_data_different_seed[data_col]
 
     assert (noised_data != data).any()
     assert (noised_data.isna() == noised_data_same_seed.isna()).all()

--- a/tests/unit/test_row_noise.py
+++ b/tests/unit/test_row_noise.py
@@ -41,7 +41,8 @@ def test_omit_row(dummy_data):
         NOISE_TYPES.omit_row.name
     ]
     dataset_name_1 = "dummy_dataset_name"
-    noised_data1 = NOISE_TYPES.omit_row(dataset_name_1, dummy_data, config, RANDOMNESS)
+    noised_data1 = dummy_data.copy()
+    NOISE_TYPES.omit_row(dataset_name_1, noised_data1, config, RANDOMNESS)
 
     expected_noise_1 = config[Keys.ROW_PROBABILITY]
     assert np.isclose(1 - len(noised_data1) / len(dummy_data), expected_noise_1, rtol=0.02)
@@ -63,12 +64,10 @@ def test_do_not_respond(mocker, dummy_data):
     my_dummy_data["age"] = 27
     my_dummy_data["sex"] = "Female"
     my_dummy_data["race_ethnicity"] = "Vulcan"
-    noised_data1 = NOISE_TYPES.do_not_respond(
-        dataset_name_1, my_dummy_data, config, RANDOMNESS
-    )
-    noised_data2 = NOISE_TYPES.do_not_respond(
-        dataset_name_2, my_dummy_data, config, RANDOMNESS
-    )
+    noised_data1 = my_dummy_data.copy()
+    NOISE_TYPES.do_not_respond(dataset_name_1, noised_data1, config, RANDOMNESS)
+    noised_data2 = my_dummy_data.copy()
+    NOISE_TYPES.do_not_respond(dataset_name_2, noised_data2, config, RANDOMNESS)
 
     # Test that noising affects expected proportion with expected types
     assert np.isclose(
@@ -111,7 +110,7 @@ def test_do_not_respond_missing_columns(dummy_data):
         NOISE_TYPES.do_not_respond.name
     ]
     with pytest.raises(ValueError, match="missing required columns"):
-        _ = NOISE_TYPES.do_not_respond("silly_dataset", dummy_data, config, RANDOMNESS)
+        NOISE_TYPES.do_not_respond("silly_dataset", dummy_data, config, RANDOMNESS)
 
 
 @pytest.mark.skip(reason="TODO")


### PR DESCRIPTION
## Noise data in-place

### Description
- *Category*: performance
- *JIRA issue*: None

The thinking here is that we could reduce memory use by doing noising operations in-place on our data instead of making copies. However, I've yet to actually achieve that.

### Testing
- [ ] all tests pass (`pytest --runslow`)

Compared peak memory usage between `main` and this branch for a benchmark test of noising 2 USA shards of each dataset. Do not see a significant decrease, which means that this branch is not addressing the most important memory hotspots.