### PR TITLE
Optimize noise functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,6 @@
+**0.8.0 - 10/24/23**
+ - Improve performance of dataset generation functions
+
 **0.7.2 - 10/16/23**
  - Drop support for python 3.8
  - Fix bug in "Choose the wrong option" noise type

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -392,8 +392,9 @@ def use_nicknames(
     :return: pd.Series of nicknames replacing original names
     """
     nicknames = load_nicknames_data()
+    nickname_eligible_names = set(nicknames.index)
     column = data[column_name]
-    have_nickname_idx = column.index[column.isin(nicknames.index)]
+    have_nickname_idx = column.index[column.isin(nickname_eligible_names)]
     noised = two_d_array_choice(
         column.loc[have_nickname_idx], nicknames, randomness_stream, column_name
     )

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -611,14 +611,9 @@ def make_ocr_errors(
     # Apply keyboard corrupt for OCR to column
     token_noise_level = configuration[Keys.TOKEN_PROBABILITY]
     rng = np.random.default_rng(seed=get_hash(f"{randomness_stream.seed}_make_ocr_errors"))
-    column = data[column_name]
-    column = column.astype(str)
-    for idx in column.index:
-        noised_value = ocr_corrupt(
-            column.loc[idx],
-            token_noise_level,
-            rng,
-        )
-        column[idx] = noised_value
 
-    return column
+    return (
+        data[column_name]
+        .astype(str)
+        .apply(ocr_corrupt, corrupted_pr=token_noise_level, rng=rng)
+    )

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -10,11 +10,15 @@ from pseudopeople.configuration import Keys
 from pseudopeople.constants import data_values, paths
 from pseudopeople.constants.metadata import COPY_HOUSEHOLD_MEMBER_COLS, DatasetNames
 from pseudopeople.data.fake_names import fake_first_names, fake_last_names
-from pseudopeople.noise_scaling import load_nicknames_data
+from pseudopeople.noise_scaling import (
+    load_incorrect_select_options,
+    load_nicknames_data,
+)
 from pseudopeople.utilities import (
     get_index_to_noise,
     load_ocr_errors_dict,
     load_phonetic_errors_dict,
+    load_qwerty_errors_data,
     two_d_array_choice,
     vectorized_choice,
 )
@@ -171,7 +175,7 @@ def choose_wrong_options(
         "mailing_address_state": "state",
     }.get(str(column_name), column_name)
 
-    selection_options = pd.read_csv(paths.INCORRECT_SELECT_NOISE_OPTIONS_DATA)
+    selection_options = load_incorrect_select_options()
 
     # Get possible noise values
     # todo: Update with exclusive resampling when vectorized_choice is improved
@@ -546,11 +550,10 @@ def make_typos(
     :param column_name: String for column that will be noised, will be the key for RandomnessStream
     :returns: pd.Series of column with noised data
     """
-    with open(paths.QWERTY_ERRORS) as f:
-        qwerty_errors = yaml.safe_load(f)
 
-    qwerty_errors_eligible_chars = set(qwerty_errors.keys())
-    qwerty_errors = pd.DataFrame.from_dict(qwerty_errors, orient="index")
+    qwerty_errors = load_qwerty_errors_data()
+    qwerty_errors_eligible_chars = set(qwerty_errors.index)
+
     column = data[column_name]
     if column.empty:
         return column

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -476,6 +476,7 @@ def make_phonetic_errors(
                         err += rng.choice(phonetic_error_dict[token])
                         i += token_length
                         error_introduced = True
+                        break
             if not error_introduced:
                 err += truth[i : (i + 1)]
                 i += 1
@@ -485,16 +486,11 @@ def make_phonetic_errors(
     rng = np.random.default_rng(
         seed=get_hash(f"{randomness_stream.seed}_make_phonetic_errors")
     )
-    column = data[column_name]
-    column = column.astype(str)
-    for idx in column.index:
-        noised_value = phonetic_corrupt(
-            column[idx],
-            token_noise_level,
-            rng,
-        )
-        column[idx] = noised_value
-    return column
+    return (
+        data[column_name]
+        .astype(str)
+        .apply(phonetic_corrupt, corrupted_pr=token_noise_level, rng=rng)
+    )
 
 
 def leave_blanks(

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -66,15 +66,21 @@ def _get_census_omission_noise_levels(
         .astype(str)
         .map(data_values.DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_RACE)
     )
+    ages = pd.Series(np.arange(population["age"].max() + 1))
     for sex in ["Female", "Male"]:
-        sex_mask = population["sex"] == sex
-        age_bins = pd.cut(
-            x=population[sex_mask]["age"],
-            bins=data_values.DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_SEX_AGE[sex].index,
+        effect_by_age_bin = data_values.DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_SEX_AGE[sex]
+        # NOTE: calling pd.cut on a large array with an IntervalIndex is slow,
+        # see https://github.com/pandas-dev/pandas/issues/47614
+        # Instead, we only pd.cut the unique ages, then do a simpler `.map` on the age column
+        age_bins = pd.cut(ages, bins=effect_by_age_bin.index)
+        effect_by_age = pd.Series(
+            age_bins.map(effect_by_age_bin),
+            index=ages,
         )
-        probabilities[sex_mask] += age_bins.map(
-            data_values.DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_SEX_AGE[sex]
-        ).astype(float)
+        sex_mask = population["sex"] == sex
+        probabilities[sex_mask] += (
+            population[sex_mask]["age"].map(effect_by_age).astype(float)
+        )
     probabilities[probabilities < 0.0] = 0.0
     probabilities[probabilities > 1.0] = 1.0
     return probabilities

--- a/src/pseudopeople/noise_scaling.py
+++ b/src/pseudopeople/noise_scaling.py
@@ -1,3 +1,5 @@
+from functools import cache
+
 import numpy as np
 import pandas as pd
 
@@ -47,6 +49,7 @@ def scale_copy_from_household_member(data: pd.DataFrame, column_name: str) -> fl
 ####################
 
 
+@cache
 def load_nicknames_data():
     # Load and format nicknames dataset
     nicknames = pd.read_csv(paths.NICKNAMES_DATA)
@@ -69,5 +72,10 @@ def get_options_for_column(column_name: str) -> pd.Series:
         COLUMNS.mailing_state.name: COLUMNS.state.name,
     }.get(column_name, column_name)
 
-    selection_options = pd.read_csv(paths.INCORRECT_SELECT_NOISE_OPTIONS_DATA)
+    selection_options = load_incorrect_select_options()
     return selection_options.loc[selection_options[selection_type].notna(), selection_type]
+
+
+@cache
+def load_incorrect_select_options() -> pd.DataFrame:
+    return pd.read_csv(paths.INCORRECT_SELECT_NOISE_OPTIONS_DATA)

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -198,7 +198,7 @@ def load_phonetic_errors_dict():
         header=None,
         names=["where", "orig", "new", "pre", "post", "pattern", "start"],
     )
-    phonetic_error_dict = phonetic_errors.groupby("orig")["new"].apply(
+    phonetic_error_series = phonetic_errors.groupby("orig")["new"].apply(
         lambda x: list(x.str.replace("@", ""))
     )
-    return phonetic_error_dict
+    return phonetic_error_series.to_dict()

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -1,6 +1,6 @@
 import sys
 from functools import cache
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -65,6 +65,7 @@ def get_index_to_noise(
     randomness_stream: RandomnessStream,
     additional_key: Any,
     is_column_noise: bool = False,
+    missingness: Optional[pd.DataFrame] = None,
 ) -> pd.Index:
     """
     Function that takes a series and returns a pd.Index that chosen by Vivarium Common Random Number to be noised.
@@ -72,8 +73,10 @@ def get_index_to_noise(
 
     # Get rows to noise
     if is_column_noise:
-        missing_idx = data.index[(data.isna().any(axis=1)) | (data.isin([""]).any(axis=1))]
-        eligible_for_noise_idx = data.index.difference(missing_idx)
+        if missingness is None:
+            missingness = data.isna() | (data == "")
+        missing = missingness.any(axis=1)
+        eligible_for_noise_idx = data.index[~missing]
     else:
         # Any index can be noised for row noise
         eligible_for_noise_idx = data.index

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -1,8 +1,10 @@
 import sys
+from functools import cache
 from typing import Any, Union
 
 import numpy as np
 import pandas as pd
+import yaml
 from loguru import logger
 from vivarium.framework.randomness import RandomnessStream, get_hash
 from vivarium.framework.randomness.index_map import IndexMap
@@ -191,6 +193,7 @@ def cleanse_integer_columns(column: pd.Series) -> pd.Series:
 ##########################
 
 
+@cache
 def load_ocr_errors_dict():
     ocr_errors = pd.read_csv(
         paths.OCR_ERRORS_DATA, skiprows=[0, 1], header=None, names=["ocr_true", "ocr_err"]
@@ -203,6 +206,7 @@ def load_ocr_errors_dict():
     return ocr_error_dict
 
 
+@cache
 def load_phonetic_errors_dict():
     phonetic_errors = pd.read_csv(
         paths.PHONETIC_ERRORS_DATA,
@@ -214,3 +218,11 @@ def load_phonetic_errors_dict():
         lambda x: list(x.str.replace("@", ""))
     )
     return phonetic_error_series.to_dict()
+
+
+@cache
+def load_qwerty_errors_data() -> pd.DataFrame:
+    with open(paths.QWERTY_ERRORS) as f:
+        qwerty_errors = yaml.safe_load(f)
+
+    return pd.DataFrame.from_dict(qwerty_errors, orient="index")

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -41,21 +41,22 @@ def vectorized_choice(
 
     returns: ndarray
     """
-    if weights is None:
-        n = len(options)
-        weights = np.ones(n) / n
-    if isinstance(weights, list):
-        weights = np.array(weights)
     # for each of n_to_choose, sample uniformly between 0 and 1
     index = pd.Index(np.arange(n_to_choose))
     probs = randomness_stream.get_draw(index, additional_key=additional_key)
 
-    # build cdf based on weights
-    pmf = weights / weights.sum()
-    cdf = np.cumsum(pmf)
+    if weights is None:
+        chosen_indices = np.floor(probs * len(options)).astype(int)
+    else:
+        if isinstance(weights, list):
+            weights = np.array(weights)
+        # build cdf based on weights
+        pmf = weights / weights.sum()
+        cdf = np.cumsum(pmf)
 
-    # for each p_i in probs, count how many elements of cdf for which p_i >= cdf_i
-    chosen_indices = np.searchsorted(cdf, probs, side="right")
+        # for each p_i in probs, count how many elements of cdf for which p_i >= cdf_i
+        chosen_indices = np.searchsorted(cdf, probs, side="right")
+
     return np.take(options, chosen_indices, axis=0)
 
 

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -123,7 +123,7 @@ def test_generate_dataset_from_sample_and_source(
         elif dataset_name == DATASETS.tax_1040.name:
             rtol = 0.35
         else:
-            rtol = 0.13
+            rtol = 0.15
         assert np.isclose(noise_level_full_dataset, noise_level_single_dataset, rtol=rtol)
 
 

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -150,7 +150,7 @@ def test_leave_blank(dummy_dataset):
         }
     )
     data = dummy_dataset[["numbers"]]
-    noised_data = NOISE_TYPES.leave_blank(data, config, RANDOMNESS0, "dataset", "numbers")
+    noised_data, _ = NOISE_TYPES.leave_blank(data, config, RANDOMNESS0, "dataset", "numbers")
 
     # Calculate newly missing data, ie data that didn't come in as already missing
     data = data.squeeze()
@@ -174,7 +174,7 @@ def test_choose_wrong_option(dummy_dataset):
         NOISE_TYPES.choose_wrong_option.name
     ]
     data = dummy_dataset[["state"]]
-    noised_data = NOISE_TYPES.choose_wrong_option(
+    noised_data, _ = NOISE_TYPES.choose_wrong_option(
         data, config, RANDOMNESS0, "dataset", "state"
     )
     data = data.squeeze()
@@ -196,7 +196,7 @@ def test_generate_copy_from_household_member(dummy_dataset):
         NOISE_TYPES.copy_from_household_member.name
     ]
     data = dummy_dataset[["age", "copy_age"]]
-    noised_data = NOISE_TYPES.copy_from_household_member(
+    noised_data, _ = NOISE_TYPES.copy_from_household_member(
         data, config, RANDOMNESS0, "dataset", "age"
     )
 
@@ -246,7 +246,7 @@ def test_swap_months_and_days(dummy_dataset):
                 NOISE_TYPES.swap_month_and_day.name
             ]
         expected_noise = config[Keys.CELL_PROBABILITY]
-        noised_data = NOISE_TYPES.swap_month_and_day(
+        noised_data, _ = NOISE_TYPES.swap_month_and_day(
             data, config, RANDOMNESS0, DATASETS.census.name, col
         )
 
@@ -284,7 +284,7 @@ def test_write_wrong_zipcode_digits(dummy_dataset):
     # Get configuration values for each piece of 5 digit zipcode
     probability = config[Keys.CELL_PROBABILITY]
     data = dummy_dataset[["zipcode"]]
-    noised_data = NOISE_TYPES.write_wrong_zipcode_digits(
+    noised_data, _ = NOISE_TYPES.write_wrong_zipcode_digits(
         data, config, RANDOMNESS0, "dataset", "zipcode"
     )
 
@@ -310,7 +310,7 @@ def test_miswrite_ages_default_config(dummy_dataset):
         NOISE_TYPES.misreport_age.name
     ]
     data = dummy_dataset[["age"]]
-    noised_data = NOISE_TYPES.misreport_age(data, config, RANDOMNESS0, "dataset", "age")
+    noised_data, _ = NOISE_TYPES.misreport_age(data, config, RANDOMNESS0, "dataset", "age")
     data = data.squeeze()
 
     # Check for expected noise level
@@ -353,7 +353,7 @@ def test_miswrite_ages_uniform_probabilities():
 
     data = pd.Series([str(original_age)] * num_rows, name="age")
     df = pd.DataFrame({"age": data})
-    noised_data = NOISE_TYPES.misreport_age(df, config, RANDOMNESS0, "dataset", "age")
+    noised_data, _ = NOISE_TYPES.misreport_age(df, config, RANDOMNESS0, "dataset", "age")
     expected_noise = 1 / len(perturbations)
     for perturbation in perturbations:
         actual_noise = (noised_data.astype(int) - original_age == perturbation).mean()
@@ -383,7 +383,7 @@ def test_miswrite_ages_provided_probabilities():
 
     data = pd.Series([str(original_age)] * num_rows, name="age")
     df = pd.DataFrame({"age": data})
-    noised_data = NOISE_TYPES.misreport_age(df, config, RANDOMNESS0, "dataset", "age")
+    noised_data, _ = NOISE_TYPES.misreport_age(df, config, RANDOMNESS0, "dataset", "age")
     for perturbation in perturbations:
         expected_noise = perturbations[perturbation]
         actual_noise = (noised_data.astype(int) - original_age == perturbation).mean()
@@ -417,7 +417,7 @@ def test_miswrite_ages_handles_perturbation_to_same_age():
 
     data = pd.Series([str(age)] * num_rows, name="age")
     df = pd.DataFrame({"age": data})
-    noised_data = NOISE_TYPES.misreport_age(df, config, RANDOMNESS0, "dataset", "age")
+    noised_data, _ = NOISE_TYPES.misreport_age(df, config, RANDOMNESS0, "dataset", "age")
 
     assert (noised_data == 0).all()
 
@@ -445,7 +445,7 @@ def test_miswrite_ages_flips_negative_to_positive():
 
     data = pd.Series([str(age)] * num_rows, name="age")
     df = pd.DataFrame({"age": data})
-    noised_data = NOISE_TYPES.misreport_age(df, config, RANDOMNESS0, "dataset", "age")
+    noised_data, _ = NOISE_TYPES.misreport_age(df, config, RANDOMNESS0, "dataset", "age")
 
     assert (noised_data == 4).all()
 
@@ -480,7 +480,7 @@ def test_write_wrong_digits_robust(dummy_dataset):
     data = dummy_dataset[["street_number"]]
     # Note: I changed this column from string_series to street number. It has several string formats
     # containing both numeric and alphabetically string characters.
-    noised_data = NOISE_TYPES.write_wrong_digits(
+    noised_data, _ = NOISE_TYPES.write_wrong_digits(
         data, config, RANDOMNESS0, "dataset", "street_number"
     )
 
@@ -585,7 +585,7 @@ def test_write_wrong_digits(dummy_dataset):
     data = dummy_dataset[["street_number"]]
     # Note: I changed this column from string_series to street number. It has several string formats
     # containing both numeric and alphabetically string characters.
-    noised_data = NOISE_TYPES.write_wrong_digits(
+    noised_data, _ = NOISE_TYPES.write_wrong_digits(
         data, config, RANDOMNESS0, "dataset", "street_number"
     )
 
@@ -609,7 +609,9 @@ def test_use_nickname(dummy_dataset):
     ]
     expected_noise = config[Keys.CELL_PROBABILITY]
     data = dummy_dataset[["first_name"]]
-    noised_data = NOISE_TYPES.use_nickname(data, config, RANDOMNESS0, "dataset", "first_name")
+    noised_data, _ = NOISE_TYPES.use_nickname(
+        data, config, RANDOMNESS0, "dataset", "first_name"
+    )
     data = data.squeeze()
 
     # Validate missing stays missing
@@ -681,10 +683,10 @@ def test_use_fake_name(dummy_dataset):
     # This will help demonstrate that the additional key is working correctly
     first_name_data = dummy_dataset[["first_name"]]
     last_name_data = dummy_dataset[["last_name"]]
-    noised_first_names = NOISE_TYPES.use_fake_name(
+    noised_first_names, _ = NOISE_TYPES.use_fake_name(
         first_name_data, first_name_config, RANDOMNESS0, "dataset", "first_name"
     )
-    noised_last_names = NOISE_TYPES.use_fake_name(
+    noised_last_names, _ = NOISE_TYPES.use_fake_name(
         last_name_data, last_name_config, RANDOMNESS0, "dataset", "last_name"
     )
     first_name_data = first_name_data.squeeze()
@@ -745,7 +747,7 @@ def test_generate_phonetic_errors(dummy_dataset, column):
     config = config[DATASETS.census.name][Keys.COLUMN_NOISE][column][
         NOISE_TYPES.make_phonetic_errors.name
     ]
-    noised_data = NOISE_TYPES.make_phonetic_errors(
+    noised_data, _ = NOISE_TYPES.make_phonetic_errors(
         dummy_dataset, config, RANDOMNESS0, "dataset", column
     )
     data = data.squeeze()
@@ -786,7 +788,7 @@ def test_phonetic_error_values():
         NOISE_TYPES.make_phonetic_errors.name
     ]
     df = pd.DataFrame({"street_name": data})
-    noised_data = NOISE_TYPES.make_phonetic_errors(
+    noised_data, _ = NOISE_TYPES.make_phonetic_errors(
         df, config, RANDOMNESS0, "dataset", "street_name"
     )
 
@@ -827,7 +829,7 @@ def test_generate_ocr_errors(dummy_dataset, column):
         NOISE_TYPES.make_ocr_errors.name
     ]
     data = dummy_dataset[[column]]
-    noised_data = NOISE_TYPES.make_ocr_errors(data, config, RANDOMNESS0, "dataset", column)
+    noised_data, _ = NOISE_TYPES.make_ocr_errors(data, config, RANDOMNESS0, "dataset", column)
     data = data.squeeze()
 
     # Validate we do not change any missing data
@@ -879,7 +881,7 @@ def test_ocr_replacement_values():
     config = config[DATASETS.census.name][Keys.COLUMN_NOISE]["employer_name"][
         NOISE_TYPES.make_ocr_errors.name
     ]
-    noised_data = NOISE_TYPES.make_ocr_errors(
+    noised_data, _ = NOISE_TYPES.make_ocr_errors(
         df, config, RANDOMNESS0, "dataset", "employer_name"
     )
 
@@ -919,7 +921,7 @@ def test_make_typos(dummy_dataset, column):
         NOISE_TYPES.make_typos.name
     ]
     data = dummy_dataset[[column]]
-    noised_data = NOISE_TYPES.make_typos(data, config, RANDOMNESS0, "dataset", column)
+    noised_data, _ = NOISE_TYPES.make_typos(data, config, RANDOMNESS0, "dataset", column)
     data = data.squeeze()
 
     not_missing_idx = data.index[(data.notna()) & (data != "")]
@@ -994,9 +996,9 @@ def test_seeds_behave_as_expected(noise_type, data_col, dataset, dataset_col, du
     else:
         data = dummy_dataset[[data_col]]
 
-    noised_data = noise_type(data, config, RANDOMNESS0, dataset, data_col)
-    noised_data_same_seed = noise_type(data, config, RANDOMNESS0, dataset, data_col)
-    noised_data_different_seed = noise_type(data, config, RANDOMNESS1, dataset, data_col)
+    noised_data, _ = noise_type(data, config, RANDOMNESS0, dataset, data_col)
+    noised_data_same_seed, _ = noise_type(data, config, RANDOMNESS0, dataset, data_col)
+    noised_data_different_seed, _ = noise_type(data, config, RANDOMNESS1, dataset, data_col)
     data = data[data_col]
 
     assert (noised_data != data).any()

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -290,34 +290,34 @@ def test_two_noise_functions_are_independent(mocker):
     assert np.isclose(
         noised_data["fake_column_one"].str.contains("abc").mean(),
         col1_expected_abc_proportion,
-        rtol=0.01,
+        rtol=0.02,
     )
     assert np.isclose(
         noised_data["fake_column_two"].str.contains("abc").mean(),
         col2_expected_abc_proportion,
-        rtol=0.01,
+        rtol=0.02,
     )
     assert np.isclose(
         noised_data["fake_column_one"].str.contains("123").mean(),
         col1_expected_123_proportion,
-        rtol=0.01,
+        rtol=0.02,
     )
     assert np.isclose(
         noised_data["fake_column_two"].str.contains("123").mean(),
         col2_expected_123_proportion,
-        rtol=0.01,
+        rtol=0.02,
     )
 
     # Assert columns experience both noise
     assert np.isclose(
         noised_data["fake_column_one"].str.contains("abc123").mean(),
         col1_expected_abc_proportion * col1_expected_123_proportion,
-        rtol=0.01,
+        rtol=0.02,
     )
     assert np.isclose(
         noised_data["fake_column_two"].str.contains("abc123").mean(),
         col2_expected_abc_proportion * col2_expected_123_proportion,
-        rtol=0.01,
+        rtol=0.02,
     )
     assert noised_data["fake_column_one"].str.contains("123abc").sum() == 0
     assert noised_data["fake_column_two"].str.contains("123abc").sum() == 0

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -234,10 +234,12 @@ def test_two_noise_functions_are_independent(mocker):
                     "fake_column_one": {
                         "alpha": {Keys.CELL_PROBABILITY: 0.20},
                         "beta": {Keys.CELL_PROBABILITY: 0.30},
+                        "leave_blank": {Keys.CELL_PROBABILITY: 0},
                     },
                     "fake_column_two": {
                         "alpha": {Keys.CELL_PROBABILITY: 0.40},
                         "beta": {Keys.CELL_PROBABILITY: 0.50},
+                        "leave_blank": {Keys.CELL_PROBABILITY: 0},
                     },
                 },
             }
@@ -254,6 +256,10 @@ def test_two_noise_functions_are_independent(mocker):
         BETA: ColumnNoiseType = ColumnNoiseType(
             "beta",
             lambda data, *_: data.squeeze().str.cat(pd.Series("123", index=data.index)),
+        )
+        leave_blank = ColumnNoiseType(
+            "leave_blank",
+            lambda data, *_: pd.Series(np.nan, index=data.index),
         )
 
     mock_noise_types = MockNoiseTypes()


### PR DESCRIPTION
## Optimize noise functions

### Description
- *Category*: performance
- *JIRA issue*: none

Speeds up the noising process by taking advantage of vectorization, avoiding unnecessary random number generation, and caching expensive information.

This is a large PR but I have broken it down into pretty atomic commits. You may want to review one at a time.

### Testing
- [x] all tests pass (`pytest --runslow`)

To get a pretty representative benchmark of pseudopeople performance, I noised the first two shards of each dataset in the full-USA data. On `main` this took about 15 minutes.

I profiled this benchmark with cProfile, and drilled down to what was taking the time in the noising process (within `noise_dataset`):

![image](https://github.com/ihmeuw/pseudopeople/assets/13357648/c28b96b3-5e75-41e0-823c-f2cde5be0857)

I then tried to address all the hotspots I saw in that benchmark. I didn't optimize all the noise functions, just the ones that seemed to be easily optimizable.

On this branch, the benchmark takes 7.5 minutes to run. Since a big chunk of the time is just loading the data, that means noising sped up by significantly more than 50%. Here is what the same profile looks like after these changes:

![image](https://github.com/ihmeuw/pseudopeople/assets/13357648/5b1a789d-0e25-4ec1-ae3a-4920f83f02d3)
