### PR TITLE
Drop index from simulated population data

### DIFF
--- a/src/pseudopeople/loader.py
+++ b/src/pseudopeople/loader.py
@@ -44,4 +44,12 @@ def load_standard_dataset(
             "Please provide the path to the unmodified root data directory."
         )
 
+    # TODO: The index in our simulated population files is never meaningful.
+    # For some reason, the 1040 dataset is currently saved with a non-RangeIndex
+    # in the large data, and all datasets have a non-RangeIndex in the sample data.
+    # If we don't drop these here, our index can have duplicates when we load multiple
+    # shards at once. Having duplicates in the index breaks much of
+    # our noising logic.
+    data.reset_index(drop=True, inplace=True)
+
     return data

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -110,7 +110,7 @@ def test_generate_dataset_from_sample_and_source(
         # meaningfully compare because the stochastic variation is so great
         # As of 8/31/2023, this only skips unit_number (very missing) in the
         # ACS and CPS datasets (very small)
-        if len(compare_sample_idx) < 30 or len(compare_dataset_idx) < 30:
+        if len(compare_sample_idx) < 50 or len(compare_dataset_idx) < 50:
             warnings.warn(
                 f"Noise levels in {col} of {dataset_name} were not compared because the numbers of rows eligible "
                 f"for noise were only {len(compare_sample_idx)} and {len(compare_dataset_idx)}"


### PR DESCRIPTION
## Drop index from simulated population data

### Description
- *Category*: bugfix
- *JIRA issue*: None, workaround for [MIC-4620](https://jira.ihme.washington.edu/browse/MIC-4620)

Note that for the large data, this only affects the 1040, but for the sample data it affects all datasets. I don't know why this is.

### Testing
- [x] all tests pass (`pytest --runslow`)

After making this change, I can load and noise the USA 1040 data with Modin.