### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**0.8.0 - 10/24/23**
+**0.8.0 - 10/25/23**
  - Improve performance of dataset generation functions
 
 **0.7.2 - 10/16/23**

--- a/src/pseudopeople/__about__.py
+++ b/src/pseudopeople/__about__.py
@@ -13,7 +13,7 @@ __title__ = "pseudopeople"
 __summary__ = "pseudopeople is package which adds noise to simulated census-scale data using standard scientific Python tools."
 __uri__ = "https://github.com/ihmeuw/pseudopeople"
 
-__version__ = "0.7.2"
+__version__ = "0.8.0"
 
 __author__ = "The pseudopeople developers"
 __email__ = "vivarium.dev@gmail.com"


### PR DESCRIPTION
## Release 0.8.0

### Description
- *Category*: release
- *JIRA issue*: None

PR #333 did not update the version number, causing the release to fail.

### Testing
- [ ] all tests pass (`pytest --runslow`)

None.