### PR TITLE
Mic 4666/schedule build slow tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           isort . --check --verbose --only-modified --diff
       - name: Test
         run: |
-          if "${{ github.event_name == 'push' }}"; then
+          if "${{ github.event_name == 'schedule' }}"; then
             pytest --runslow ./tests
           else
             pytest --limit=1 ./tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-    defaults:
-      run:
-        shell: bash -le {0}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -42,7 +39,7 @@ jobs:
           isort . --check --verbose --only-modified --diff
       - name: Test
         run: |
-          if [ ${{ github.event_name }} == 'push']; then
+          if "${{ github.event_name == 'push' }}"; then
             pytest --runslow ./tests
           else
             pytest --limit=1 ./tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
+    defaults:
+      run:
+        shell: bash -le {0}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           isort . --check --verbose --only-modified --diff
       - name: Test
         run: |
-          if github.event_name == 'schedule'; then
+          if [ ${{ github.event_name }} == 'push']; then
             pytest --runslow ./tests
           else
             pytest --limit=1 ./tests


### PR DESCRIPTION
## Mic 4666/schedule build slow tests

### Fixes format of command to trig if block to run schedule tests
- *Category*: CI
- *JIRA issue*: [MIC-4666](https://jira.ihme.washington.edu/browse/MIC-4666)

-updates format of command to trigger slow tests on schedule build

### Testing
Tested new format with push event trigger.