### PR TITLE
Fix bug formatting missing dates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,6 @@
+**0.8.2 - 10/30/23**
+- Fixes a bug in date formatting
+
 **0.8.1 - 10/25/23**
  - Implements setuptools-scm for versioning
 


### PR DESCRIPTION
## Fix bug formatting missing dates

### Description
- *Category*: bugfix
- *JIRA issue*: None

#333 introduced a bug when formatting dates that can have missingness. I did not consider this case because I thought dates were never missing, but their copy-from-household-member "shadow columns" can have missingness.

### Testing
- [x] all tests pass (`pytest --runslow`)

I ran this script to make the rare issue show up a lot:

```python
import pseudopeople as psp

data = psp.generate_social_security(
    source="<USA data but with only one shard>",
    config={
        "social_security": {
            "column_noise": {
                "date_of_birth": {"copy_from_household_member": {"cell_probability": 1}}
            }
        }
    }
)

print(data)
```

On `main` the output is:

```
          simulant_id          ssn first_name middle_name   last_name date_of_birth     sex event_type event_date                                                                                           
0          1007_26121  786-77-6454        Ada     Frances        Clay       nananan  Female   creation   19607416                                                                                           
1         1007_817178  688-88-6377     Robert        John  Scheuneman           NaN    Male   creation   19200705
2         1007_495445  651-33-9561      Ethel       Elsie      Landey       nananan  Female   creation   19200815
3         1007_203914  665-25-7858        NaN      Willie        Owen    2007.0.0.0  Female   creation   19200819
4         1007_439828  875-10-2359    Dorothy       Helen   Gustafson       nananan  Female   creation   19600924
...               ...          ...        ...         ...         ...           ...     ...        ...        ...
1016489  1007_1035841  636-34-4126    Jackson       Jesus      Nguyen    1961.0.0.0    Male   creation   20201231
1016490  1007_1035891  457-49-7291   Avaleigh    Catalina       Stone       nananan  Female   creation   20201231
1016491  1007_1035898  519-72-5170       Lena      Nalani       Mulka       nananan  Female   creation   20201231
1016492  1007_1035950  709-67-8850       Ezra         Kai      Aceves    1979.0.0.0    Male   creation   20201231
1016493  1007_1035960  087-35-6191    Marisol   Gabriella      Dawson    2023.0.0.0  Female   creation   20201231
```

while on this branch it is:

```
          simulant_id          ssn first_name middle_name   last_name date_of_birth     sex event_type event_date                                                                                           
0          1007_26121  786-77-6454        Ada     Frances        Clay      19200416  Female   creation   19607416                                                                                           
1         1007_817178  688-88-6377     Robert        John  Scheuneman           NaN    Male   creation   19200705
2         1007_495445  651-33-9561      Ethel       Elsie      Landey      19200815  Female   creation   19200815
3         1007_203914  665-25-7858        NaN      Willie        Owen      20070104  Female   creation   19200819
4         1007_439828  875-10-2359    Dorothy       Helen   Gustafson      19200924  Female   creation   19600924
...               ...          ...        ...         ...         ...           ...     ...        ...        ...
1016489  1007_1035841  636-34-4126    Jackson       Jesus      Nguyen      19610418    Male   creation   20201231
1016490  1007_1035891  457-49-7291   Avaleigh    Catalina       Stone      20201231  Female   creation   20201231
1016491  1007_1035898  519-72-5170       Lena      Nalani       Mulka      20201231  Female   creation   20201231
1016492  1007_1035950  709-67-8850       Ezra         Kai      Aceves      19791225    Male   creation   20201231
1016493  1007_1035960  087-35-6191    Marisol   Gabriella      Dawson      20230421  Female   creation   20201231
```