### PR TITLE
DOC: add notes about Anytown, WA in default data

### DIFF
--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -8,7 +8,7 @@ Here we cover the realistic simulated datasets, which are analogous to "real wor
 and routinely generated files of social security numbers, that users can generate using Pseudopeople for developing and testing Entity
 Resolution algorithms and software.
 
-Each of the datasets that can be generated using Pseudopeople has "noise" added to them, thereby realistically
+Each of the datasets that can be generated using pseudopeople has "noise" added to it, thereby realistically
 simulating how population data can be corrupted or distorted, which creates challenges in linking those
 records. To read more about the different kinds of noise that can be applied to the different datasets, please see the
 :ref:`Noise page <noise_main>`.

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -26,7 +26,7 @@ A **mailing address** represents the address a simulant uses to receive mail,
 which may be different -- for example, a PO box.
 Mailing addresses, not physical addresses, are recorded in tax filings.
 
-Note that in the small-scale simulated data that is available by default, these addresses all have their city/state/zip code set to the fictitious location of Anytown, WA 00000.  To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see :ref:`Simulated populations <_simulated_populations_main>`.
+Note that in the small-scale simulated data that is available by default, these addresses all have their city/state/zip code set to the fictitious location of Anytown, WA 00000.  To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see :ref:`Simulated populations <simulated_populations_main>`.
 
 Some fields are not applicable to every record in a simulated dataset,
 so some columns may contain "missing" values, even if no noise has been added to the data.

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -26,7 +26,7 @@ A **mailing address** represents the address a simulant uses to receive mail,
 which may be different -- for example, a PO box.
 Mailing addresses, not physical addresses, are recorded in tax filings.
 
-Note that in the small-scale simulated data that is available by default, these addresses all have their city/state/zip code set to the fictitious location of Anytown, WA 00000.  To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see :ref:`Simulated populations <simulated_populations_main>`.
+Note that in the small-scale simulated population that is available by default, these addresses all have their city/state/zip code set to the fictitious location of Anytown, WA 00000.  To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see :ref:`Simulated populations <simulated_populations_main>`.
 
 Some fields are not applicable to every record in a simulated dataset,
 so some columns may contain "missing" values, even if no noise has been added to the data.
@@ -97,10 +97,10 @@ The following columns are included in this dataset:
      - Default simulated population always has value "Anytown"
    * - Physical address state
      - :code:`state`
-     - Default simulated data always has value "WA"
+     - Default simulated population always has value "WA"
    * - Physical address ZIP code
      - :code:`zipcode`
-     - Default simulated data always has value "00000"
+     - Default simulated population always has value "00000"
    * - Housing type
      - :code:`housing_type`
      - Possible values for housing type are "Household" for an individual
@@ -189,13 +189,13 @@ The following columns are included in this dataset:
      -
    * - Physical address city
      - :code:`city`
-     - Default simulated data always has value "Anytown"
+     - Default simulated population always has value "Anytown"
    * - Physical address state
      - :code:`state`
-     - Default simulated data always has value "WA"
+     - Default simulated population always has value "WA"
    * - Physical address ZIP code
      - :code:`zipcode`
-     - Default simulated data always has value "00000"
+     - Default simulated population always has value "00000"
    * - Housing type
      - :code:`housing_type`
      - Possible values for housing type are "Household" for an individual
@@ -281,13 +281,13 @@ The following columns are included in this dataset:
      -
    * - Physical address city
      - :code:`city`
-     - Default simulated data always has value "Anytown"
+     - Default simulated population always has value "Anytown"
    * - Physical address state
      - :code:`state`
-     - Default simulated data always has value "WA"
+     - Default simulated population always has value "WA"
    * - Physical address ZIP code
      - :code:`zipcode`
-     - Default simulated data always has value "00000"
+     - Default simulated population always has value "00000"
    * - Sex
      - :code:`sex`
      - Binary; "male" or "female"
@@ -350,13 +350,13 @@ The following columns are included in this dataset:
      -
    * - Physical address city
      - :code:`city`
-     - Default simulated data always has value "Anytown"
+     - Default simulated population always has value "Anytown"
    * - Physical address state
      - :code:`state`
-     - Default simulated data always has value "WA"
+     - Default simulated population always has value "WA"
    * - Physical address ZIP code
      - :code:`zipcode`
-     - Default simulated data always has value "00000"
+     - Default simulated population always has value "00000"
    * - Sex
      - :code:`sex`
      - Binary; "male" or "female"
@@ -476,13 +476,13 @@ The following columns are included in these datasets:
      -
    * - Employer city
      - :code:`employer_city`
-     - Default simulated data always has value "Anytown"
+     - Default simulated population always has value "Anytown"
    * - Employer state
      - :code:`employer_state`
-     - Default simulated data always has value "WA"
+     - Default simulated population always has value "WA"
    * - Employer ZIP code
      - :code:`employer_zipcode`
-     - Default simulated data always has value "00000"
+     - Default simulated population always has value "00000"
    * - First name
      - :code:`first_name`
      -
@@ -506,13 +506,13 @@ The following columns are included in these datasets:
      -
    * - Mailing address city
      - :code:`mailing_address_city`
-     - Default simulated data always has value "Anytown"
+     - Default simulated population always has value "Anytown"
    * - Mailing address state
      - :code:`mailing_address_state`
-     - Default simulated data always has value "WA"
+     - Default simulated population always has value "WA"
    * - Mailing address ZIP code
      - :code:`mailing_address_zipcode`
-     - Default simulated data always has value "00000"
+     - Default simulated population always has value "00000"
    * - Type of tax form
      - :code:`tax_form`
      - Possible values are "W2" or "1099".
@@ -599,13 +599,13 @@ The following columns are included in this dataset:
      -
    * - Mailing address city
      - :code:`mailing_address_city`
-     - Default simulated data always has value "Anytown"
+     - Default simulated population always has value "Anytown"
    * - Mailing address state
      - :code:`mailing_address_state`
-     - Default simulated data always has value "WA"
+     - Default simulated population always has value "WA"
    * - Mailing address ZIP code
      - :code:`mailing_address_zipcode`
-     - Default simulated data always has value "00000"
+     - Default simulated population always has value "00000"
    * - Joint filer first name
      - :code:`spouse_first_name`
      -

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -8,8 +8,8 @@ Here we cover the realistic simulated datasets, which are analogous to "real wor
 and routinely generated files of social security numbers, that users can generate using Pseudopeople for developing and testing Entity
 Resolution algorithms and software.
 
-Each of the datasets that can be generated using Pseudopeople have "noise" added to them, thereby realistically
-simulating how administrative records can be corrupted or distorted, which creates challenges in linking those
+Each of the datasets that can be generated using Pseudopeople has "noise" added to them, thereby realistically
+simulating how population data can be corrupted or distorted, which creates challenges in linking those
 records. To read more about the different kinds of noise that can be applied to the different datasets, please see the
 :ref:`Noise page <noise_main>`.
 
@@ -25,6 +25,8 @@ which is where they are recorded in the Decennial Census and surveys.
 A **mailing address** represents the address a simulant uses to receive mail,
 which may be different -- for example, a PO box.
 Mailing addresses, not physical addresses, are recorded in tax filings.
+
+Note that in the small-scale simulated data that is available by default, these addresses all have their city/state/zip code set to the fictitious location of Anytown, WA 00000.  To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see :ref:`Simulated populations <_simulated_populations_main>`.
 
 Some fields are not applicable to every record in a simulated dataset,
 so some columns may contain "missing" values, even if no noise has been added to the data.
@@ -92,13 +94,13 @@ The following columns are included in this dataset:
      -
    * - Physical address city
      - :code:`city`
-     -
+     - Default simulated data always has value "Anytown"
    * - Physical address state
      - :code:`state`
-     -
+     - Default simulated data always has value "WA"
    * - Physical address ZIP code
      - :code:`zipcode`
-     -
+     - Default simulated data always has value "00000"
    * - Housing type
      - :code:`housing_type`
      - Possible values for housing type are "Household" for an individual
@@ -187,13 +189,13 @@ The following columns are included in this dataset:
      -
    * - Physical address city
      - :code:`city`
-     -
+     - Default simulated data always has value "Anytown"
    * - Physical address state
      - :code:`state`
-     -
+     - Default simulated data always has value "WA"
    * - Physical address ZIP code
      - :code:`zipcode`
-     -
+     - Default simulated data always has value "00000"
    * - Housing type
      - :code:`housing_type`
      - Possible values for housing type are "Household" for an individual
@@ -279,13 +281,13 @@ The following columns are included in this dataset:
      -
    * - Physical address city
      - :code:`city`
-     -
+     - Default simulated data always has value "Anytown"
    * - Physical address state
      - :code:`state`
-     -
+     - Default simulated data always has value "WA"
    * - Physical address ZIP code
      - :code:`zipcode`
-     -
+     - Default simulated data always has value "00000"
    * - Sex
      - :code:`sex`
      - Binary; "male" or "female"
@@ -348,13 +350,13 @@ The following columns are included in this dataset:
      -
    * - Physical address city
      - :code:`city`
-     -
+     - Default simulated data always has value "Anytown"
    * - Physical address state
      - :code:`state`
-     -
+     - Default simulated data always has value "WA"
    * - Physical address ZIP code
      - :code:`zipcode`
-     -
+     - Default simulated data always has value "00000"
    * - Sex
      - :code:`sex`
      - Binary; "male" or "female"
@@ -474,13 +476,13 @@ The following columns are included in these datasets:
      -
    * - Employer city
      - :code:`employer_city`
-     -
+     - Default simulated data always has value "Anytown"
    * - Employer state
      - :code:`employer_state`
-     -
+     - Default simulated data always has value "WA"
    * - Employer ZIP code
      - :code:`employer_zipcode`
-     -
+     - Default simulated data always has value "00000"
    * - First name
      - :code:`first_name`
      -
@@ -504,13 +506,13 @@ The following columns are included in these datasets:
      -
    * - Mailing address city
      - :code:`mailing_address_city`
-     -
+     - Default simulated data always has value "Anytown"
    * - Mailing address state
      - :code:`mailing_address_state`
-     -
+     - Default simulated data always has value "WA"
    * - Mailing address ZIP code
      - :code:`mailing_address_zipcode`
-     -
+     - Default simulated data always has value "00000"
    * - Type of tax form
      - :code:`tax_form`
      - Possible values are "W2" or "1099".
@@ -597,13 +599,13 @@ The following columns are included in this dataset:
      -
    * - Mailing address city
      - :code:`mailing_address_city`
-     -
+     - Default simulated data always has value "Anytown"
    * - Mailing address state
      - :code:`mailing_address_state`
-     -
+     - Default simulated data always has value "WA"
    * - Mailing address ZIP code
      - :code:`mailing_address_zipcode`
-     -
+     - Default simulated data always has value "00000"
    * - Joint filer first name
      - :code:`spouse_first_name`
      -

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -94,7 +94,7 @@ The following columns are included in this dataset:
      -
    * - Physical address city
      - :code:`city`
-     - Default simulated data always has value "Anytown"
+     - Default simulated population always has value "Anytown"
    * - Physical address state
      - :code:`state`
      - Default simulated data always has value "WA"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -113,6 +113,9 @@ Both datasets have a :code:`simulant_id` column that uniquely identifies an indi
 The unique :code:`simulant_id` present in both datasets provides us with a truth deck,
 which we wouldn't have for a linkage task with real, sensitive data.
 
+Note that in the small-scale simulated data that is available by default, these addresses all have their city/state/zip code set to the fictitious location of Anytown, WA 00000.  To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see :ref:`Simulated populations <_simulated_populations_main>`.
+
+
 ::
 
    >>> # To find how many matches there are between records about a given simulant,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -113,7 +113,7 @@ Both datasets have a :code:`simulant_id` column that uniquely identifies an indi
 The unique :code:`simulant_id` present in both datasets provides us with a truth deck,
 which we wouldn't have for a linkage task with real, sensitive data.
 
-Note that in the small-scale simulated data that is available by default, these addresses all have their city/state/zip code set to the fictitious location of Anytown, WA 00000.  To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see :ref:`Simulated populations <_simulated_populations_main>`.
+Note that in the small-scale simulated data that is available by default, these addresses all have their city/state/zip code set to the fictitious location of Anytown, WA 00000.  To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see :ref:`Simulated populations <simulated_populations_main>`.
 
 
 ::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -113,7 +113,7 @@ Both datasets have a :code:`simulant_id` column that uniquely identifies an indi
 The unique :code:`simulant_id` present in both datasets provides us with a truth deck,
 which we wouldn't have for a linkage task with real, sensitive data.
 
-Note that in the small-scale simulated data that is available by default, these addresses all have their city/state/zip code set to the fictitious location of Anytown, WA 00000.  To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see :ref:`Simulated populations <simulated_populations_main>`.
+Note that in the small-scale simulated population that is available by default, these addresses all have their city/state/zip code set to the fictitious location of Anytown, WA 00000. To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see :ref:`Simulated populations <simulated_populations_main>`.
 
 
 ::

--- a/docs/source/simulated_populations/index.rst
+++ b/docs/source/simulated_populations/index.rst
@@ -37,7 +37,7 @@ datasets.
 ..
   The entire simulation process can be visualized as follows.
 
-  [[Insert image here]]
+  [[TODO: Insert image here]]
 
 Accessing the large-scale simulated populations
 -----------------------------------------------


### PR DESCRIPTION
## Title: Make it clearer in docs that sample data is all for Anytown, WA 00000

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: doc
- *JIRA issue*: none

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

Sam was confused that the default data all had zip code 00000, which he had been using for blocking in his pre-pseudopeople experiements.  I thought I'd make this clearer in the docs, in case it helped future users.

### Testing


I could not remember how to build the docs locally, so we'll see if this passes CI as the test.

- ~~[ ] all tests pass (`pytest --runslow`)~~ --- Not necessary, since I just changed docs
