### PR TITLE
Optimize OCR and phonetic noise types

### DIFF
--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -16,8 +16,8 @@ from pseudopeople.noise_scaling import (
 )
 from pseudopeople.utilities import (
     get_index_to_noise,
-    load_ocr_errors_dict,
-    load_phonetic_errors_dict,
+    load_ocr_errors,
+    load_phonetic_errors,
     load_qwerty_errors_data,
     two_d_array_choice,
     vectorized_choice,
@@ -485,34 +485,16 @@ def make_phonetic_errors(
     :return: pd.Series of noised data
     """
 
-    phonetic_error_dict = load_phonetic_errors_dict()
+    # Load phonetic errors
+    phonetic_errors = load_phonetic_errors()
 
-    def phonetic_corrupt(truth, corrupted_pr, rng):
-        err = ""
-        i = 0
-        while i < len(truth):
-            error_introduced = False
-            for token_length in [7, 6, 5, 4, 3, 2, 1]:
-                token = truth[i : (i + token_length)]
-                if token in phonetic_error_dict and not error_introduced:
-                    if rng.uniform() < corrupted_pr:
-                        err += rng.choice(phonetic_error_dict[token])
-                        i += token_length
-                        error_introduced = True
-                        break
-            if not error_introduced:
-                err += truth[i : (i + 1)]
-                i += 1
-        return err
-
-    token_noise_level = configuration[Keys.TOKEN_PROBABILITY]
-    rng = np.random.default_rng(
-        seed=get_hash(f"{randomness_stream.seed}_make_phonetic_errors")
-    )
-    return (
-        data[column_name]
-        .astype(str)
-        .apply(phonetic_corrupt, corrupted_pr=token_noise_level, rng=rng)
+    return _corrupt_tokens(
+        phonetic_errors,
+        data,
+        configuration,
+        randomness_stream,
+        column_name,
+        addl_key="make_phonetic_errors",
     )
 
 
@@ -634,32 +616,102 @@ def make_ocr_errors(
     """
 
     # Load OCR error dict
-    ocr_error_dict = load_ocr_errors_dict()
+    ocr_errors = load_ocr_errors()
 
-    def ocr_corrupt(truth, corrupted_pr, rng):
-        err = ""
-        i = 0
-        while i < len(truth):
-            error_introduced = False
-            for token_length in [3, 2, 1]:
-                token = truth[i : (i + token_length)]
-                if token in ocr_error_dict and not error_introduced:
-                    if rng.uniform() < corrupted_pr:
-                        err += rng.choice(ocr_error_dict[token])
-                        i += token_length
-                        error_introduced = True
-                        break
-            if not error_introduced:
-                err += truth[i : (i + 1)]
-                i += 1
-        return err
-
-    # Apply keyboard corrupt for OCR to column
-    token_noise_level = configuration[Keys.TOKEN_PROBABILITY]
-    rng = np.random.default_rng(seed=get_hash(f"{randomness_stream.seed}_make_ocr_errors"))
-
-    return (
-        data[column_name]
-        .astype(str)
-        .apply(ocr_corrupt, corrupted_pr=token_noise_level, rng=rng)
+    return _corrupt_tokens(
+        ocr_errors,
+        data,
+        configuration,
+        randomness_stream,
+        column_name,
+        addl_key="make_ocr_errors",
     )
+
+
+def _corrupt_tokens(
+    errors, data, configuration, randomness_stream, column_name, addl_key
+) -> pd.Series:
+    max_token_length = errors.index.str.len().max()
+    errors_eligible_tokens = (
+        pd.Series(errors.index).groupby(errors.index.str.len()).apply(set).to_dict()
+    )
+    number_of_options = errors.count(axis=1)
+    errors_stacked = errors.stack()
+
+    column = data[column_name].astype(str)
+
+    lengths = column.str.len().values
+
+    same_len_col_exploded = (
+        column
+        # Convert to numpy string dtype
+        .values.astype(str)
+        .view("U1")
+        .reshape((len(data), lengths.max()))
+    )
+
+    token_noise_level = configuration[Keys.TOKEN_PROBABILITY]
+    rng = np.random.default_rng(seed=get_hash(f"{randomness_stream.seed}_{addl_key}"))
+
+    result = np.empty(same_len_col_exploded.shape, dtype=str).astype("object")
+    next_due = np.zeros(len(data))
+    for i in range(same_len_col_exploded.shape[1]):
+        error_introduced = np.zeros(len(data), dtype=bool)
+        for token_length in range(max_token_length, 0, -1):
+            if i + token_length > same_len_col_exploded.shape[1]:
+                continue
+
+            due = ~error_introduced & (next_due <= i)
+
+            long_enough = np.zeros(len(data), dtype=bool)
+            long_enough[due] = i + token_length <= lengths[due]
+            if long_enough.sum() == 0:
+                continue
+
+            tokens = np.empty(len(data), dtype=f"U{token_length}")
+            tokens[long_enough] = (
+                same_len_col_exploded[long_enough, i : (i + token_length)]
+                .view(f"U{token_length}")
+                .reshape(long_enough.sum())
+            )
+
+            eligible = np.zeros(len(data), dtype=bool)
+            eligible[long_enough] = (
+                pd.Series(tokens[long_enough])
+                .isin(errors_eligible_tokens[token_length])
+                .values
+            )
+            if eligible.sum() == 0:
+                continue
+
+            corrupted = np.zeros(len(data), dtype=bool)
+            corrupted[eligible] = rng.random(eligible.sum()) < token_noise_level
+            if corrupted.sum() == 0:
+                continue
+
+            to_corrupt = tokens[corrupted]
+            corrupted_token_index = np.floor(
+                rng.random(corrupted.sum()) * number_of_options.loc[to_corrupt].to_numpy()
+            )
+            # Numpy does not have an efficient way to do this merge operation
+            result[corrupted, i] = (
+                pd.DataFrame(
+                    {"to_corrupt": to_corrupt, "corrupted_token_index": corrupted_token_index}
+                )
+                .reset_index()
+                .merge(
+                    errors_stacked.rename("corruption"),
+                    left_on=["to_corrupt", "corrupted_token_index"],
+                    right_index=True,
+                )
+                # Merge does not return the results in order
+                .sort_values("index")
+                .corruption.to_numpy()
+            )
+            next_due[corrupted] += token_length
+            error_introduced[corrupted] = True
+
+        use_original_char = ~error_introduced & (next_due <= i)
+        result[use_original_char, i] = same_len_col_exploded[use_original_char, i]
+
+    return pd.Series(result.sum(axis=1), index=data.index)

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -198,7 +198,7 @@ def cleanse_integer_columns(column: pd.Series) -> pd.Series:
 
 
 @cache
-def load_ocr_errors_dict():
+def load_ocr_errors():
     ocr_errors = pd.read_csv(
         paths.OCR_ERRORS_DATA, skiprows=[0, 1], header=None, names=["ocr_true", "ocr_err"]
     )
@@ -206,22 +206,27 @@ def load_ocr_errors_dict():
     ocr_error_dict = (
         ocr_errors.groupby("ocr_true")["ocr_err"].apply(lambda x: list(x)).to_dict()
     )
+    ocr_errors = pd.DataFrame.from_dict(ocr_error_dict, orient="index")
 
-    return ocr_error_dict
+    return ocr_errors
 
 
 @cache
-def load_phonetic_errors_dict():
+def load_phonetic_errors():
     phonetic_errors = pd.read_csv(
         paths.PHONETIC_ERRORS_DATA,
         skiprows=[0, 1],
         header=None,
         names=["where", "orig", "new", "pre", "post", "pattern", "start"],
     )
-    phonetic_error_series = phonetic_errors.groupby("orig")["new"].apply(
-        lambda x: list(x.str.replace("@", ""))
+    phonetic_error_dict = (
+        phonetic_errors.groupby("orig")["new"]
+        .apply(lambda x: list(x.str.replace("@", "")))
+        .to_dict()
     )
-    return phonetic_error_series.to_dict()
+    phonetic_errors = pd.DataFrame.from_dict(phonetic_error_dict, orient="index")
+
+    return phonetic_errors
 
 
 @cache

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -12,7 +12,7 @@ from pseudopeople.constants.metadata import COPY_HOUSEHOLD_MEMBER_COLS
 from pseudopeople.data.fake_names import fake_first_names, fake_last_names
 from pseudopeople.noise_entities import NOISE_TYPES
 from pseudopeople.schema_entities import DATASETS
-from pseudopeople.utilities import load_ocr_errors_dict, load_phonetic_errors_dict
+from pseudopeople.utilities import load_ocr_errors, load_phonetic_errors
 
 RANDOMNESS0 = RandomnessStream(
     key="test_column_noise",
@@ -767,8 +767,8 @@ def test_generate_phonetic_errors(dummy_dataset, column):
 
 
 def test_phonetic_error_values():
-    phonetic_errors_dict = load_phonetic_errors_dict()
-    data = pd.Series(list(phonetic_errors_dict.keys()) * 100, name="street_name")
+    phonetic_errors = load_phonetic_errors()
+    data = pd.Series(list(phonetic_errors.index) * 100, name="street_name")
     config = get_configuration()
     config.update(
         {
@@ -792,10 +792,10 @@ def test_phonetic_error_values():
         df, config, RANDOMNESS0, "dataset", "street_name"
     )
 
-    for key in phonetic_errors_dict.keys():
+    for key in phonetic_errors.index:
         key_idx = data.index[data == key]
         noised_values = set(noised_data.loc[key_idx])
-        pho_error_values = set(phonetic_errors_dict[key])
+        pho_error_values = set(phonetic_errors.loc[key]) - set([None])
         assert noised_values == pho_error_values
 
     assert (data != noised_data).all()
@@ -859,9 +859,9 @@ def test_generate_ocr_errors(dummy_dataset, column):
 def test_ocr_replacement_values():
     # Test that OCR noising replaces truth value with correct error values
     # Load OCR errors dict
-    ocr_errors_dict = load_ocr_errors_dict()
-    # Make series of OCR error dict keys - is there an intelligent numberto pick besides 10?
-    data = pd.Series(list(ocr_errors_dict.keys()) * 10, name="employer_name")
+    ocr_errors = load_ocr_errors()
+    # Is there an intelligent numberto pick besides 10?
+    data = pd.Series(list(ocr_errors.index) * 10, name="employer_name")
     df = pd.DataFrame({"employer_name": data})
     config = get_configuration()
     config.update(
@@ -885,10 +885,10 @@ def test_ocr_replacement_values():
         df, config, RANDOMNESS0, "dataset", "employer_name"
     )
 
-    for key in ocr_errors_dict.keys():
+    for key in ocr_errors.index:
         key_idx = data.index[data == key]
         noised_values = set(noised_data.loc[key_idx])
-        ocr_error_values = set(ocr_errors_dict[key])
+        ocr_error_values = set(ocr_errors.loc[key]) - set([None])
         assert noised_values == ocr_error_values
 
     assert (data != noised_data).all()


### PR DESCRIPTION
## Optimize OCR and phonetic noise types

### Description
- *Category*: performance
- *JIRA issue*: None

Mostly vectorizes the operations of these noise types.

**I'm not sure if it's worth it to merge this PR, see testing results below. But since I did the work, I figured I would open a PR, even if we decide to close it, so that we can revisit in the future if we want.**

### Testing
- [x] all tests pass (`pytest --runslow`)

This makes the slow tests about 1.5 minutes faster, based on my testing. However, noising is no longer a major bottleneck for loading and noising the large data (my benchmark from before), so this has a pretty negligible effect. It's also worth noting that this speedup is less than I saw for other noise types, I think because the pandas `merge` needs to do so much work here.

| Benchmark | Time on `main` branch | Time on `optimize_noise_functions_ocr_phonetic` branch | Percent improvement |
| --- | --- | --- | --- |
| Tests (with `--runslow`) | | | |
| Tests (without `--runslow`) | | | |
| Load and noise 5 shards of USA data | | | |
| Load and noise 5 shards of RI data | | | |
| Load and noise 5 shards of USA data with `cell_probability` of OCR and phonetic set to 15% | | | |