### PR TITLE
Mic-4669/Add metadata cols to metadata

### DIFF
--- a/src/pseudopeople/constants/metadata.py
+++ b/src/pseudopeople/constants/metadata.py
@@ -99,3 +99,15 @@ COPY_HOUSEHOLD_MEMBER_COLS = {
 INT_COLUMNS = ["age", "wages", "mailing_address_po_box"]
 
 DATA_VERSION = "2.0.0"
+
+METADATA_COLUMNS = [
+    "first_name",
+    "copy_age",
+    "copy_date_of_birth",
+    "copy_ssn",
+    "spouse_copy_ssn",
+    "dependent_1_copy_ssn",
+    "dependent_2_copy_ssn",
+    "dependent_3_copy_ssn",
+    "de pendent_4_copy_ssn",
+]


### PR DESCRIPTION
## Mic-4669/Add metadata cols to metadata

### Adds metadata columns for use in PRL outputs
- *Category*: Other
- *JIRA issue*: [MIC-4669](https://jira.ihme.washington.edu/browse/MIC-4669)

-adds metadata columns 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [ ] all tests pass (`pytest --runslow`)
