### PR TITLE
Don't return config in user warnings validation

### DIFF
--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -317,7 +317,7 @@ def validate_noise_level_proportions(
     # If there is no data for a queried dataset, we want the user's to hit the correct error that there
     # is no data available so we do not throw an error here.
     if dataset_noise_proportions.empty:
-        return configuration_tree
+        return None
     else:
         # Go through each row in the queried dataset noise proportions to validate the noise levels
         for i in range(len(dataset_noise_proportions)):

--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -316,9 +316,7 @@ def validate_noise_level_proportions(
 
     # If there is no data for a queried dataset, we want the user's to hit the correct error that there
     # is no data available so we do not throw an error here.
-    if dataset_noise_proportions.empty:
-        return None
-    else:
+    if not dataset_noise_proportions.empty:
         # Go through each row in the queried dataset noise proportions to validate the noise levels
         for i in range(len(dataset_noise_proportions)):
             row = dataset_noise_proportions.iloc[i]


### PR DESCRIPTION
## Bugfix/user-warnings

### Fixes logic in user warnings validation for noise proportions to not return the configuration
- *Category*: Bugfix
- *JIRA issue*: [MIC-4565](https://jira.ihme.washington.edu/browse/MIC-4565)

-Fixes logic in user warning validation for noise proportions

### Testing
-ALl tests pass