### PR TITLE
Update docs for new default probability for omit_row

### DIFF
--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -76,7 +76,7 @@ This noise type is called :code:`omit_row` in the configuration. It takes one
 parameter:
 
 .. list-table:: Parameters to the omit_row noise type
-  :widths: 1 5 1
+  :widths: 1 5 3
   :header-rows: 1
 
   * - Parameter

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -84,7 +84,8 @@ parameter:
     - Default
   * - :code:`row_probability`
     - The probability that a row is missing from the dataset.
-    - 0.01 (1%)
+    - * 0.005 (0.5%) for WIC and tax forms W2 and 1099
+      * 0.0 (0%) for other datasets
 
 When applying :code:`omit_row` noise, each row of data is selected for omission
 independently with probability :code:`row_probability`.


### PR DESCRIPTION
## Title: Update omit row probability
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: [SSCI-1588](https://jira.ihme.washington.edu/browse/SSCI-1588)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [X] all tests pass (`pytest --runslow`)
