### PR TITLE
Mic 4712/invalid data path

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -55,7 +55,7 @@ def _generate_dataset(
         source = paths.SAMPLE_DATA_ROOT
     else:
         source = Path(source)
-        validate_source_compatibility(source)
+        validate_source_compatibility(source, dataset)
 
     data_paths = fetch_filepaths(dataset, source)
     if not data_paths:
@@ -106,8 +106,15 @@ def _generate_dataset(
     return noised_dataset
 
 
-def validate_source_compatibility(source: Path):
+def validate_source_compatibility(source: Path, dataset: Dataset):
     # TODO [MIC-4546]: Clean this up w/ metadata and update test_interface.py tests to be generic
+    directories = [x.name for x in source.iterdir() if x.is_dir()]
+    if dataset.name not in directories:
+        raise FileNotFoundError(
+            f"Could not find '{dataset.name}' in '{source}'. Please check that the provided source "
+            "directory is correct. If using the sample data, no source is required. If providing a source, "
+            f"a directory should provided that has a subdirectory for '{dataset.name}'. "
+        )
     changelog = source / "CHANGELOG.rst"
     if changelog.exists():
         version = _get_data_changelog_version(changelog)

--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -4,11 +4,15 @@ import pytest
 import yaml
 from packaging.version import parse
 
+from pseudopeople.constants.metadata import DatasetNames
 from pseudopeople.exceptions import DataSourceError
 from pseudopeople.interface import (
     _get_data_changelog_version,
     validate_source_compatibility,
 )
+from pseudopeople.schema_entities import DATASETS
+
+CENSUS = DATASETS.get_dataset(DatasetNames.CENSUS)
 
 
 # TODO [MIC-4546]: stop hardcoding the data version number
@@ -35,6 +39,8 @@ def simulated_data_changelog_path(tmpdir_factory):
 
     # Create a dir with no changelog
     tmpdir_factory.mktemp("no_changelog_dir")
+    # Make fake data directory for census
+    tmpdir_factory.mktemp(tmp_path + "/" + CENSUS.name)
 
     return Path(tmp_path)
 
@@ -54,7 +60,7 @@ def mock_data_version(version, mocker):
 
 def test_validate_source_compatibility_passes(simulated_data_changelog_path):
     """Baseline test for validate_source_compatibility function"""
-    validate_source_compatibility(simulated_data_changelog_path)
+    validate_source_compatibility(simulated_data_changelog_path, CENSUS)
 
 
 def test_validate_source_compatibility_no_metadata_error(simulated_data_changelog_path):
@@ -62,7 +68,7 @@ def test_validate_source_compatibility_no_metadata_error(simulated_data_changelo
         DataSourceError,
         match="An older version of simulated population data has been provided.",
     ):
-        validate_source_compatibility(simulated_data_changelog_path / "no_metadata")
+        validate_source_compatibility(simulated_data_changelog_path / "no_metadata", CENSUS)
 
 
 @pytest.mark.parametrize(
@@ -78,4 +84,4 @@ def test_validate_source_compatibility_bad_version_errors(
 ):
     mock_data_version(version, mocker)
     with pytest.raises(DataSourceError, match=match):
-        validate_source_compatibility(simulated_data_changelog_path)
+        validate_source_compatibility(simulated_data_changelog_path, CENSUS)


### PR DESCRIPTION
## Mic-4712/invalid-data-path

### Adds error message when invalid path is provided for generate dataset functions
- *Category*: Feature
- *JIRA issue*: [MIC-4712](https://jira.ihme.washington.edu/browse/MIC-4712)

-adds error message when directory does not contain subdirectory for simulated data for dataset to be noised
-adds related test

### Testing
All tests pass.
