### PR TITLE
Update Psp docs for v1.0 release: guardian based duplication

### DIFF
--- a/docs/source/noise/index.rst
+++ b/docs/source/noise/index.rst
@@ -58,6 +58,10 @@ The "Config key" column shows the name of the noise type in the :ref:`configurat
   * - Omit a row
     - ``omit_row``
     - Losing data because of an administrative error
+  * - Duplicate with guardian
+    - ``duplicate_with_guardian``
+    - Filling out a survey questionnaire for your child that lives in college housing, while they simultaneously
+      fill out the same questionnaire for themselves
 
 .. list-table:: Types of column-based noise (``column_noise``)
   :widths: 1 2 5

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -95,7 +95,7 @@ Duplicate with guardian
 
 A known challenge in entity resolution is children being reported multiple
 times at different addresses. This can occur when family structures are
-complex and children might spend time at multiple households. A related
+complex and children spend time at multiple households. A related
 challenge occurs with college students, who often are counted both at their
 university and at their guardian’s home address.
 

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -104,9 +104,9 @@ To simulate such challenges, pseudopeople can apply this type of duplication to 
 simulants based on age and GQ status: Simulants younger than 18 and not
 in GQ and simulants under 24 and in college GQ.
 
-For each of the two categories of simulants, the maximum duplication rate will
-be calculated based on those who have a guardian living at a different address
-in the sim. Most simulants in college GQ will have a guardian at a
+For each of the two categories of simulants, a maximum duplication rate will
+be calculated based on those who have a guardian living at a different address.
+Most simulants in college GQ will have a guardian at a
 different address, but most simulants younger than 18 will not.
 If you as the user select a duplication rate that is higher than the 
 calculated maximum rate in the sim, you will see a warning that 

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -99,12 +99,6 @@ complex and children spend time at multiple households. A related
 challenge occurs with college students, who are sometimes counted both at their
 university and at their guardian’s home address.
 
-To facilitate this type of error, we have simulants assigned to guardians
-within the simulation. Sometimes, those guardians may live at
-different addresses than their dependents. In this case, there is an
-opportunity for duplication. Since this mechanism occurs within the
-simulation, there is a natural maximum on how many simulants can be duplicated
-in this way.
 
 Guardian-based duplication is applied to two mutually exclusive categories of
 simulants based on age and GQ status: Simulants younger than 18 (<18) and not

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -132,7 +132,7 @@ It takes two parameters:
     - Default
   * - :code:`row_probability_in_households_under_18`
     - The probability that a simulant under 18 in a household is recorded twice.
-    - * 0.05 (5%)
+    - 0.05 (5%)
   * - :code:`row_probability_in_college_group_quarters_under_24`
     - The probability that a simulant under 24 in college GQ is recorded twice.
-    - * 0.05 (5%)
+    - 0.05 (5%)

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -100,7 +100,7 @@ challenge occurs with college students, who are sometimes counted both at their
 university and at their guardian’s home address.
 
 
-Guardian-based duplication is applied to two mutually exclusive categories of
+To simulate such challenges, pseudopeople can apply this type of duplication to two mutually exclusive categories of
 simulants based on age and GQ status: Simulants younger than 18 (<18) and not
 in GQ and simulants under 24 (<24) and in college GQ.
 

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -112,10 +112,9 @@ in GQ and simulants under 24 (<24) and in college GQ.
 
 For each of the two categories of simulants, the maximum duplication rate will
 be calculated based on those who have a guardian living at a different address
-in the sim. Note that all simulants in *college* GQ are initialized with a
-guardian living at a different address, but this is not true for simulants in
-other types of GQ, so both maximum duplication rates will be less than
-100%. If you as the user select a duplication rate that is higher than the 
+in the sim. Most simulants in college GQ will have a guardian at a
+different address, but most simulants younger than 18 will not.
+If you as the user select a duplication rate that is higher than the 
 calculated maximum rate in the sim, a warning will be issued explaining that 
 the selected rate is greater than the maximum available, and the actual rate of 
 duplication should be set to the maximum for the specified simulant category.

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -101,8 +101,8 @@ university and at their guardian’s home address.
 
 
 To simulate such challenges, pseudopeople can apply this type of duplication to two mutually exclusive categories of
-simulants based on age and GQ status: Simulants younger than 18 (<18) and not
-in GQ and simulants under 24 (<24) and in college GQ.
+simulants based on age and GQ status: Simulants younger than 18 and not
+in GQ and simulants under 24 and in college GQ.
 
 For each of the two categories of simulants, the maximum duplication rate will
 be calculated based on those who have a guardian living at a different address

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -89,3 +89,50 @@ parameter:
 
 When applying :code:`omit_row` noise, each row of data is selected for omission
 independently with probability :code:`row_probability`.
+
+Duplicate with guardian
+-----------------------
+
+A known entity resolution challenge is children being reported multiple
+times at different addresses. This can occur when family structures are
+complex and children might spend time at multiple households. A related
+challenge occurs with college students, who often are counted both at their
+university and at their guardian’s home address.
+
+To facilitate this type of error, we have simulants assigned to guardians
+within the simulation. Sometimes, those guardians may move and live at
+different addresses than their dependents. In this case, there is an
+opportunity for duplication. Since this mechanism occurs within the
+simulation, there is a natural maximum that we will impose in the
+noise function.
+
+Guardian-based duplication is applied to two mutually exclusive categories of
+simulants based on age and GQ status: Simulants younger than 18  (<18) and not
+in GQ and simulants under 24 (<24) and in college GQ.
+
+For each of the two categories of simulants, the maximum duplication rate will
+be calculated based on those who have a guardian living at a different address
+in the sim. Note that all simulants in *college* GQ are initialized with a
+guardian living at a different address, but this is not true for simulants in
+other types of GQ, so both maximum duplication rates will be less than
+100%. If you as the user select a duplication rate that is higher than the 
+calculated maximum rate in the sim, a warning will be issued explaining that 
+the selected rate is greater than the maximum available, and the actual rate of 
+duplication should be set to the maximum for the specified simulant category.
+
+This noise type is called :code:`duplicate_with_guardian` in the configuration. 
+It takes two parameters:
+
+.. list-table:: Parameters to the duplicate_with_guardian noise type
+  :widths: 1 5 3
+  :header-rows: 1
+
+  * - Parameter
+    - Description
+    - Default
+  * - :code:`row_probability_in_households_under_18`
+    - The probability that a simulant under 18 in a household is recorded twice.
+    - * 0.05 (5%)
+  * - :code:`row_probability_in_college_group_quarters_under_24`
+    - The probability that a simulant under 24 in college GQ is recorded twice.
+    - * 0.05 (5%)

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -107,7 +107,7 @@ simulation, there is a natural maximum that we will impose in the
 noise function.
 
 Guardian-based duplication is applied to two mutually exclusive categories of
-simulants based on age and GQ status: Simulants younger than 18  (<18) and not
+simulants based on age and GQ status: Simulants younger than 18 (<18) and not
 in GQ and simulants under 24 (<24) and in college GQ.
 
 For each of the two categories of simulants, the maximum duplication rate will

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -103,8 +103,8 @@ To facilitate this type of error, we have simulants assigned to guardians
 within the simulation. Sometimes, those guardians may live at
 different addresses than their dependents. In this case, there is an
 opportunity for duplication. Since this mechanism occurs within the
-simulation, there is a natural maximum that we will impose in the
-noise function.
+simulation, there is a natural maximum on how many simulants can be duplicated
+in this way.
 
 Guardian-based duplication is applied to two mutually exclusive categories of
 simulants based on age and GQ status: Simulants younger than 18 (<18) and not

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -109,7 +109,7 @@ be calculated based on those who have a guardian living at a different address.
 Most simulants in college GQ will have a guardian at a
 different address, but most simulants younger than 18 will not.
 If you as the user select a duplication rate that is higher than the 
-calculated maximum rate in the sim, you will see a warning that 
+calculated maximum rate, you will see a warning that 
 the requested rate is greater than the maximum possible.
 
 This noise type is called :code:`duplicate_with_guardian` in the configuration. 

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -93,7 +93,7 @@ independently with probability :code:`row_probability`.
 Duplicate with guardian
 -----------------------
 
-A known challenge in entity resolution is children being reported multiple
+A known challenge in entity resolution is people being reported multiple
 times at different addresses. This can occur when family structures are
 complex and children spend time at multiple households. A related
 challenge occurs with college students, who are sometimes counted both at their

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -124,7 +124,7 @@ It takes two parameters:
     - Default
   * - :code:`row_probability_in_households_under_18`
     - The probability that a simulant under 18 in a household is recorded twice.
-    - 0.05 (5%)
+    - 0.02 (2%)
   * - :code:`row_probability_in_college_group_quarters_under_24`
     - The probability that a simulant under 24 in college GQ is recorded twice.
     - 0.05 (5%)

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -115,9 +115,8 @@ be calculated based on those who have a guardian living at a different address
 in the sim. Most simulants in college GQ will have a guardian at a
 different address, but most simulants younger than 18 will not.
 If you as the user select a duplication rate that is higher than the 
-calculated maximum rate in the sim, a warning will be issued explaining that 
-the selected rate is greater than the maximum available, and the actual rate of 
-duplication should be set to the maximum for the specified simulant category.
+calculated maximum rate in the sim, you will see a warning that 
+the requested rate is greater than the maximum possible.
 
 This noise type is called :code:`duplicate_with_guardian` in the configuration. 
 It takes two parameters:

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -96,7 +96,7 @@ Duplicate with guardian
 A known challenge in entity resolution is children being reported multiple
 times at different addresses. This can occur when family structures are
 complex and children spend time at multiple households. A related
-challenge occurs with college students, who often are counted both at their
+challenge occurs with college students, who are sometimes counted both at their
 university and at their guardian’s home address.
 
 To facilitate this type of error, we have simulants assigned to guardians

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -100,7 +100,7 @@ challenge occurs with college students, who are sometimes counted both at their
 university and at their guardian’s home address.
 
 To facilitate this type of error, we have simulants assigned to guardians
-within the simulation. Sometimes, those guardians may move and live at
+within the simulation. Sometimes, those guardians may live at
 different addresses than their dependents. In this case, there is an
 opportunity for duplication. Since this mechanism occurs within the
 simulation, there is a natural maximum that we will impose in the

--- a/docs/source/noise/row_noise.rst
+++ b/docs/source/noise/row_noise.rst
@@ -93,7 +93,7 @@ independently with probability :code:`row_probability`.
 Duplicate with guardian
 -----------------------
 
-A known entity resolution challenge is children being reported multiple
+A known challenge in entity resolution is children being reported multiple
 times at different addresses. This can occur when family structures are
 complex and children might spend time at multiple households. A related
 challenge occurs with college students, who often are counted both at their


### PR DESCRIPTION
## Title: Update Psp docs for v1.0 release: guardian based duplication
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: [SSCI-1585](https://jira.ihme.washington.edu/browse/SSCI-1585)

- Add & define guardian-based duplication to main Noise page in pseudopeople docs
- Describe guardian-based duplication and its parameters on Row Noise page (I'm not sure if I included too much or too little detail in this section, please lmk!) 
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
visually checked with make html
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [X] all tests pass (`pytest --runslow`)
