### PR TITLE
Remove use nickname from spouse last name column

### DIFF
--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -437,7 +437,6 @@ class __Columns(NamedTuple):
         "spouse_last_name",
         (
             NOISE_TYPES.leave_blank,
-            NOISE_TYPES.use_nickname,
             NOISE_TYPES.use_fake_name,
             NOISE_TYPES.make_phonetic_errors,
             NOISE_TYPES.make_ocr_errors,


### PR DESCRIPTION
## Mic-4803

### Removes use nickname column noise from spouse last name column.
- *Category*: Bugfix
- *JIRA issue*: [MIC-4803](https://jira.ihme.washington.edu/browse/MIC-4803)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [ ] all tests pass (`pytest --runslow`)
