### PR TITLE
Mic-4809/Update row noise order

### DIFF
--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -16,10 +16,6 @@ class __NoiseTypes(NamedTuple):
     in the "baseline" ConfigTree layer.
     """
 
-    do_not_respond: RowNoiseType = RowNoiseType(
-        "do_not_respond", noise_functions.apply_do_not_respond
-    )
-    omit_row: RowNoiseType = RowNoiseType("omit_row", noise_functions.omit_rows)
     duplicate_with_guardian: RowNoiseType = RowNoiseType(
         "duplicate_with_guardian",
         noise_function=noise_functions.duplicate_with_guardian,
@@ -29,6 +25,10 @@ class __NoiseTypes(NamedTuple):
             Keys.ROW_PROBABILITY_IN_COLLEGE_GROUP_QUARTERS_UNDER_24: 0.05,
         },
     )
+    do_not_respond: RowNoiseType = RowNoiseType(
+        "do_not_respond", noise_functions.apply_do_not_respond
+    )
+    omit_row: RowNoiseType = RowNoiseType("omit_row", noise_functions.omit_rows)
     # duplicate_row: RowNoiseType = RowNoiseType("duplicate_row", noise_functions.duplicate_rows)
     leave_blank: ColumnNoiseType = ColumnNoiseType(
         "leave_blank",

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -275,6 +275,7 @@ def test_swap_months_and_days(dummy_dataset, fuzzy_checker: FuzzyChecker):
             target_proportion=expected_noise,
         )
 
+
 def test_write_wrong_zipcode_digits(dummy_dataset, fuzzy_checker: FuzzyChecker):
     dummy_digit_probabilities = [0.3, 0.3, 0.4, 0.5, 0.5]
     config = get_configuration()
@@ -919,7 +920,7 @@ def test_phonetic_error_values():
 )
 def test_generate_ocr_errors(dummy_dataset, column, fuzzy_checker: FuzzyChecker):
     config = get_configuration()
-    config.update(  
+    config.update(
         {
             DATASETS.census.name: {
                 Keys.COLUMN_NOISE: {
@@ -938,7 +939,6 @@ def test_generate_ocr_errors(dummy_dataset, column, fuzzy_checker: FuzzyChecker)
         NOISE_TYPES.make_ocr_errors.name
     ]
     data = dummy_dataset[[column]]
-    breakpoint()
     noised_data = NOISE_TYPES.make_ocr_errors(data, config, RANDOMNESS0, "dataset", column)
     data = data.squeeze()
 

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -275,7 +275,6 @@ def test_swap_months_and_days(dummy_dataset, fuzzy_checker: FuzzyChecker):
             target_proportion=expected_noise,
         )
 
-
 def test_write_wrong_zipcode_digits(dummy_dataset, fuzzy_checker: FuzzyChecker):
     dummy_digit_probabilities = [0.3, 0.3, 0.4, 0.5, 0.5]
     config = get_configuration()
@@ -649,7 +648,6 @@ def test_write_wrong_digits(dummy_dataset, fuzzy_checker: FuzzyChecker):
     ]
     expected_cell_noise = config[Keys.CELL_PROBABILITY]
     expected_token_noise = config[Keys.TOKEN_PROBABILITY]
-
     data = dummy_dataset[["street_number"]]
     # Note: I changed this column from string_series to street number. It has several string formats
     # containing both numeric and alphabetically string characters.
@@ -921,7 +919,7 @@ def test_phonetic_error_values():
 )
 def test_generate_ocr_errors(dummy_dataset, column, fuzzy_checker: FuzzyChecker):
     config = get_configuration()
-    config.update(
+    config.update(  
         {
             DATASETS.census.name: {
                 Keys.COLUMN_NOISE: {
@@ -940,6 +938,7 @@ def test_generate_ocr_errors(dummy_dataset, column, fuzzy_checker: FuzzyChecker)
         NOISE_TYPES.make_ocr_errors.name
     ]
     data = dummy_dataset[[column]]
+    breakpoint()
     noised_data = NOISE_TYPES.make_ocr_errors(data, config, RANDOMNESS0, "dataset", column)
     data = data.squeeze()
 
@@ -1170,7 +1169,6 @@ def test_age_write_wrong_digits(dummy_dataset, fuzzy_checker: FuzzyChecker):
     ]
     data = dummy_dataset[["age"]]
     noised_data = NOISE_TYPES.write_wrong_digits(data, config, RANDOMNESS0, "dataset", "age")
-
     # Calculate expected noise level
     data = data.squeeze()
     missing_mask = data == ""

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -309,7 +309,6 @@ def test_two_noise_functions_are_independent(mocker, fuzzy_checker: FuzzyChecker
     col2_expected_123_proportion = (
         config_tree.decennial_census.column_noise.fake_column_two.beta[Keys.CELL_PROBABILITY]
     )
-
     fuzzy_checker.fuzzy_assert_proportion(
         name="fake_column_one_abc_proportion",
         observed_numerator=noised_data["fake_column_one"].str.contains("abc").sum(),

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -178,10 +178,10 @@ def test_noise_order(mocker, dummy_data, dataset):
         for noise_type in NOISE_TYPES._fields
         if noise_type
         in [
+            NOISE_TYPES.duplicate_with_guardian.name,
             NOISE_TYPES.do_not_respond.name,
             NOISE_TYPES.omit_row.name,
             "duplicate_row",
-            NOISE_TYPES.duplicate_with_guardian.name,
         ]
     ]
     column_order = [


### PR DESCRIPTION
## Mic-4809/Update row noise order

### Updates order or row noise to duplicate with guardian, do not respond, omit row
- *Category*: Feature
- *JIRA issue*: [MIC-4809](https://jira.ihme.washington.edu/browse/MIC-4809)

-updates order of row noise types

### Testing
All tests pass with new row noise order
