### PR TITLE
Mic-4807/Update noise level for under 18 in household

### DIFF
--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -21,7 +21,7 @@ class __NoiseTypes(NamedTuple):
         noise_function=noise_functions.duplicate_with_guardian,
         probability=None,
         additional_parameters={
-            Keys.ROW_PROBABILITY_IN_HOUSEHOLDS_UNDER_18: 0.05,
+            Keys.ROW_PROBABILITY_IN_HOUSEHOLDS_UNDER_18: 0.02,
             Keys.ROW_PROBABILITY_IN_COLLEGE_GROUP_QUARTERS_UNDER_24: 0.05,
         },
     )

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -275,6 +275,7 @@ def test_swap_months_and_days(dummy_dataset, fuzzy_checker: FuzzyChecker):
             target_proportion=expected_noise,
         )
 
+
 def test_write_wrong_zipcode_digits(dummy_dataset, fuzzy_checker: FuzzyChecker):
     dummy_digit_probabilities = [0.3, 0.3, 0.4, 0.5, 0.5]
     config = get_configuration()
@@ -919,7 +920,7 @@ def test_phonetic_error_values():
 )
 def test_generate_ocr_errors(dummy_dataset, column, fuzzy_checker: FuzzyChecker):
     config = get_configuration()
-    config.update(  
+    config.update(
         {
             DATASETS.census.name: {
                 Keys.COLUMN_NOISE: {
@@ -938,7 +939,6 @@ def test_generate_ocr_errors(dummy_dataset, column, fuzzy_checker: FuzzyChecker)
         NOISE_TYPES.make_ocr_errors.name
     ]
     data = dummy_dataset[[column]]
-    breakpoint()
     noised_data = NOISE_TYPES.make_ocr_errors(data, config, RANDOMNESS0, "dataset", column)
     data = data.squeeze()
 

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -275,7 +275,6 @@ def test_swap_months_and_days(dummy_dataset, fuzzy_checker: FuzzyChecker):
             target_proportion=expected_noise,
         )
 
-
 def test_write_wrong_zipcode_digits(dummy_dataset, fuzzy_checker: FuzzyChecker):
     dummy_digit_probabilities = [0.3, 0.3, 0.4, 0.5, 0.5]
     config = get_configuration()
@@ -920,7 +919,7 @@ def test_phonetic_error_values():
 )
 def test_generate_ocr_errors(dummy_dataset, column, fuzzy_checker: FuzzyChecker):
     config = get_configuration()
-    config.update(
+    config.update(  
         {
             DATASETS.census.name: {
                 Keys.COLUMN_NOISE: {
@@ -939,6 +938,7 @@ def test_generate_ocr_errors(dummy_dataset, column, fuzzy_checker: FuzzyChecker)
         NOISE_TYPES.make_ocr_errors.name
     ]
     data = dummy_dataset[[column]]
+    breakpoint()
     noised_data = NOISE_TYPES.make_ocr_errors(data, config, RANDOMNESS0, "dataset", column)
     data = data.squeeze()
 


### PR DESCRIPTION
## Mic-4807/Update noise level for under 18 in household

### Update default configuration level of under 18 in households guardian duplicatio.
- *Category*: Feature
- *JIRA issue*: [MIC-4807](https://jira.ihme.washington.edu/browse/MIC-4807)

-updates default configuration level of under 18 in households from 0.05 to 0.02

### Testing
All tests pass