### PR TITLE
Mic-4832/guardian duplication relationships

### DIFF
--- a/src/pseudopeople/constants/noise_type_metadata.py
+++ b/src/pseudopeople/constants/noise_type_metadata.py
@@ -27,3 +27,14 @@ COPY_HOUSEHOLD_MEMBER_COLS = {
 
 
 INT_COLUMNS = ["age", "wages", "mailing_address_po_box"]
+
+
+HOUSING_TYPE_GUARDIAN_DUPLICATION_RELATONSHIP_MAP = {
+    "Carceral": "Institutionalized group quarters population",
+    "Nursing home": "Institutionalized group quarters population",
+    "Other institutional": "Institutionalized group quarters population",
+    "College": "Noninstitutionalized group quarters population",
+    "Military": "Noninstitutionalized group quarters population",
+    "Other noninstitutional": "Noninstitutionalized group quarters population",
+    "Household": "Other relative",
+}

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -298,7 +298,6 @@ def generate_decennial_census(
         user_filters.append(
             (DATASETS.census.state_column_name, "==", get_state_abbreviation(state))
         )
-    # Sort by year and household_id to ensure that the same household's simulants are grouped together.
     return _generate_dataset(DATASETS.census, source, seed, config, user_filters, verbose)
 
 

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -7,11 +7,12 @@ from vivarium import ConfigTree
 from vivarium.framework.randomness import RandomnessStream, get_hash
 
 from pseudopeople.configuration import Keys
-from pseudopeople.constants import data_values, paths
+from pseudopeople.constants import data_values
 from pseudopeople.constants.metadata import DatasetNames
 from pseudopeople.constants.noise_type_metadata import (
     COPY_HOUSEHOLD_MEMBER_COLS,
     GUARDIAN_DUPLICATION_ADDRESS_COLUMNS,
+    HOUSING_TYPE_GUARDIAN_DUPLICATION_RELATONSHIP_MAP,
 )
 from pseudopeople.data.fake_names import fake_first_names, fake_last_names
 from pseudopeople.noise_scaling import (
@@ -292,7 +293,10 @@ def duplicate_with_guardian(
         return dataset_data
     else:
         noised_data = pd.concat(noised_data)
-        noised_data["relationship_to_reference_person"] = "Other relative"
+        # Update relationship to reference person for duplicated simulants based on housing type
+        noised_data["relationship_to_reference_person"] = noised_data["housing_type"].map(
+            HOUSING_TYPE_GUARDIAN_DUPLICATION_RELATONSHIP_MAP
+        )
         # Clean columns
         noised_data = noised_data[dataset_data.columns]
         # Fix to help keep optimization code for noise.py


### PR DESCRIPTION
## Mic-4832/guardian duplication relationships

### Updates relationship to reference person for guardian duplication noise function to match housing type.
- *Category*: Feature
- *JIRA issue*: [MIC-4832](https://jira.ihme.washington.edu/browse/MIC-4832)

-updates relationship to reference person column in guardian duplication noise function to match housing typefor copied rows

### Testing
All tests pass
