### PR TITLE
Mic-4794/fuzzy-checker-pt3

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -298,7 +298,6 @@ def generate_decennial_census(
         user_filters.append(
             (DATASETS.census.state_column_name, "==", get_state_abbreviation(state))
         )
-    # Sort by year and household_id to ensure that the same household's simulants are grouped together.
     return _generate_dataset(DATASETS.census, source, seed, config, user_filters, verbose)
 
 

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -298,7 +298,10 @@ def generate_decennial_census(
         user_filters.append(
             (DATASETS.census.state_column_name, "==", get_state_abbreviation(state))
         )
-    return _generate_dataset(DATASETS.census, source, seed, config, user_filters, verbose)
+    # Sort by year and household_id to ensure that the same household's simulants are grouped together.
+    return _generate_dataset(
+        DATASETS.census, source, seed, config, user_filters, verbose
+    ).sort_values(by=[DATASETS.census.date_column_name, COLUMNS.household_id.name])
 
 
 def generate_american_community_survey(

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -299,9 +299,7 @@ def generate_decennial_census(
             (DATASETS.census.state_column_name, "==", get_state_abbreviation(state))
         )
     # Sort by year and household_id to ensure that the same household's simulants are grouped together.
-    return _generate_dataset(
-        DATASETS.census, source, seed, config, user_filters, verbose
-    ).sort_values(by=[DATASETS.census.date_column_name, COLUMNS.household_id.name])
+    return _generate_dataset(DATASETS.census, source, seed, config, user_filters, verbose)
 
 
 def generate_american_community_survey(


### PR DESCRIPTION
## Mic-4794/fuzzy-checker-pt3

### Adds series level fuzzy checker for zipcodes
- *Category*: Test
- *JIRA issue*: [MIC-4794](https://jira.ihme.washington.edu/browse/MIC-4794)

-for our unit tests that test token noise, we want to test both at the token level and series level. We were doing that for all token noise types except for zipcode digits.

### Testing
All tests pass
