### PR TITLE
Bugfix/Census order

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -298,9 +298,11 @@ def generate_decennial_census(
         user_filters.append(
             (DATASETS.census.state_column_name, "==", get_state_abbreviation(state))
         )
-    return _generate_dataset(
-        DATASETS.census, source, seed, config, user_filters, verbose
-    ).sort_values(by=[DATASETS.census.date_column_name, "household_id"])
+    return (
+        _generate_dataset(DATASETS.census, source, seed, config, user_filters, verbose)
+        .sort_values(by=[DATASETS.census.date_column_name, "household_id"])
+        .reset_index()
+    )
 
 
 def generate_american_community_survey(

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -301,7 +301,7 @@ def generate_decennial_census(
     return (
         _generate_dataset(DATASETS.census, source, seed, config, user_filters, verbose)
         .sort_values(by=[DATASETS.census.date_column_name, "household_id"])
-        .reset_index()
+        .reset_index(drop=True)
     )
 
 

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -298,7 +298,9 @@ def generate_decennial_census(
         user_filters.append(
             (DATASETS.census.state_column_name, "==", get_state_abbreviation(state))
         )
-    return _generate_dataset(DATASETS.census, source, seed, config, user_filters, verbose)
+    return _generate_dataset(
+        DATASETS.census, source, seed, config, user_filters, verbose
+    ).sort_values(by=[DATASETS.census.date_column_name, "household_id"])
 
 
 def generate_american_community_survey(

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -283,11 +283,6 @@ def duplicate_with_guardian(
             ]
             noised_data.append(noised_group_df)
 
-    # We need to get the date column below when we sort the noised data
-    from pseudopeople.schema_entities import DATASETS
-
-    dataset = DATASETS.get_dataset(dataset_name)
-
     # Combine all noised dataframes
     if not noised_data:
         return dataset_data
@@ -302,9 +297,7 @@ def duplicate_with_guardian(
         # Fix to help keep optimization code for noise.py
         index_start_value = dataset_data.index.max() + 1
         noised_data.index = range(index_start_value, index_start_value + len(noised_data))
-        dataset_data = pd.concat([dataset_data, noised_data]).sort_values(
-            by=[dataset.date_column_name, "household_id"]
-        )
+        dataset_data = pd.concat([dataset_data, noised_data])
 
     return dataset_data
 

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -36,3 +36,15 @@ def test_unnoised_id_cols(dataset_name: str, request):
         .all()
         .all()
     )
+
+
+def test_census_order(noised_sample_data_decennial_census):
+    """
+    Tests that the census gets ordered by year and household_id. Note this test will need to
+    be updated once we properly move the sorting to the guardian duplication noise function.
+    """
+
+    # TODO: DELTED ME
+    data = noised_sample_data_decennial_census
+    for year, year_df in data.groupby("year"):
+        assert year_df[COLUMNS.household_id.name].is_monotonic_increasing


### PR DESCRIPTION
## Bugfix/Census order

### Hotfix for correct census order
- *Category*: Bugfix
- *JIRA issue*: [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-XYZ)

-orders census by year and household id
NOTE: This is a hotfix and the implementation for this will be updated with a larger refactor after release

### Testing
All tests pass