### PR TITLE
Mic-4870/Revert census order

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -298,11 +298,7 @@ def generate_decennial_census(
         user_filters.append(
             (DATASETS.census.state_column_name, "==", get_state_abbreviation(state))
         )
-    return (
-        _generate_dataset(DATASETS.census, source, seed, config, user_filters, verbose)
-        .sort_values(by=[DATASETS.census.date_column_name, "household_id"])
-        .reset_index(drop=True)
-    )
+    return _generate_dataset(DATASETS.census, source, seed, config, user_filters, verbose)
 
 
 def generate_american_community_survey(

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -36,15 +36,3 @@ def test_unnoised_id_cols(dataset_name: str, request):
         .all()
         .all()
     )
-
-
-def test_census_order(noised_sample_data_decennial_census):
-    """
-    Tests that the census gets ordered by year and household_id. Note this test will need to
-    be updated once we properly move the sorting to the guardian duplication noise function.
-    """
-
-    # TODO: DELTED ME
-    data = noised_sample_data_decennial_census
-    for year, year_df in data.groupby("year"):
-        assert year_df[COLUMNS.household_id.name].is_monotonic_increasing


### PR DESCRIPTION
## Mic-4870/Revert census order

### Mic-4870/Revert census order
- *Category*: Feature
- *JIRA issue*: [MIC-4870](https://jira.ihme.washington.edu/browse/MIC-4870

-reverts census ordering due to runtime issues

### Testing
All tests pass