### PR TITLE
Hotfix: fix typo in make_typos parameter table title

### DIFF
--- a/docs/source/noise/column_noise.rst
+++ b/docs/source/noise/column_noise.rst
@@ -417,7 +417,7 @@ There are currently no typos involving special characters.
 
 This noise type is called :code:`make_typos` in the configuration. It takes two parameters:
 
-.. list-table:: Parameters to the leave_blank noise type
+.. list-table:: Parameters to the make_typos noise type
   :widths: 1 5 1
   :header-rows: 1
 


### PR DESCRIPTION
## Title: Fix typo in make_typos parameter table title
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: [SSCI-1784](https://jira.ihme.washington.edu/browse/SSCI-1784)

I also quickly reviewed other table titles but didn't see any other typos.
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [x] all tests pass (`pytest --runslow`)
