### PR TITLE
Add brief explanation of why sample population has single city/state/zip 

### DIFF
--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -26,7 +26,7 @@ A **mailing address** represents the address a simulant uses to receive mail,
 which may be different -- for example, a PO box.
 Mailing addresses, not physical addresses, are recorded in tax filings.
 
-Note that in the small-scale simulated population that is available by default, these addresses all have their city/state/zip code set to the fictitious location of Anytown, WA 00000.  To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see :ref:`Simulated populations <simulated_populations_main>`.
+Note that in the small-scale simulated population that is available by default, these addresses all have their city/state/zip code set to the fictitious location of Anytown, WA 00000. This is to ensure that linking is not unrealistically easy with the sample population (i.e., you cannot block on these attributes, as they are all identical). To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see :ref:`Simulated populations <simulated_populations_main>`.
 
 Some fields are not applicable to every record in a simulated dataset,
 so some columns may contain "missing" values, even if no noise has been added to the data.

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -28,8 +28,8 @@ Mailing addresses, not physical addresses, are recorded in tax filings.
 
 Note that in the small-scale simulated population that is available by default, these addresses all have their 
 city/state/zip code set to the fictitious location of Anytown, WA 00000. This is to ensure that linking is not 
-unrealistically easy with the sample population (i.e., you cannot block on these attributes, as they are all identical). 
-To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see 
+unrealistically easy with the sample population (i.e., using these attributes to eliminate clear non-matches is
+not possible, as they are all identical). To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see 
 :ref:`Simulated populations <simulated_populations_main>`.
 
 Some fields are not applicable to every record in a simulated dataset,

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -26,11 +26,16 @@ A **mailing address** represents the address a simulant uses to receive mail,
 which may be different -- for example, a PO box.
 Mailing addresses, not physical addresses, are recorded in tax filings.
 
-Note that in the small-scale simulated population that is available by default, these addresses all have their city/state/zip code set to the fictitious location of Anytown, WA 00000. This is to ensure that linking is not unrealistically easy with the sample population (i.e., you cannot block on these attributes, as they are all identical). To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see :ref:`Simulated populations <simulated_populations_main>`.
+Note that in the small-scale simulated population that is available by default, these addresses all have their 
+city/state/zip code set to the fictitious location of Anytown, WA 00000. This is to ensure that linking is not 
+unrealistically easy with the sample population (i.e., you cannot block on these attributes, as they are all identical). 
+To read more about obtaining large-scale data with more realistic city, state, and zip code data, please see 
+:ref:`Simulated populations <simulated_populations_main>`.
 
 Some fields are not applicable to every record in a simulated dataset,
 so some columns may contain "missing" values, even if no noise has been added to the data.
-For example, most addresses do not have a unit number, and some do not have a street number, so the :code:`unit_number` and/or :code:`street_number` fields will be "missing" for many rows in any dataset that contains addresses.
+For example, most addresses do not have a unit number, and some do not have a street number, so the 
+:code:`unit_number` and/or :code:`street_number` fields will be "missing" for many rows in any dataset that contains addresses.
 Similarly, columns pertaining to spouse or dependents in the 1040 tax dataset are not applicable to every simulant, so these columns also contain missing values.
 Values that are missing because they are not applicable are represented by :code:`numpy.nan`.
 


### PR DESCRIPTION
## Title: Hotfix: add brief explanation of why sample population has single city/state/zip 
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: [SSCI-1589](https://jira.ihme.washington.edu/browse/SSCI-1589)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [x] all tests pass (`pytest --runslow`)
