### PR TITLE
use LayeredConfigTree

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ if __name__ == "__main__":
         "vivarium>=1.2.0",
         "pyarrow",
         "tqdm",
+        "layered_config_tree",
     ]
 
     setup_requires = ["setuptools_scm"]

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 import yaml
-from vivarium.config_tree import ConfigTree
 
+from layered_config_tree import LayeredConfigTree
 from pseudopeople.configuration import NO_NOISE, Keys
 from pseudopeople.configuration.validator import (
     validate_noise_level_proportions,
@@ -84,12 +84,12 @@ def get_configuration(
     overrides: Optional[Union[Path, str, Dict]] = None,
     dataset: Dataset = None,
     user_filters: List[Tuple[Union[str, int, pd.Timestamp]]] = None,
-) -> ConfigTree:
+) -> LayeredConfigTree:
     """
-    Gets a noising configuration ConfigTree, optionally overridden by a user-provided YAML.
+    Gets a noising configuration LayeredConfigTree, optionally overridden by a user-provided YAML.
 
     :param overrides: A path to the YAML file or a dictionary defining user overrides for the defaults
-    :return: a ConfigTree object of the noising configuration
+    :return: a LayeredConfigTree object of the noising configuration
     """
 
     if overrides == NO_NOISE:
@@ -108,13 +108,13 @@ def get_configuration(
     return noising_configuration
 
 
-def _generate_configuration(is_no_noise: bool) -> ConfigTree:
+def _generate_configuration(is_no_noise: bool) -> LayeredConfigTree:
     default_config_layers = [
         "baseline",
         "default",
         "user",
     ]
-    noising_configuration = ConfigTree(layers=default_config_layers)
+    noising_configuration = LayeredConfigTree(layers=default_config_layers)
     # Instantiate the configuration file with baseline values
     baseline_dict = {}
     # Loop through each dataset
@@ -175,7 +175,7 @@ def get_noise_type_dict(noise_type, is_no_noise: bool) -> Dict:
 
 
 def add_overrides(
-    noising_configuration: ConfigTree,
+    noising_configuration: LayeredConfigTree,
     overrides: Dict,
     dataset: Dataset = None,
     user_filters: List[Tuple[Union[str, int, pd.Timestamp]]] = None,
@@ -191,7 +191,7 @@ def add_overrides(
         validate_noise_level_proportions(noising_configuration, dataset, user_filters)
 
 
-def _format_overrides(default_config: ConfigTree, user_dict: Dict) -> Dict:
+def _format_overrides(default_config: LayeredConfigTree, user_dict: Dict) -> Dict:
     """Formats the user's configuration file as necessary, so it can properly
     update noising configuration to be used
     """
@@ -199,7 +199,9 @@ def _format_overrides(default_config: ConfigTree, user_dict: Dict) -> Dict:
     return user_dict
 
 
-def _format_misreport_age_perturbations(default_config: ConfigTree, user_dict: Dict) -> Dict:
+def _format_misreport_age_perturbations(
+    default_config: LayeredConfigTree, user_dict: Dict
+) -> Dict:
     # Format any age perturbation lists as a dictionary with uniform probabilities
     for dataset in user_dict:
         user_perturbations = (

--- a/src/pseudopeople/configuration/generator.py
+++ b/src/pseudopeople/configuration/generator.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 import yaml
-
 from layered_config_tree import LayeredConfigTree
+
 from pseudopeople.configuration import NO_NOISE, Keys
 from pseudopeople.configuration.validator import (
     validate_noise_level_proportions,

--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -3,8 +3,8 @@ from typing import Callable, Dict, List, Tuple, Union
 import numpy as np
 import pandas as pd
 from loguru import logger
-from vivarium.config_tree import ConfigTree, ConfigurationKeyError
 
+from layered_config_tree import ConfigurationKeyError, LayeredConfigTree
 from pseudopeople.configuration import Keys
 from pseudopeople.constants import metadata, paths
 from pseudopeople.exceptions import ConfigurationError
@@ -13,7 +13,7 @@ from pseudopeople.noise_scaling import get_options_for_column
 from pseudopeople.schema_entities import Dataset
 
 
-def validate_overrides(overrides: Dict, default_config: ConfigTree) -> None:
+def validate_overrides(overrides: Dict, default_config: LayeredConfigTree) -> None:
     """
     Validates the user-provided overrides. Confirms that all user-provided
     keys exist in the default configuration. Confirms that all user-provided
@@ -107,7 +107,7 @@ def validate_overrides(overrides: Dict, default_config: ConfigTree) -> None:
 
 def _validate_noise_type_config(
     noise_type_config: Union[Dict, List],
-    default_noise_type_config: ConfigTree,
+    default_noise_type_config: LayeredConfigTree,
     dataset: str,
     noise_type: str,
     parameter_config_validator_map: Dict[str, Callable],
@@ -133,13 +133,13 @@ def _validate_noise_type_config(
 
 
 def _get_default_config_node(
-    default_config: ConfigTree,
+    default_config: LayeredConfigTree,
     key: str,
     key_type: str,
     dataset: str = None,
     column: str = None,
     noise_type: str = None,
-) -> ConfigTree:
+) -> LayeredConfigTree:
     """
     Validate that the node the user is trying to add exists in the default
     configuration.
@@ -258,7 +258,7 @@ def _validate_choose_wrong_option_probability(
 
 
 def validate_noise_level_proportions(
-    configuration_tree: ConfigTree, dataset: Dataset, user_filters: List[Tuple]
+    configuration_tree: LayeredConfigTree, dataset: Dataset, user_filters: List[Tuple]
 ) -> None:
     """
     Validates that the noise levels provided do not exceed the allowable proportions from the

--- a/src/pseudopeople/configuration/validator.py
+++ b/src/pseudopeople/configuration/validator.py
@@ -2,9 +2,9 @@ from typing import Callable, Dict, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
+from layered_config_tree import ConfigurationKeyError, LayeredConfigTree
 from loguru import logger
 
-from layered_config_tree import ConfigurationKeyError, LayeredConfigTree
 from pseudopeople.configuration import Keys
 from pseudopeople.constants import metadata, paths
 from pseudopeople.exceptions import ConfigurationError

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -3,12 +3,12 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pandas as pd
-from loguru import logger
-
 from layered_config_tree import LayeredConfigTree
+from loguru import logger
+from vivarium.framework.randomness import RandomnessStream
+
 from pseudopeople.configuration import Keys
 from pseudopeople.utilities import get_index_to_noise
-from vivarium.framework.randomness import RandomnessStream
 
 
 @dataclass

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -4,17 +4,19 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pandas as pd
 from loguru import logger
-from vivarium import ConfigTree
-from vivarium.framework.randomness import RandomnessStream
 
+from layered_config_tree import LayeredConfigTree
 from pseudopeople.configuration import Keys
 from pseudopeople.utilities import get_index_to_noise
+from vivarium.framework.randomness import RandomnessStream
 
 
 @dataclass
 class NoiseType(ABC):
     name: str
-    noise_function: Callable[[pd.DataFrame, ConfigTree, RandomnessStream], pd.DataFrame]
+    noise_function: Callable[
+        [pd.DataFrame, LayeredConfigTree, RandomnessStream], pd.DataFrame
+    ]
     probability: Optional[float] = 0.0
     additional_parameters: Dict[str, Any] = None
 
@@ -45,7 +47,7 @@ class RowNoiseType(NoiseType):
         self,
         dataset_name: str,
         dataset_data: pd.DataFrame,
-        configuration: ConfigTree,
+        configuration: LayeredConfigTree,
         randomness_stream: RandomnessStream,
     ) -> pd.DataFrame:
         return self.noise_function(
@@ -61,7 +63,7 @@ class ColumnNoiseType(NoiseType):
     The name is the name of the particular noise type (e.g. use_nickname" or
     "make_phonetic_errors").
 
-    The noise function takes as input a DataFrame, the ConfigTree object for this
+    The noise function takes as input a DataFrame, the LayeredConfigTree object for this
     ColumnNoise operation, a RandomnessStream for controlling randomness, and
     a column name, which is the column that will be noised and who's name will be used
     as the additional key for the RandomnessStream.
@@ -83,7 +85,7 @@ class ColumnNoiseType(NoiseType):
     def __call__(
         self,
         data: pd.DataFrame,
-        configuration: ConfigTree,
+        configuration: LayeredConfigTree,
         randomness_stream: RandomnessStream,
         dataset_name: str,
         column_name: str,

--- a/src/pseudopeople/noise.py
+++ b/src/pseudopeople/noise.py
@@ -15,9 +15,9 @@ by column and row for each type of additional noise type.
 from typing import Any
 
 import pandas as pd
+from layered_config_tree import LayeredConfigTree
 from tqdm import tqdm
 
-from layered_config_tree import LayeredConfigTree
 from pseudopeople.configuration import Keys
 from pseudopeople.entity_types import ColumnNoiseType, RowNoiseType
 from pseudopeople.noise_entities import NOISE_TYPES

--- a/src/pseudopeople/noise.py
+++ b/src/pseudopeople/noise.py
@@ -11,12 +11,13 @@ provided by the user.  First, the Dataset will be noised for missing data and ha
 rows in each columns changed to null values.  Then, the dataset data will be noised
 by column and row for each type of additional noise type.
 """
+
 from typing import Any
 
 import pandas as pd
 from tqdm import tqdm
-from vivarium import ConfigTree
 
+from layered_config_tree import LayeredConfigTree
 from pseudopeople.configuration import Keys
 from pseudopeople.entity_types import ColumnNoiseType, RowNoiseType
 from pseudopeople.noise_entities import NOISE_TYPES
@@ -27,7 +28,7 @@ from pseudopeople.utilities import get_randomness_stream
 def noise_dataset(
     dataset: Dataset,
     dataset_data: pd.DataFrame,
-    configuration: ConfigTree,
+    configuration: LayeredConfigTree,
     seed: Any,
 ) -> pd.DataFrame:
     """

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -13,7 +13,7 @@ class __NoiseTypes(NamedTuple):
     make_phonetic_errors, make_ocr_errors, make_typos
 
     NOTE: Any configuration tree overwrites in these objects are what ends up
-    in the "baseline" ConfigTree layer.
+    in the "baseline" LayeredConfigTree layer.
     """
 
     duplicate_with_guardian: RowNoiseType = RowNoiseType(

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -2,10 +2,8 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-import yaml
-from vivarium import ConfigTree
-from vivarium.framework.randomness import RandomnessStream, get_hash
 
+from layered_config_tree import LayeredConfigTree
 from pseudopeople.configuration import Keys
 from pseudopeople.constants import data_values
 from pseudopeople.constants.metadata import DatasetNames
@@ -27,12 +25,13 @@ from pseudopeople.utilities import (
     two_d_array_choice,
     vectorized_choice,
 )
+from vivarium.framework.randomness import RandomnessStream, get_hash
 
 
 def omit_rows(
     dataset_name: str,
     dataset_data: pd.DataFrame,
-    configuration: ConfigTree,
+    configuration: LayeredConfigTree,
     randomness_stream: RandomnessStream,
 ) -> pd.DataFrame:
     """
@@ -40,7 +39,7 @@ def omit_rows(
       we need to account for oversampling in the PRL simulation so a helper function has been hadded here to do so.
     :param dataset_name: Dataset object being noised
     :param dataset_data:  pd.DataFrame of one of the dataset types used in Pseudopeople
-    :param configuration: ConfigTree object containing noise level values
+    :param configuration: LayeredConfigTree object containing noise level values
     :param randomness_stream: RandomnessStream object to make random selection for noise
     :return: pd.DataFrame with rows from the original dataframe removed
     """
@@ -98,7 +97,7 @@ def _get_census_omission_noise_levels(
 def apply_do_not_respond(
     dataset_name: str,
     dataset_data: pd.DataFrame,
-    configuration: ConfigTree,
+    configuration: LayeredConfigTree,
     randomness_stream: RandomnessStream,
 ) -> pd.DataFrame:
     """
@@ -106,7 +105,7 @@ def apply_do_not_respond(
 
     :param dataset_name: Dataset object name being noised
     :param dataset_data:  pd.DataFrame of one of the form types used in Pseudopeople
-    :param configuration: ConfigTree object containing noise level values
+    :param configuration: LayeredConfigTree object containing noise level values
     :param randomness_stream: RandomnessStream object to make random selection for noise
     :return: pd.DataFrame with rows from the original dataframe removed
     """
@@ -143,7 +142,7 @@ def apply_do_not_respond(
 
 # def duplicate_rows(
 #     dataset_data: pd.DataFrame,
-#     configuration: ConfigTree,
+#     configuration: LayeredConfigTree,
 #     randomness_stream: RandomnessStream,
 # ) -> pd.DataFrame:
 #     """
@@ -160,7 +159,7 @@ def apply_do_not_respond(
 def duplicate_with_guardian(
     dataset_name: str,
     dataset_data: pd.DataFrame,
-    configuration: ConfigTree,
+    configuration: LayeredConfigTree,
     randomness_stream: RandomnessStream,
 ) -> pd.DataFrame:
     """
@@ -171,7 +170,7 @@ def duplicate_with_guardian(
     have the dependent's correct address and the other will have the guardian's address.
     :param dataset_name: Name of the dataset being noised
     :param dataset_data: pd.DataFrame that will be noised
-    :param configuration: ConfigTree object containing noise level values. Dict with three key groups for duplication
+    :param configuration: LayeredConfigTree object containing noise level values. Dict with three key groups for duplication
     :param randomness_stream: RandomnessStream instance to make random selection for noise
     :return: pd.DataFrame with rows from the original dataframe duplicated along with the original
     dataframe itself.
@@ -223,12 +222,12 @@ def duplicate_with_guardian(
     ]
 
     # Merge depedents with their guardians
-    formatted_group_data[
-        Keys.ROW_PROBABILITY_IN_HOUSEHOLDS_UNDER_18
-    ] = _merge_dependents_and_guardians(in_households_under_18, dataset_data)
-    formatted_group_data[
-        Keys.ROW_PROBABILITY_IN_COLLEGE_GROUP_QUARTERS_UNDER_24
-    ] = _merge_dependents_and_guardians(in_college_under_24, dataset_data)
+    formatted_group_data[Keys.ROW_PROBABILITY_IN_HOUSEHOLDS_UNDER_18] = (
+        _merge_dependents_and_guardians(in_households_under_18, dataset_data)
+    )
+    formatted_group_data[Keys.ROW_PROBABILITY_IN_COLLEGE_GROUP_QUARTERS_UNDER_24] = (
+        _merge_dependents_and_guardians(in_college_under_24, dataset_data)
+    )
     # Note: We have two dicts (configuration and formatted_group_data) at this point that have
     # the key for the group and then a dataframe for that group or the group and the configured
     # noise level
@@ -304,7 +303,7 @@ def duplicate_with_guardian(
 
 def choose_wrong_options(
     data: pd.DataFrame,
-    _: ConfigTree,
+    _: LayeredConfigTree,
     randomness_stream: RandomnessStream,
     dataset_name: str,
     column_name: str,
@@ -314,7 +313,7 @@ def choose_wrong_options(
     a list.
 
     :param data:  A pandas dataframe containing necessary columns for column noise
-    :param _: ConfigTree with rate at which to blank the data in column.
+    :param _: LayeredConfigTree with rate at which to blank the data in column.
     :param randomness_stream:  RandomnessStream to utilize Vivarium CRN.
     :param column_name: String for column that will be noised, will be the key for RandomnessStream
     :returns: pd.Series where data has been noised with other values from a list of possibilities
@@ -342,7 +341,7 @@ def choose_wrong_options(
 
 def copy_from_household_member(
     data: pd.DataFrame,
-    configuration: ConfigTree,
+    configuration: LayeredConfigTree,
     randomness_stream: RandomnessStream,
     dataset_name: str,
     column_name: str,
@@ -350,7 +349,7 @@ def copy_from_household_member(
     """
 
     :param data:  A pandas dataframe containing necessary columns for column noise
-    :param _: ConfigTree with rate at which to blank the data in column.
+    :param _: LayeredConfigTree with rate at which to blank the data in column.
     :param randomness_stream:  RandomnessStream to utilize Vivarium CRN.
     :param column_name: String for column that will be noised, will be the key for RandomnessStream
     :returns: pd.Series where data has been noised with other values from a list of possibilities
@@ -363,7 +362,7 @@ def copy_from_household_member(
 
 def swap_months_and_days(
     data: pd.DataFrame,
-    _: ConfigTree,
+    _: LayeredConfigTree,
     randomness_stream: RandomnessStream,
     dataset_name: str,
     column_name: str,
@@ -372,7 +371,7 @@ def swap_months_and_days(
     Function that swaps month and day of dates.
 
     :param data: A pandas dataframe containing necessary columns for column noise
-    :param _: ConfigTree object containing noise level values
+    :param _: LayeredConfigTree object containing noise level values
     :param randomness_stream: Randomness Stream object for random choices using vivarium CRN framework
     :param column_name: String for column that will be noised, will be the key for RandomnessStream
     :return: Noised pd.Series where some dates have month and day swapped.
@@ -405,7 +404,7 @@ def swap_months_and_days(
 
 def write_wrong_zipcode_digits(
     data: pd.DataFrame,
-    configuration: ConfigTree,
+    configuration: LayeredConfigTree,
     randomness_stream: RandomnessStream,
     dataset_name: str,
     column_name: str,
@@ -460,7 +459,7 @@ def write_wrong_zipcode_digits(
 
 def misreport_ages(
     data: pd.DataFrame,
-    configuration: ConfigTree,
+    configuration: LayeredConfigTree,
     randomness_stream: RandomnessStream,
     dataset_name: str,
     column_name: str,
@@ -495,7 +494,7 @@ def misreport_ages(
 
 def write_wrong_digits(
     data: pd.DataFrame,
-    configuration: ConfigTree,
+    configuration: LayeredConfigTree,
     randomness_stream: RandomnessStream,
     dataset_name: str,
     column_name: str,
@@ -504,7 +503,7 @@ def write_wrong_digits(
     Function that noises numeric characters in a series.
 
     :param data:  A pandas dataframe containing necessary columns for column noise
-    :param configuration: ConfigTree with rate at which to blank the data in column.
+    :param configuration: LayeredConfigTree with rate at which to blank the data in column.
     :param randomness_stream:  RandomnessStream to utilize Vivarium CRN.
     :param column_name: String for column that will be noised, will be the key for RandomnessStream
 
@@ -552,7 +551,7 @@ def write_wrong_digits(
 
 def use_nicknames(
     data: pd.DataFrame,
-    _: ConfigTree,
+    _: LayeredConfigTree,
     randomness_stream: RandomnessStream,
     dataset_name: str,
     column_name: str,
@@ -561,7 +560,7 @@ def use_nicknames(
     Function that replaces a name with a choice of potential nicknames.
 
     :param data:  A pandas dataframe containing necessary columns for column noise
-    :param _: ConfigTree with rate at which to blank the data in column.
+    :param _: LayeredConfigTree with rate at which to blank the data in column.
     :param randomness_stream:  RandomnessStream to utilize Vivarium CRN.
     :param column_name: String for column that will be noised, will be the key for RandomnessStream
     :return: pd.Series of nicknames replacing original names
@@ -582,7 +581,7 @@ def use_nicknames(
 
 def use_fake_names(
     data: pd.DataFrame,
-    _: ConfigTree,
+    _: LayeredConfigTree,
     randomness_stream: RandomnessStream,
     dataset_name: str,
     column_name: str,
@@ -590,7 +589,7 @@ def use_fake_names(
     """
 
     :param data:  A pandas dataframe containing necessary columns for column noise
-    :param _: ConfigTree with rate at which to blank the data in column.
+    :param _: LayeredConfigTree with rate at which to blank the data in column.
     :param randomness_stream:  RandomnessStream to utilize Vivarium CRN.
     :param column_name: String for column that will be noised, will be the key for RandomnessStream
     :return:
@@ -626,7 +625,7 @@ def use_fake_names(
 
 def make_phonetic_errors(
     data: pd.Series,
-    configuration: ConfigTree,
+    configuration: LayeredConfigTree,
     randomness_stream: RandomnessStream,
     dataset_name: str,
     column_name: Any,
@@ -634,7 +633,7 @@ def make_phonetic_errors(
     """
 
     :param data:  A pandas dataframe containing necessary columns for column noise
-    :param configuration: ConfigTree with rate at which to blank the data in column.
+    :param configuration: LayeredConfigTree with rate at which to blank the data in column.
     :param randomness_stream:  RandomnessStream to utilize Vivarium CRN.
     :param column_name: String for column that will be noised, will be the key for RandomnessStream
     :return: pd.Series of noised data
@@ -654,7 +653,7 @@ def make_phonetic_errors(
 
 def leave_blanks(
     data: pd.DataFrame,
-    configuration: ConfigTree,
+    configuration: LayeredConfigTree,
     randomness_stream: RandomnessStream,
     dataset_name: str,
     column_name: str,
@@ -663,7 +662,7 @@ def leave_blanks(
     Function that takes a column and blanks out all values.
 
     :param data:  A pandas dataframe containing necessary columns for column noise
-    :param configuration: ConfigTree with rate at which to blank the data in column.
+    :param configuration: LayeredConfigTree with rate at which to blank the data in column.
     :param randomness_stream:  RandomnessStream to utilize Vivarium CRN.
     :param column_name: String for column that will be noised, will be the key for RandomnessStream
     """
@@ -672,7 +671,7 @@ def leave_blanks(
 
 def make_typos(
     data: pd.DataFrame,
-    configuration: ConfigTree,
+    configuration: LayeredConfigTree,
     randomness_stream: RandomnessStream,
     dataset_name: str,
     column_name: str,
@@ -681,7 +680,7 @@ def make_typos(
     representative of keyboard mistyping.
 
     :param data:  A pandas dataframe containing necessary columns for column noise
-    :param configuration: ConfigTree with rate at which to blank the data in column.
+    :param configuration: LayeredConfigTree with rate at which to blank the data in column.
     :param randomness_stream:  RandomnessStream to utilize Vivarium CRN.
     :param column_name: String for column that will be noised, will be the key for RandomnessStream
     :returns: pd.Series of column with noised data
@@ -758,14 +757,14 @@ def make_typos(
 
 def make_ocr_errors(
     data: pd.DataFrame,
-    configuration: ConfigTree,
+    configuration: LayeredConfigTree,
     randomness_stream: RandomnessStream,
     dataset_name: str,
     column_name: str,
 ) -> pd.Series:
     """
     :param data:  A pandas dataframe containing necessary columns for column noise
-    :param configuration: ConfigTree with rate at which to blank the data in column.
+    :param configuration: LayeredConfigTree with rate at which to blank the data in column.
     :param randomness_stream:  RandomnessStream to utilize Vivarium CRN.
     :param column_name: String for column that will be noised, will be the key for RandomnessStream
     :return: pd.Series of noised data

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -2,8 +2,9 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-
 from layered_config_tree import LayeredConfigTree
+from vivarium.framework.randomness import RandomnessStream, get_hash
+
 from pseudopeople.configuration import Keys
 from pseudopeople.constants import data_values
 from pseudopeople.constants.metadata import DatasetNames
@@ -25,7 +26,6 @@ from pseudopeople.utilities import (
     two_d_array_choice,
     vectorized_choice,
 )
-from vivarium.framework.randomness import RandomnessStream, get_hash
 
 
 def omit_rows(
@@ -222,12 +222,12 @@ def duplicate_with_guardian(
     ]
 
     # Merge depedents with their guardians
-    formatted_group_data[Keys.ROW_PROBABILITY_IN_HOUSEHOLDS_UNDER_18] = (
-        _merge_dependents_and_guardians(in_households_under_18, dataset_data)
-    )
-    formatted_group_data[Keys.ROW_PROBABILITY_IN_COLLEGE_GROUP_QUARTERS_UNDER_24] = (
-        _merge_dependents_and_guardians(in_college_under_24, dataset_data)
-    )
+    formatted_group_data[
+        Keys.ROW_PROBABILITY_IN_HOUSEHOLDS_UNDER_18
+    ] = _merge_dependents_and_guardians(in_households_under_18, dataset_data)
+    formatted_group_data[
+        Keys.ROW_PROBABILITY_IN_COLLEGE_GROUP_QUARTERS_UNDER_24
+    ] = _merge_dependents_and_guardians(in_college_under_24, dataset_data)
     # Note: We have two dicts (configuration and formatted_group_data) at this point that have
     # the key for the group and then a dataframe for that group or the group and the configured
     # noise level

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -7,18 +7,9 @@ from typing import Tuple
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.api.types import is_datetime64_any_dtype as is_datetime
-from tests.conftest import FuzzyChecker
-from tests.integration.conftest import (
-    CELL_PROBABILITY,
-    IDX_COLS,
-    SEED,
-    STATE,
-    _get_common_datasets,
-    _load_sample_data,
-)
-
 from layered_config_tree import LayeredConfigTree
+from pandas.api.types import is_datetime64_any_dtype as is_datetime
+
 from pseudopeople.configuration import Keys, get_configuration
 from pseudopeople.constants.noise_type_metadata import INT_COLUMNS
 from pseudopeople.interface import (
@@ -38,6 +29,15 @@ from pseudopeople.utilities import (
     load_ocr_errors,
     load_phonetic_errors,
     load_qwerty_errors_data,
+)
+from tests.conftest import FuzzyChecker
+from tests.integration.conftest import (
+    CELL_PROBABILITY,
+    IDX_COLS,
+    SEED,
+    STATE,
+    _get_common_datasets,
+    _load_sample_data,
 )
 
 DATASET_GENERATION_FUNCS = {

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -8,8 +8,17 @@ import numpy as np
 import pandas as pd
 import pytest
 from pandas.api.types import is_datetime64_any_dtype as is_datetime
-from vivarium.config_tree import ConfigTree
+from tests.conftest import FuzzyChecker
+from tests.integration.conftest import (
+    CELL_PROBABILITY,
+    IDX_COLS,
+    SEED,
+    STATE,
+    _get_common_datasets,
+    _load_sample_data,
+)
 
+from layered_config_tree import LayeredConfigTree
 from pseudopeople.configuration import Keys, get_configuration
 from pseudopeople.constants.noise_type_metadata import INT_COLUMNS
 from pseudopeople.interface import (
@@ -29,15 +38,6 @@ from pseudopeople.utilities import (
     load_ocr_errors,
     load_phonetic_errors,
     load_qwerty_errors_data,
-)
-from tests.conftest import FuzzyChecker
-from tests.integration.conftest import (
-    CELL_PROBABILITY,
-    IDX_COLS,
-    SEED,
-    STATE,
-    _get_common_datasets,
-    _load_sample_data,
 )
 
 DATASET_GENERATION_FUNCS = {
@@ -610,7 +610,7 @@ def _validate_column_noise_level(
     check_idx: pd.Index,
     noise_level: float,
     col: Column,
-    config: ConfigTree,
+    config: LayeredConfigTree,
     fuzzy_name: str,
     validator: FuzzyChecker,
 ):

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -29,7 +29,7 @@ ROW_NOISE_TYPES = [
 
 def test_get_default_configuration(mocker):
     """Tests that the default configuration can be retrieved."""
-    mock = mocker.patch("pseudopeople.configuration.generator.ConfigTree")
+    mock = mocker.patch("pseudopeople.configuration.generator.LayeredConfigTree")
     _ = get_configuration()
     mock.assert_called_once_with(layers=["baseline", "default", "user"])
 
@@ -120,7 +120,7 @@ def validate_noise_type_config(dataset, noise_type, config_level, column=None):
 
 def test_get_configuration_with_user_override(mocker):
     """Tests that the default configuration get updated when a user configuration is supplied."""
-    mock = mocker.patch("pseudopeople.configuration.generator.ConfigTree")
+    mock = mocker.patch("pseudopeople.configuration.generator.LayeredConfigTree")
     config = {
         DATASETS.census.name: {
             Keys.ROW_NOISE: {NOISE_TYPES.omit_row.name: {Keys.ROW_PROBABILITY: 0.05}},
@@ -179,7 +179,7 @@ def test_loading_from_yaml(tmp_path):
     ids=["list", "dict"],
 )
 def test_format_miswrite_ages(age_differences, expected):
-    """Test that user-supplied dictionary properly updates ConfigTree object.
+    """Test that user-supplied dictionary properly updates LayeredConfigTree object.
     This includes zero-ing out default values that don't exist in the user config
     """
     overrides = {

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -5,9 +5,8 @@ from typing import NamedTuple
 import numpy as np
 import pandas as pd
 import pytest
-from tests.conftest import FuzzyChecker
-
 from layered_config_tree import LayeredConfigTree
+
 from pseudopeople.configuration import Keys
 from pseudopeople.entity_types import ColumnNoiseType
 from pseudopeople.interface import (
@@ -22,6 +21,7 @@ from pseudopeople.interface import (
 from pseudopeople.noise import noise_dataset
 from pseudopeople.noise_entities import NOISE_TYPES
 from pseudopeople.schema_entities import DATASETS
+from tests.conftest import FuzzyChecker
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -5,8 +5,9 @@ from typing import NamedTuple
 import numpy as np
 import pandas as pd
 import pytest
-from vivarium.config_tree import ConfigTree
+from tests.conftest import FuzzyChecker
 
+from layered_config_tree import LayeredConfigTree
 from pseudopeople.configuration import Keys
 from pseudopeople.entity_types import ColumnNoiseType
 from pseudopeople.interface import (
@@ -21,7 +22,6 @@ from pseudopeople.interface import (
 from pseudopeople.noise import noise_dataset
 from pseudopeople.noise_entities import NOISE_TYPES
 from pseudopeople.schema_entities import DATASETS
-from tests.conftest import FuzzyChecker
 
 
 @pytest.fixture(scope="module")
@@ -48,7 +48,7 @@ def get_dummy_config_noise_numbers(dataset):
     NOTE: this is not a realistic scenario but allows for certain
     types of stress testing.
     """
-    return ConfigTree(
+    return LayeredConfigTree(
         {
             dataset.name: {
                 Keys.COLUMN_NOISE: {
@@ -208,7 +208,7 @@ def test_columns_noised(dummy_data):
     """Test that the noise functions are only applied to the numbers column
     (as specified in the dummy config)
     """
-    config = ConfigTree(
+    config = LayeredConfigTree(
         {
             DATASETS.census.name: {
                 Keys.COLUMN_NOISE: {
@@ -250,7 +250,7 @@ def test_correct_datasets_are_used(func, dataset, mocker):
 
 def test_two_noise_functions_are_independent(mocker, fuzzy_checker: FuzzyChecker):
     # Make simple config tree to test 2 noise functions work together
-    config_tree = ConfigTree(
+    config_tree = LayeredConfigTree(
         {
             DATASETS.census.name: {
                 "column_noise": {


### PR DESCRIPTION
## Use LayeredConfigTree instead of vivarium.ConfigTree
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: [MIC-4989](https://jira.ihme.washington.edu/browse/MIC-4989)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This replaces vivarium.ConfigTree with the LayeredConfigTree package
now available on pypi.

NOTE: I'm merging this directly into main since we tend to release
pseudopeople very infrequently; I don't want to forget about this
and officially remove the ConfigTree class from vivarium and
break psp for everyone.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [x] all tests pass (`pytest --runslow`)
