### PR TITLE
Fix dtype bug in int columns

### DIFF
--- a/src/pseudopeople/constants/noise_type_metadata.py
+++ b/src/pseudopeople/constants/noise_type_metadata.py
@@ -25,8 +25,10 @@ COPY_HOUSEHOLD_MEMBER_COLS = {
     "dependent_4_ssn": "dependent_4_copy_ssn",
 }
 
-
-INT_COLUMNS = ["age", "wages", "mailing_address_po_box"]
+# Columns that are integers in pseudopeople input but strings in
+# the pseudopeople output. We have to be careful that they don't
+# end up getting stringified as floats, e.g. age being 26.0 instead of 26
+INT_TO_STRING_COLUMNS = ["age", "wages", "mailing_address_po_box"]
 
 
 HOUSING_TYPE_GUARDIAN_DUPLICATION_RELATONSHIP_MAP = {

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -122,10 +122,6 @@ class ColumnNoiseType(NoiseType):
             column_name,
         )
 
-        # Coerce noised column dtype back to original column's if it has changed
-        if noised_data.dtype.name != data[column_name].dtype.name:
-            noised_data = noised_data.astype(data[column_name].dtype)
-
         result = data[column_name].copy()
         result.loc[to_noise_idx] = noised_data
 

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -13,16 +13,17 @@ from pseudopeople.constants import paths
 from pseudopeople.constants.metadata import DATEFORMATS
 from pseudopeople.constants.noise_type_metadata import (
     COPY_HOUSEHOLD_MEMBER_COLS,
-    INT_COLUMNS,
+    INT_TO_STRING_COLUMNS,
 )
 from pseudopeople.exceptions import DataSourceError
 from pseudopeople.loader import load_standard_dataset_file
 from pseudopeople.noise import noise_dataset
-from pseudopeople.schema_entities import COLUMNS, DATASETS, Dataset
+from pseudopeople.schema_entities import COLUMNS, DATASETS, Dataset, DtypeNames
 from pseudopeople.utilities import (
     cleanse_integer_columns,
     configure_logging_to_terminal,
     get_state_abbreviation,
+    to_string_preserve_nans,
 )
 
 
@@ -81,7 +82,7 @@ def _generate_dataset(
         if data.empty:
             continue
         data = _reformat_dates_for_noising(data, dataset)
-        data = _coerce_dtypes(data, dataset)
+        data = _clean_input_data(data, dataset)
         # Use a different seed for each data file/shard, otherwise the randomness will duplicate
         # and the Nth row in each shard will get the same noise
         data_path_seed = f"{seed}_{data_path_index}"
@@ -97,12 +98,9 @@ def _generate_dataset(
         )
     noised_dataset = pd.concat(noised_dataset, ignore_index=True)
 
-    # Known pandas bug: pd.concat does not preserve category dtypes so we coerce
-    # again after concat (https://github.com/pandas-dev/pandas/issues/51362)
     noised_dataset = _coerce_dtypes(
         noised_dataset,
         dataset,
-        cleanse_int_cols=True,
     )
 
     logger.debug("*** Finished ***")
@@ -149,21 +147,36 @@ def _get_data_changelog_version(changelog):
     return version
 
 
+def _clean_input_data(
+    data: pd.DataFrame,
+    dataset: Dataset,
+) -> pd.DataFrame:
+    for col in dataset.columns:
+        # Coerce empty strings to nans
+        data[col.name] = data[col.name].replace("", np.nan)
+
+        if data[col.name].dtype.name == "category" and col.dtype_name == DtypeNames.OBJECT:
+            # We made some columns in the pseudopeople input categorical
+            # purely as a kind of DIY compression.
+            # TODO: Determine whether this is benefitting us after
+            # the switch to Parquet.
+            data[col.name] = to_string_preserve_nans(data[col.name])
+
+    return data
+
 def _coerce_dtypes(
     data: pd.DataFrame,
     dataset: Dataset,
-    cleanse_int_cols: bool = False,
 ) -> pd.DataFrame:
-    # Coerce dtypes prior to noising to catch issues early as well as
-    # get most columns away from dtype 'category' and into 'object' (strings)
     for col in dataset.columns:
-        if cleanse_int_cols and col.name in INT_COLUMNS:
+        if col.name in INT_TO_STRING_COLUMNS:
             data[col.name] = cleanse_integer_columns(data[col.name])
-        # Coerce empty strings to nans
-        if cleanse_int_cols and col.name not in INT_COLUMNS:
-            data[col.name] = data[col.name].replace("", np.nan)
+
         if col.dtype_name != data[col.name].dtype.name:
-            data[col.name] = data[col.name].astype(col.dtype_name)
+            if col.dtype_name == DtypeNames.OBJECT:
+                data[col.name] = to_string_preserve_nans(data[col.name])
+            else:
+                data[col.name] = data[col.name].astype(col.dtype_name)
 
     return data
 

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -164,6 +164,7 @@ def _clean_input_data(
 
     return data
 
+
 def _coerce_dtypes(
     data: pd.DataFrame,
     dataset: Dataset,

--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -12,6 +12,7 @@ class DtypeNames:
     CATEGORICAL = "category"
     DATETIME = "datetime64[ns]"
     OBJECT = "object"
+    INT = "int64"
 
 
 @dataclass
@@ -550,6 +551,7 @@ class __Columns(NamedTuple):
     )
     tax_year: Column = Column(
         "tax_year",
+        dtype_name=DtypeNames.INT,
     )
     unit_number: Column = Column(
         "unit_number",
@@ -562,6 +564,7 @@ class __Columns(NamedTuple):
     )
     year: Column = Column(
         "year",
+        dtype_name=DtypeNames.INT,
     )
     zipcode: Column = Column(
         "zipcode",

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -184,10 +184,14 @@ def get_state_abbreviation(state: str) -> str:
         raise ValueError(f"Unexpected state input: '{state}'") from None
 
 
+def to_string_preserve_nans(s: pd.Series) -> pd.Series:
+    result = s.astype(str)
+    result[s.isna()] = np.nan
+    return result
+
 def cleanse_integer_columns(column: pd.Series) -> pd.Series:
-    column = column.copy()
-    column[column.notna()] = column[column.notna()].astype(str)
-    float_mask = column.notna() & (column.astype(str).str.contains(".", regex=False))
+    column = to_string_preserve_nans(column)
+    float_mask = column.notna() & (column.str.contains(".", regex=False))
     column.loc[float_mask] = column.loc[float_mask].astype(str).str.split(".").str[0]
     return column
 

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -189,6 +189,7 @@ def to_string_preserve_nans(s: pd.Series) -> pd.Series:
     result[s.isna()] = np.nan
     return result
 
+
 def cleanse_integer_columns(column: pd.Series) -> pd.Series:
     column = to_string_preserve_nans(column)
     float_mask = column.notna() & (column.str.contains(".", regex=False))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,6 +8,7 @@ from pseudopeople.configuration.entities import NO_NOISE
 from pseudopeople.constants import paths
 from pseudopeople.constants.metadata import DatasetNames
 from pseudopeople.interface import (
+    _coerce_dtypes,
     _reformat_dates_for_noising,
     generate_american_community_survey,
     generate_current_population_survey,
@@ -268,7 +269,7 @@ def _get_common_datasets(dataset_name, data, noised_data):
     """
     idx_cols = IDX_COLS.get(dataset_name)
     dataset = DATASETS.get_dataset(dataset_name)
-    check_original = _reformat_dates_for_noising(data, dataset).set_index(idx_cols)
+    check_original = _coerce_dtypes(_reformat_dates_for_noising(data, dataset), dataset).set_index(idx_cols)
     check_noised = noised_data.set_index(idx_cols)
     # Ensure the idx_cols are unique
     assert check_original.index.duplicated().sum() == 0

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -269,7 +269,9 @@ def _get_common_datasets(dataset_name, data, noised_data):
     """
     idx_cols = IDX_COLS.get(dataset_name)
     dataset = DATASETS.get_dataset(dataset_name)
-    check_original = _coerce_dtypes(_reformat_dates_for_noising(data, dataset), dataset).set_index(idx_cols)
+    check_original = _coerce_dtypes(
+        _reformat_dates_for_noising(data, dataset), dataset
+    ).set_index(idx_cols)
     check_noised = noised_data.set_index(idx_cols)
     # Ensure the idx_cols are unique
     assert check_original.index.duplicated().sum() == 0

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -282,7 +282,10 @@ def test_row_noising_omit_row_or_do_not_respond(dataset_name: str, config, reque
         pytest.skip(reason=dataset_name)
     idx_cols = IDX_COLS.get(dataset_name)
     dataset = DATASETS.get_dataset(dataset_name)
-    data = _coerce_dtypes(_reformat_dates_for_noising(_load_sample_data(dataset_name, request), dataset), dataset)
+    data = _coerce_dtypes(
+        _reformat_dates_for_noising(_load_sample_data(dataset_name, request), dataset),
+        dataset,
+    )
     data = data.set_index(idx_cols)
     noised_data = request.getfixturevalue(f"noised_sample_data_{dataset_name}").set_index(
         idx_cols

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -185,14 +185,15 @@ def test_column_dtypes(dataset_name: str, request):
     if "TODO" in dataset_name:
         pytest.skip(reason=dataset_name)
     noised_data = request.getfixturevalue(f"noised_sample_data_{dataset_name}")
-    idx_cols = IDX_COLS.get(dataset_name)
-    check_noised = noised_data.set_index(idx_cols)
-    for col_name in check_noised.columns:
+    for col_name in noised_data.columns:
         col = COLUMNS.get_column(col_name)
         expected_dtype = col.dtype_name
-        if expected_dtype == np.dtype(str):
+        if expected_dtype == np.dtype(object):
             # str dtype is 'object'
-            expected_dtype = np.dtype(object)
+            # Check that they are actually strings and not some other
+            # type of object.
+            actual_types = noised_data[col.name].dropna().apply(type)
+            assert (actual_types == str).all(), actual_types.unique()
         assert noised_data[col.name].dtype == expected_dtype
 
 


### PR DESCRIPTION
## Fix dtype bug in int columns

### Description
- *Category*: bugfix
- *JIRA issue*: None

Discovered in the course of working on #404 that there was some very strange dtype behavior going on: pseudopeople was returning columns with dtype "object" that contained integer objects. Our test was not catching this.

I've beefed up the test (got it actually failing on `main`), and fixed the issue with the integer columns to make them int dtypes. 

### Testing
- [ ] all tests pass (`pytest --runslow`)
