### PR TITLE
Don't draw progress bars when using Dask

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -139,6 +139,7 @@ def _generate_dataset(
                     dataset,
                     configuration_tree,
                     seed=f"{seed}_{partition_info['number'] if partition_info is not None else 1}",
+                    progress_bar=False,
                 ),
                 dataset,
             ),
@@ -151,11 +152,17 @@ def _generate_dataset(
 
 
 def _prep_and_noise_dataset(
-    data: pd.DataFrame, dataset: Dataset, configuration_tree: LayeredConfigTree, seed: Any
+    data: pd.DataFrame,
+    dataset: Dataset,
+    configuration_tree: LayeredConfigTree,
+    seed: Any,
+    progress_bar: bool = True,
 ) -> pd.DataFrame:
     data = _reformat_dates_for_noising(data, dataset)
     data = _clean_input_data(data, dataset)
-    noised_data = noise_dataset(dataset, data, configuration_tree, seed)
+    noised_data = noise_dataset(
+        dataset, data, configuration_tree, seed, progress_bar=progress_bar
+    )
     noised_data = _extract_columns(dataset.columns, noised_data)
     return noised_data
 

--- a/src/pseudopeople/noise.py
+++ b/src/pseudopeople/noise.py
@@ -30,6 +30,7 @@ def noise_dataset(
     dataset_data: pd.DataFrame,
     configuration: LayeredConfigTree,
     seed: Any,
+    progress_bar: bool = True,
 ) -> pd.DataFrame:
     """
     Adds noise to the input dataset data. Noise functions are executed in the order
@@ -57,7 +58,14 @@ def noise_dataset(
     # except for the leave_blank kind which is special-cased below
     missingness = (dataset_data == "") | (dataset_data.isna())
 
-    for noise_type in tqdm(NOISE_TYPES, desc="Applying noise", unit="type", leave=False):
+    if progress_bar:
+        noise_type_iterator = tqdm(
+            NOISE_TYPES, desc="Applying noise", unit="type", leave=False
+        )
+    else:
+        noise_type_iterator = NOISE_TYPES
+
+    for noise_type in noise_type_iterator:
         if isinstance(noise_type, RowNoiseType):
             if (
                 Keys.ROW_NOISE in noise_configuration

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -618,6 +618,8 @@ def _mock_noise_dataset(
     dataset_data: pd.DataFrame,
     configuration,
     seed: int,
+    *args,
+    **kwargs,
 ):
     """Mock noise_dataset that just returns unnoised data"""
     return dataset_data


### PR DESCRIPTION
## Don't draw progress bars when using Dask

### Description
- *Category*: bugfix
- *JIRA issue*: None

The progress bars don't work when they aren't sequential. With a local Dask cluster, they would all overwrite each other; with a distributed Dask cluster, they were just never seen.

### Testing
- [ ] all tests pass (`pytest --runslow`)

No progress bars appear.