### PR TITLE
Make dtype handling much more explicit

### DIFF
--- a/src/pseudopeople/dtypes.py
+++ b/src/pseudopeople/dtypes.py
@@ -1,0 +1,7 @@
+class DtypeNames:
+    """Container of expected dtype names"""
+
+    CATEGORICAL = "category"
+    DATETIME = "datetime64[ns]"
+    OBJECT = "object"
+    INT = "int64"

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -10,10 +10,7 @@ from vivarium.framework.randomness import RandomnessStream
 
 from pseudopeople.configuration import Keys
 from pseudopeople.dtypes import DtypeNames
-from pseudopeople.utilities import (
-    get_index_to_noise,
-    to_string,
-)
+from pseudopeople.utilities import get_index_to_noise, to_string
 
 
 @dataclass

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -9,12 +9,10 @@ from loguru import logger
 from vivarium.framework.randomness import RandomnessStream
 
 from pseudopeople.configuration import Keys
-from pseudopeople.constants.noise_type_metadata import INT_TO_STRING_COLUMNS
 from pseudopeople.dtypes import DtypeNames
 from pseudopeople.utilities import (
     get_index_to_noise,
-    to_string_as_integer,
-    to_string_preserve_nans,
+    to_string,
 )
 
 
@@ -133,11 +131,7 @@ class ColumnNoiseType(NoiseType):
         input_dtype = data[column_name].dtype
         output_dtype = self.output_dtype_getter(input_dtype)
         if output_dtype == DtypeNames.OBJECT:
-            as_output_dtype = (
-                to_string_as_integer
-                if column_name in INT_TO_STRING_COLUMNS
-                else to_string_preserve_nans
-            )
+            as_output_dtype = to_string
         else:
             as_output_dtype = lambda x: x.astype(output_dtype)
         result = as_output_dtype(data[column_name].copy())

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -2,13 +2,19 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+import numpy as np
 import pandas as pd
 from layered_config_tree import LayeredConfigTree
 from loguru import logger
 from vivarium.framework.randomness import RandomnessStream
 
 from pseudopeople.configuration import Keys
-from pseudopeople.utilities import get_index_to_noise
+from pseudopeople.constants.noise_type_metadata import INT_TO_STRING_COLUMNS
+from pseudopeople.utilities import (
+    get_index_to_noise,
+    to_string_as_integer,
+    to_string_preserve_nans,
+)
 
 
 @dataclass
@@ -77,6 +83,7 @@ class ColumnNoiseType(NoiseType):
     probability: Optional[float] = 0.01
     noise_level_scaling_function: Callable[[pd.DataFrame, str], float] = lambda x, y: 1.0
     additional_column_getter: Callable[[str], List[str]] = lambda column_name: []
+    output_dtype_getter: Callable[[np.dtype], np.dtype] = lambda dtype: dtype
 
     @property
     def probability_key(self) -> str:
@@ -122,7 +129,17 @@ class ColumnNoiseType(NoiseType):
             column_name,
         )
 
-        result = data[column_name].copy()
-        result.loc[to_noise_idx] = noised_data
+        input_dtype = data[column_name].dtype
+        output_dtype = self.output_dtype_getter(input_dtype)
+        if output_dtype == np.dtype("O"):
+            as_output_dtype = (
+                to_string_as_integer
+                if column_name in INT_TO_STRING_COLUMNS
+                else to_string_preserve_nans
+            )
+        else:
+            as_output_dtype = lambda x: x.astype(output_dtype)
+        result = as_output_dtype(data[column_name].copy())
+        result.loc[to_noise_idx] = as_output_dtype(noised_data)
 
         return result, to_noise_idx

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -10,6 +10,7 @@ from vivarium.framework.randomness import RandomnessStream
 
 from pseudopeople.configuration import Keys
 from pseudopeople.constants.noise_type_metadata import INT_TO_STRING_COLUMNS
+from pseudopeople.dtypes import DtypeNames
 from pseudopeople.utilities import (
     get_index_to_noise,
     to_string_as_integer,
@@ -131,7 +132,7 @@ class ColumnNoiseType(NoiseType):
 
         input_dtype = data[column_name].dtype
         output_dtype = self.output_dtype_getter(input_dtype)
-        if output_dtype == np.dtype("O"):
+        if output_dtype == DtypeNames.OBJECT:
             as_output_dtype = (
                 to_string_as_integer
                 if column_name in INT_TO_STRING_COLUMNS

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -25,8 +25,6 @@ from pseudopeople.utilities import (
     get_engine_from_string,
     get_state_abbreviation,
     to_string,
-    to_string_as_integer,
-    to_string_preserve_nans,
 )
 
 
@@ -218,7 +216,7 @@ def _clean_input_data(
             # purely as a kind of DIY compression.
             # TODO: Determine whether this is benefitting us after
             # the switch to Parquet.
-            data[col.name] = to_string_preserve_nans(data[col.name])
+            data[col.name] = to_string(data[col.name])
 
     return data
 

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -14,7 +14,6 @@ from pseudopeople.constants import paths
 from pseudopeople.constants.metadata import DATEFORMATS
 from pseudopeople.constants.noise_type_metadata import (
     COPY_HOUSEHOLD_MEMBER_COLS,
-    INT_TO_STRING_COLUMNS,
 )
 from pseudopeople.dtypes import DtypeNames
 from pseudopeople.exceptions import DataSourceError
@@ -27,6 +26,7 @@ from pseudopeople.utilities import (
     configure_logging_to_terminal,
     get_engine_from_string,
     get_state_abbreviation,
+    to_string,
     to_string_as_integer,
     to_string_preserve_nans,
 )
@@ -230,12 +230,9 @@ def _coerce_dtypes(
     dataset: Dataset,
 ) -> pd.DataFrame:
     for col in dataset.columns:
-        if col.name in INT_TO_STRING_COLUMNS:
-            data[col.name] = to_string_as_integer(data[col.name])
-
         if col.dtype_name != data[col.name].dtype.name:
             if col.dtype_name == DtypeNames.OBJECT:
-                data[col.name] = to_string_preserve_nans(data[col.name])
+                data[col.name] = to_string(data[col.name])
             else:
                 data[col.name] = data[col.name].astype(col.dtype_name)
 

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -12,9 +12,7 @@ from pseudopeople import __version__ as psp_version
 from pseudopeople.configuration import get_configuration
 from pseudopeople.constants import paths
 from pseudopeople.constants.metadata import DATEFORMATS
-from pseudopeople.constants.noise_type_metadata import (
-    COPY_HOUSEHOLD_MEMBER_COLS,
-)
+from pseudopeople.constants.noise_type_metadata import COPY_HOUSEHOLD_MEMBER_COLS
 from pseudopeople.dtypes import DtypeNames
 from pseudopeople.exceptions import DataSourceError
 from pseudopeople.loader import load_standard_dataset

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -16,17 +16,18 @@ from pseudopeople.constants.noise_type_metadata import (
     COPY_HOUSEHOLD_MEMBER_COLS,
     INT_TO_STRING_COLUMNS,
 )
+from pseudopeople.dtypes import DtypeNames
 from pseudopeople.exceptions import DataSourceError
 from pseudopeople.loader import load_standard_dataset
 from pseudopeople.noise import noise_dataset
-from pseudopeople.schema_entities import COLUMNS, DATASETS, Dataset, DtypeNames
+from pseudopeople.schema_entities import COLUMNS, DATASETS, Dataset
 from pseudopeople.utilities import (
     PANDAS_ENGINE,
     DataFrame,
-    cleanse_integer_columns,
     configure_logging_to_terminal,
     get_engine_from_string,
     get_state_abbreviation,
+    to_string_as_integer,
     to_string_preserve_nans,
 )
 
@@ -223,7 +224,7 @@ def _coerce_dtypes(
 ) -> pd.DataFrame:
     for col in dataset.columns:
         if col.name in INT_TO_STRING_COLUMNS:
-            data[col.name] = cleanse_integer_columns(data[col.name])
+            data[col.name] = to_string_as_integer(data[col.name])
 
         if col.dtype_name != data[col.name].dtype.name:
             if col.dtype_name == DtypeNames.OBJECT:

--- a/src/pseudopeople/noise_entities.py
+++ b/src/pseudopeople/noise_entities.py
@@ -1,6 +1,11 @@
 from typing import NamedTuple
 
-from pseudopeople import column_getters, noise_functions, noise_scaling
+from pseudopeople import (
+    column_getters,
+    noise_functions,
+    noise_scaling,
+    output_dtype_getters,
+)
 from pseudopeople.configuration import Keys
 from pseudopeople.entity_types import ColumnNoiseType, RowNoiseType
 
@@ -33,6 +38,7 @@ class __NoiseTypes(NamedTuple):
     leave_blank: ColumnNoiseType = ColumnNoiseType(
         "leave_blank",
         noise_functions.leave_blanks,
+        output_dtype_getter=output_dtype_getters.output_dtype_getter_leave_blank,
     )
     choose_wrong_option: ColumnNoiseType = ColumnNoiseType(
         "choose_wrong_option",
@@ -48,10 +54,12 @@ class __NoiseTypes(NamedTuple):
     swap_month_and_day: ColumnNoiseType = ColumnNoiseType(
         "swap_month_and_day",
         noise_functions.swap_months_and_days,
+        output_dtype_getter=output_dtype_getters.output_dtype_getter_always_string,
     )
     write_wrong_zipcode_digits: ColumnNoiseType = ColumnNoiseType(
         "write_wrong_zipcode_digits",
         noise_functions.write_wrong_zipcode_digits,
+        output_dtype_getter=output_dtype_getters.output_dtype_getter_always_string,
         additional_parameters={
             Keys.ZIPCODE_DIGIT_PROBABILITIES: [0.04, 0.04, 0.20, 0.36, 0.36],
         },
@@ -66,6 +74,7 @@ class __NoiseTypes(NamedTuple):
     write_wrong_digits: ColumnNoiseType = ColumnNoiseType(
         "write_wrong_digits",
         noise_functions.write_wrong_digits,
+        output_dtype_getter=output_dtype_getters.output_dtype_getter_always_string,
         additional_parameters={
             Keys.TOKEN_PROBABILITY: 0.1,
         },
@@ -82,6 +91,7 @@ class __NoiseTypes(NamedTuple):
     make_phonetic_errors: ColumnNoiseType = ColumnNoiseType(
         "make_phonetic_errors",
         noise_functions.make_phonetic_errors,
+        output_dtype_getter=output_dtype_getters.output_dtype_getter_always_string,
         additional_parameters={
             Keys.TOKEN_PROBABILITY: 0.1,
         },
@@ -89,6 +99,7 @@ class __NoiseTypes(NamedTuple):
     make_ocr_errors: ColumnNoiseType = ColumnNoiseType(
         "make_ocr_errors",
         noise_functions.make_ocr_errors,
+        output_dtype_getter=output_dtype_getters.output_dtype_getter_always_string,
         additional_parameters={
             Keys.TOKEN_PROBABILITY: 0.1,
         },
@@ -96,6 +107,7 @@ class __NoiseTypes(NamedTuple):
     make_typos: ColumnNoiseType = ColumnNoiseType(
         "make_typos",
         noise_functions.make_typos,
+        output_dtype_getter=output_dtype_getters.output_dtype_getter_always_string,
         additional_parameters={
             Keys.TOKEN_PROBABILITY: 0.1,
         },

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -12,6 +12,7 @@ from pseudopeople.constants.noise_type_metadata import (
     COPY_HOUSEHOLD_MEMBER_COLS,
     GUARDIAN_DUPLICATION_ADDRESS_COLUMNS,
     HOUSING_TYPE_GUARDIAN_DUPLICATION_RELATONSHIP_MAP,
+    INT_TO_STRING_COLUMNS,
 )
 from pseudopeople.data.fake_names import fake_first_names, fake_last_names
 from pseudopeople.noise_scaling import (
@@ -23,6 +24,7 @@ from pseudopeople.utilities import (
     load_ocr_errors,
     load_phonetic_errors,
     load_qwerty_errors_data,
+    to_string_as_integer,
     two_d_array_choice,
     vectorized_choice,
 )
@@ -517,7 +519,11 @@ def write_wrong_digits(
     rng = np.random.default_rng(
         get_hash(f"{randomness_stream.seed}_{column_name}_write_wrong_digits")
     )
-    column = column.astype(str)
+    if column_name in INT_TO_STRING_COLUMNS:
+        column = to_string_as_integer(column)
+    else:
+        column = column.astype(str)
+
     max_str_length = column.str.len().max()
 
     possible_replacements = np.array(list("0123456789"))

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -12,7 +12,6 @@ from pseudopeople.constants.noise_type_metadata import (
     COPY_HOUSEHOLD_MEMBER_COLS,
     GUARDIAN_DUPLICATION_ADDRESS_COLUMNS,
     HOUSING_TYPE_GUARDIAN_DUPLICATION_RELATONSHIP_MAP,
-    INT_TO_STRING_COLUMNS,
 )
 from pseudopeople.data.fake_names import fake_first_names, fake_last_names
 from pseudopeople.noise_scaling import (
@@ -24,7 +23,7 @@ from pseudopeople.utilities import (
     load_ocr_errors,
     load_phonetic_errors,
     load_qwerty_errors_data,
-    to_string_as_integer,
+    to_string,
     two_d_array_choice,
     vectorized_choice,
 )
@@ -519,10 +518,7 @@ def write_wrong_digits(
     rng = np.random.default_rng(
         get_hash(f"{randomness_stream.seed}_{column_name}_write_wrong_digits")
     )
-    if column_name in INT_TO_STRING_COLUMNS:
-        column = to_string_as_integer(column)
-    else:
-        column = column.astype(str)
+    column = to_string(column)
 
     max_str_length = column.str.len().max()
 

--- a/src/pseudopeople/output_dtype_getters.py
+++ b/src/pseudopeople/output_dtype_getters.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from pseudopeople.dtypes import DtypeNames
+
+
+def output_dtype_getter_leave_blank(dtype: np.dtype) -> np.dtype:
+    # Make sure the dtype is nullable
+    if "int" in dtype.name:
+        return "float"
+
+    return dtype
+
+
+def output_dtype_getter_always_string(_: np.dtype) -> np.dtype:
+    return DtypeNames.OBJECT

--- a/src/pseudopeople/schema_entities.py
+++ b/src/pseudopeople/schema_entities.py
@@ -2,17 +2,9 @@ from dataclasses import dataclass
 from typing import NamedTuple, Optional, Tuple
 
 from pseudopeople.constants.metadata import DATEFORMATS, DatasetNames
+from pseudopeople.dtypes import DtypeNames
 from pseudopeople.entity_types import ColumnNoiseType, RowNoiseType
 from pseudopeople.noise_entities import NOISE_TYPES
-
-
-class DtypeNames:
-    """Container of expected dtype names"""
-
-    CATEGORICAL = "category"
-    DATETIME = "datetime64[ns]"
-    OBJECT = "object"
-    INT = "int64"
 
 
 @dataclass

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -11,6 +11,7 @@ from vivarium.framework.randomness import RandomnessStream, get_hash
 from vivarium.framework.randomness.index_map import IndexMap
 
 from pseudopeople.constants import metadata, paths
+from pseudopeople.dtypes import DtypeNames
 
 
 def get_randomness_stream(dataset_name: str, seed: Any, index: pd.Index) -> RandomnessStream:
@@ -186,12 +187,14 @@ def get_state_abbreviation(state: str) -> str:
 
 
 def to_string_preserve_nans(s: pd.Series) -> pd.Series:
-    result = s.astype(str)
+    # NOTE: In newer versions of pandas, astype(str) will use the *pandas*
+    # string type, which we haven't adopted yet.
+    result = s.astype(str).astype(DtypeNames.OBJECT)
     result[s.isna()] = np.nan
     return result
 
 
-def cleanse_integer_columns(column: pd.Series) -> pd.Series:
+def to_string_as_integer(column: pd.Series) -> pd.Series:
     column = to_string_preserve_nans(column)
     float_mask = column.notna() & (column.str.contains(".", regex=False))
     column.loc[float_mask] = column.loc[float_mask].astype(str).str.split(".").str[0]

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -11,6 +11,7 @@ from vivarium.framework.randomness import RandomnessStream, get_hash
 from vivarium.framework.randomness.index_map import IndexMap
 
 from pseudopeople.constants import metadata, paths
+from pseudopeople.constants.noise_type_metadata import INT_TO_STRING_COLUMNS
 from pseudopeople.dtypes import DtypeNames
 
 
@@ -199,6 +200,15 @@ def to_string_as_integer(column: pd.Series) -> pd.Series:
     float_mask = column.notna() & (column.str.contains(".", regex=False))
     column.loc[float_mask] = column.loc[float_mask].astype(str).str.split(".").str[0]
     return column
+
+def to_string(column: pd.Series, column_name: str = None) -> pd.Series:
+    if column_name is None:
+        column_name = column.name
+    
+    if column_name in INT_TO_STRING_COLUMNS:
+        return to_string_as_integer(column)
+    else:
+        return to_string_preserve_nans(column)
 
 
 def count_number_of_tokens_per_string(s1: pd.Series, s2: pd.Series) -> pd.Series:

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -201,10 +201,11 @@ def to_string_as_integer(column: pd.Series) -> pd.Series:
     column.loc[float_mask] = column.loc[float_mask].astype(str).str.split(".").str[0]
     return column
 
+
 def to_string(column: pd.Series, column_name: str = None) -> pd.Series:
     if column_name is None:
         column_name = column.name
-    
+
     if column_name in INT_TO_STRING_COLUMNS:
         return to_string_as_integer(column)
     else:

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -11,7 +11,6 @@ from layered_config_tree import LayeredConfigTree
 from pandas.api.types import is_datetime64_any_dtype as is_datetime
 
 from pseudopeople.configuration import Keys, get_configuration
-from pseudopeople.constants.noise_type_metadata import INT_TO_STRING_COLUMNS
 from pseudopeople.interface import (
     _coerce_dtypes,
     _reformat_dates_for_noising,
@@ -244,10 +243,6 @@ def test_column_noising(dataset_name: str, config, request, fuzzy_checker: Fuzzy
         # Check for noising where applicable
         to_compare_idx = shared_idx.difference(originally_missing_idx)
         if col.noise_types:
-            # Note: Coercing check_original to string. This seems like it should not
-            # have passed before but our rtol was 0.7
-            if col.name in INT_TO_STRING_COLUMNS:
-                check_original[col.name] = to_string_as_integer(check_original[col.name])
             assert (
                 check_original.loc[to_compare_idx, col.name].values
                 != check_noised.loc[to_compare_idx, col.name].values
@@ -705,10 +700,6 @@ def _get_column_noise_level(
 
     # Check for noising where applicable
     to_compare_sample_idx = common_idx.difference(originally_missing_sample_idx)
-    # Note: Coercing check_original to string. This seems like it should not
-    # have passed before but our rtol was 0.7
-    if column.name in INT_TO_STRING_COLUMNS:
-        unnoised_data[column.name] = to_string_as_integer(unnoised_data[column.name])
 
     noise_level = (
         unnoised_data.loc[to_compare_sample_idx, column.name].values

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -26,11 +26,11 @@ from pseudopeople.interface import (
 from pseudopeople.noise_entities import NOISE_TYPES
 from pseudopeople.schema_entities import COLUMNS, DATASETS, Column
 from pseudopeople.utilities import (
-    cleanse_integer_columns,
     count_number_of_tokens_per_string,
     load_ocr_errors,
     load_phonetic_errors,
     load_qwerty_errors_data,
+    to_string_as_integer,
 )
 from tests.conftest import FuzzyChecker
 from tests.integration.conftest import (
@@ -247,7 +247,7 @@ def test_column_noising(dataset_name: str, config, request, fuzzy_checker: Fuzzy
             # Note: Coercing check_original to string. This seems like it should not
             # have passed before but our rtol was 0.7
             if col.name in INT_TO_STRING_COLUMNS:
-                check_original[col.name] = cleanse_integer_columns(check_original[col.name])
+                check_original[col.name] = to_string_as_integer(check_original[col.name])
             assert (
                 check_original.loc[to_compare_idx, col.name].values
                 != check_noised.loc[to_compare_idx, col.name].values
@@ -706,7 +706,7 @@ def _get_column_noise_level(
     # Note: Coercing check_original to string. This seems like it should not
     # have passed before but our rtol was 0.7
     if column.name in INT_TO_STRING_COLUMNS:
-        unnoised_data[column.name] = cleanse_integer_columns(unnoised_data[column.name])
+        unnoised_data[column.name] = to_string_as_integer(unnoised_data[column.name])
 
     noise_level = (
         unnoised_data.loc[to_compare_sample_idx, column.name].values

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,11 +4,11 @@ import pytest
 from vivarium.framework.randomness import RandomnessStream
 from vivarium.framework.randomness.index_map import IndexMap
 
+from pseudopeople.dtypes import DtypeNames
 from pseudopeople.noise_functions import _corrupt_tokens
-from pseudopeople.schema_entities import DtypeNames
 from pseudopeople.utilities import (
-    cleanse_integer_columns,
     get_index_to_noise,
+    to_string_as_integer,
     two_d_array_choice,
     vectorized_choice,
 )
@@ -53,12 +53,12 @@ CORRUPT_TOKENS_TEST_CASES = {
 }
 
 
-def test_cleanse_integer_columns():
+def test_to_string_as_integer():
     # This tests that object columns return only strings.
     # This is to handle dtype issues we were having with int/float/strings in
     # age, wages, and po box columns.
     s = pd.Series([np.nan, 1, "2.0", 3.01, 4.0, "5.055", np.nan])
-    t = cleanse_integer_columns(s)
+    t = to_string_as_integer(s)
     assert s.dtype.name == t.dtype.name
     assert t.dtype.name == DtypeNames.OBJECT
 


### PR DESCRIPTION
## Make dtype handling much more explicit

### Description
- *Category*: bugfix
- *JIRA issue*: None

I got some Pandas deprecation warnings after #405, and I think there were a few dtype quirks that were not being checked or handled correctly. The biggest one is that I'm pretty sure we've been noising the ".0" after the decimal point on integer columns this whole time, only for it to be lopped off at the end.

So instead, I made it more explicit what the dtype is after each noise function.

### Testing
- [x] all tests pass (`pytest --runslow`)

This actually makes a few of the Dask tests fail but I will correct those in a follow-up Dask PR.