### PR TITLE
Include distributed and dataframe extras with dask install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
         "jupyter",
     ]
 
-    dask_requirements = ["dask"]
+    dask_requirements = ["dask[distributed,dataframe]"]
 
     test_requirements = [
         "pytest",


### PR DESCRIPTION
## Include distributed and dataframe extras with dask install

### Description
- *Category*: bugfix
- *JIRA issue*: None

*Technically* `distributed` isn't necessary if you use the most basic kind of Dask cluster (the kind that parallelizes via multiple threads in a single process) but that sort of Dask cluster isn't particularly helpful for pseudopeople.

### Testing

None