### PR TITLE
Configure logging on distributed Dask

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -115,6 +115,13 @@ def _generate_dataset(
             dataset,
         )
     else:
+        try:
+            from distributed.client import default_client
+            default_client().run(lambda: configure_logging_to_terminal(verbose))
+        except ImportError:
+            # Not using a distributed cluster, so the configure_logging_to_terminal call above already did everything
+            pass
+
         # Let dask deal with how to partition the shards -- we pass it the
         # entire directory containing the parquet files
         data_directory_path = source / dataset.name

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -117,6 +117,7 @@ def _generate_dataset(
     else:
         try:
             from distributed.client import default_client
+
             default_client().run(lambda: configure_logging_to_terminal(verbose))
         except ImportError:
             # Not using a distributed cluster, so the configure_logging_to_terminal call above already did everything


### PR DESCRIPTION
## Configure logging on distributed Dask

### Description
- *Category*: bugfix
- *JIRA issue*: none

Long-term we may want to switch away from the global loguru logger, but for now making this consistent between Dask and non-Dask.

### Testing
- [ ] all tests pass (`pytest --runslow`)

I ran the same thing that Nathaniel did when he noticed this problem (full USA ACS) and verified that the DEBUG logs were no longer displayed.