### PR TITLE
Fix bug when there is no active Dask client

### DIFF
--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -119,7 +119,7 @@ def _generate_dataset(
             from distributed.client import default_client
 
             default_client().run(lambda: configure_logging_to_terminal(verbose))
-        except ImportError:
+        except (ImportError, ValueError):
             # Not using a distributed cluster, so the configure_logging_to_terminal call above already did everything
             pass
 


### PR DESCRIPTION
## Fix bug when there is no active Dask client

### Description
- *Category*: bugfix
- *JIRA issue*: None

When the user has Dask distributed installed, but is not currently running a cluster, this would fail with a ValueError.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [x] all tests pass (`pytest --runslow`)
