### PR TITLE
Mic-5121/Pin numpy below 2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.1.1 - 06/17/24**
+
+ - Hotfix pin numpy below 2.0
+
 **1.1.0 - 05/29/24**
 
  - Adds out-of-core and distributed processing capability via Dask

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ if __name__ == "__main__":
 
     install_requirements = [
         "pandas",
+        "numpy<2.0.0",
         "pyyaml>=5.1",
         "vivarium>=1.2.0",
         "pyarrow",


### PR DESCRIPTION
## Mic-5121/Pin numpy below 2.0

### Pin numpy below 2.0 until we can update to major release at later date.
- *Category*: Build
- *JIRA issue*: [MIC-5121](https://jira.ihme.washington.edu/browse/MIC-5121)

# Updates
-pin numpy below 2.0

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [ ] all tests pass (`pytest --runslow`)
