### PR TITLE
Feature/sbachmei/mic 5128 prep for mypy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,10 @@ jobs:
           pip install .[dev]
       - name: Lint
         run: |
-          pip install black==22.3.0 isort
+          pip install black==22.3.0 isort mypy
           black . --check --diff
           isort . --check --verbose --only-modified --diff
+          mypy .
       - name: Test
         run: |
           if "${{ github.event_name == 'schedule' }}"; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,45 @@ line_length = 94
 
 [tool.isort]
 profile = "black"
+
+[tool.mypy]
+# This is the global mypy configuration.
+strict = true  # See all the enabled flags `mypy --help | grep -A 10 'Strict mode'`
+disallow_any_unimported = false
+exclude = [
+    "build",
+]
+# ignore error codes (to allow for gradual typing)
+# extract unique error codes thrown with `mypy . | grep -oP " [ \K[^\] ]+" | sort | uniq`
+disable_error_code = [
+    "arg-type",
+    "assignment",
+    "attr-defined",
+    "call-arg",
+    "call-overload",
+    "dict-item",
+    "has-type",
+    "import-untyped",
+    "index",
+    "list-item",
+    "method-assign",
+    "misc",
+    "name-defined",
+    "no-any-return",
+    "no-untyped-call",
+    "no-untyped-def",
+    "operator",
+    "override",
+    "return-value",
+    "type-arg",
+    "union-attr",
+    "var-annotated",
+]
+
+# handle mypy errors when 3rd party packages are not typed.
+[[tool.mypy.overrides]]
+module = [
+    # "scipy.*",
+    # "sklearn.*",
+]
+ignore_missing_imports = true

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ if __name__ == "__main__":
     lint_requirements = [
         "black==22.3.0",
         "isort",
+        "mypy",
     ]
 
     doc_requirements = [


### PR DESCRIPTION
## Prepare for mypy linting
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-5128)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This does two things:
1. Turns on mypy in the build lint step
2. Turns off every single mypy error type (via the pyproject.toml)

The intent here is to remove the `disable_error_code`s one at a time
until all are gone and we have full mypy implementation.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [x] all tests pass (`pytest --runslow`)
