### PR TITLE
Mic-5162/call-arg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ disable_error_code = [
     "arg-type",
     "assignment",
     "attr-defined",
-    "call-arg",
     "call-overload",
     "dict-item",
     "has-type",


### PR DESCRIPTION
## Mic-5162/call-arg

### Remove call-arg mypy error
- *Category*: Other
- *JIRA issue*: [MIC-5162](https://jira.ihme.washington.edu/browse/MIC-5162)

-remove call-arg mypy error

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [ ] all tests pass (`pytest --runslow`)
