### PR TITLE
mypy operator error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ disable_error_code = [
     "misc",
     "no-untyped-call",
     "no-untyped-def",
-    "operator",
     "type-arg",
     "var-annotated",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ disable_error_code = [
     "misc",
     "no-untyped-call",
     "no-untyped-def",
+    # operator is still being ignored because of issues with checking containment in
+    # LayeredConfigTree objects which should be resolved by changes mentioned above
+    # TODO: remove "operator" once typed object is implemented
+    "operator",
     "type-arg",
     "var-annotated",
 ]

--- a/src/pseudopeople/entity_types.py
+++ b/src/pseudopeople/entity_types.py
@@ -113,9 +113,10 @@ class ColumnNoiseType(NoiseType):
         if dataset.is_empty(column_name):
             return
 
-        noise_level = configuration[
-            Keys.CELL_PROBABILITY
-        ] * self.noise_level_scaling_function(dataset.data, column_name)
+        cell_probability: float = configuration[Keys.CELL_PROBABILITY]
+        noise_level = cell_probability * self.noise_level_scaling_function(
+            dataset.data, column_name
+        )
 
         # Certain columns have their noise level scaled so we must check to make
         # sure the noise level is within the allowed range between 0 and 1 for

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -455,7 +455,8 @@ def write_wrong_digits(
     """
     column = dataset.data.loc[to_noise_index, column_name]
     # This is a fix to not replacing the original token for noise options
-    token_noise_level = configuration[Keys.TOKEN_PROBABILITY] / 0.9
+    token_probability: float = configuration[Keys.TOKEN_PROBABILITY]
+    token_noise_level = token_probability / 0.9
 
     max_str_length = column.str.len().max()
 

--- a/src/pseudopeople/noise_level.py
+++ b/src/pseudopeople/noise_level.py
@@ -60,7 +60,7 @@ def get_apply_do_not_respond_noise_level(
         noise_levels += 0.276
 
     # Apply user-configured noise level
-    configured_noise_level = configuration[Keys.ROW_PROBABILITY]
+    configured_noise_level: float = configuration[Keys.ROW_PROBABILITY]
     default_noise_level = data_values.DEFAULT_DO_NOT_RESPOND_ROW_PROBABILITY[dataset_name]
     noise_levels = noise_levels * (configured_noise_level / default_noise_level)
 

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -1,5 +1,6 @@
 import math
 from functools import partial
+from typing import Callable, Iterable
 
 import numpy as np
 import pandas as pd
@@ -799,9 +800,11 @@ def _validate_column_noise_level(
             token_probability_key = {
                 NOISE_TYPES.write_wrong_zipcode_digits.name: Keys.ZIPCODE_DIGIT_PROBABILITIES,
             }.get(col_noise_type.name, Keys.TOKEN_PROBABILITY)
-            token_probability = tmp_config[col_noise_type.name][token_probability_key]
+            token_probability: Union[Iterable[float], float] = tmp_config[
+                col_noise_type.name
+            ][token_probability_key]
             # Get number of tokens per string to calculate expected proportion
-            tokens_per_string_getter = TOKENS_PER_STRING_MAPPER.get(
+            tokens_per_string_getter: Callable = TOKENS_PER_STRING_MAPPER.get(
                 col_noise_type.name, lambda x: x.astype(str).str.len()
             )
             tokens_per_string = tokens_per_string_getter(check_data.loc[check_idx, col.name])

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -800,7 +800,7 @@ def _validate_column_noise_level(
             token_probability_key = {
                 NOISE_TYPES.write_wrong_zipcode_digits.name: Keys.ZIPCODE_DIGIT_PROBABILITIES,
             }.get(col_noise_type.name, Keys.TOKEN_PROBABILITY)
-            token_probability: Union[Iterable[float], float] = tmp_config[
+            token_probability: Union[list[float], float] = tmp_config[
                 col_noise_type.name
             ][token_probability_key]
             # Get number of tokens per string to calculate expected proportion

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -800,9 +800,9 @@ def _validate_column_noise_level(
             token_probability_key = {
                 NOISE_TYPES.write_wrong_zipcode_digits.name: Keys.ZIPCODE_DIGIT_PROBABILITIES,
             }.get(col_noise_type.name, Keys.TOKEN_PROBABILITY)
-            token_probability: Union[list[float], float] = tmp_config[
-                col_noise_type.name
-            ][token_probability_key]
+            token_probability: Union[list[float], float] = tmp_config[col_noise_type.name][
+                token_probability_key
+            ]
             # Get number of tokens per string to calculate expected proportion
             tokens_per_string_getter: Callable = TOKENS_PER_STRING_MAPPER.get(
                 col_noise_type.name, lambda x: x.astype(str).str.len()

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -38,7 +38,7 @@ from tests.integration.conftest import (
     get_unnoised_data,
 )
 
-DATASET_GENERATION_FUNCS = {
+DATASET_GENERATION_FUNCS: dict[str, Callable] = {
     DATASET_SCHEMAS.census.name: generate_decennial_census,
     DATASET_SCHEMAS.acs.name: generate_american_community_survey,
     DATASET_SCHEMAS.cps.name: generate_current_population_survey,

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -1,6 +1,6 @@
 import math
 from functools import partial
-from typing import Callable, Iterable
+from typing import Callable, Iterable, Union
 
 import numpy as np
 import pandas as pd

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -459,7 +459,7 @@ def test_write_wrong_zipcode_digits(dataset, fuzzy_checker: FuzzyChecker):
     assert (noised_data[orig_missing] == "").all()
     # Check noise for each digits position matches expected noise
     for i in range(5):
-        digit_prob = config["digit_probabilities"][i]
+        digit_prob: float = config["digit_probabilities"][i]
         actual_noise = (data[~orig_missing].str[i] != noised_data[~orig_missing].str[i]).sum()
         expected_noise = digit_prob * cell_probability
         fuzzy_checker.fuzzy_assert_proportion(
@@ -541,7 +541,8 @@ def test_miswrite_ages_uniform_probabilities(fuzzy_checker: FuzzyChecker):
     dataset = Dataset(DATASET_SCHEMAS.get_dataset_schema(DATASET_SCHEMAS.census.name), df, 0)
     NOISE_TYPES.misreport_age(dataset, config, "age")
     noised_data = dataset.data["age"]
-    expected_noise = (1 / len(perturbations)) * config[Keys.CELL_PROBABILITY]
+    cell_probability: float = config[Keys.CELL_PROBABILITY]
+    expected_noise = (1 / len(perturbations)) * cell_probability
     for perturbation in perturbations:
         actual_noise = (noised_data.astype(int) - original_age == perturbation).sum()
         fuzzy_checker.fuzzy_assert_proportion(
@@ -579,8 +580,9 @@ def test_miswrite_ages_provided_probabilities(dataset, fuzzy_checker: FuzzyCheck
     dataset = Dataset(DATASET_SCHEMAS.get_dataset_schema(DATASET_SCHEMAS.census.name), df, 0)
     NOISE_TYPES.misreport_age(dataset, config, "age")
     noised_data = dataset.data["age"]
+    cell_probability: float = config[Keys.CELL_PROBABILITY]
     for perturbation in perturbations:
-        expected_noise = perturbations[perturbation] * config[Keys.CELL_PROBABILITY]
+        expected_noise = perturbations[perturbation] * cell_probability
         actual_noise = (noised_data.astype(int) - original_age == perturbation).sum()
         fuzzy_checker.fuzzy_assert_proportion(
             name="misreport_age_provided_probabilities",
@@ -816,7 +818,7 @@ def test_write_wrong_digits(dataset, fuzzy_checker: FuzzyChecker):
         NOISE_TYPES.write_wrong_digits.name
     ]
     expected_cell_noise = config[Keys.CELL_PROBABILITY]
-    expected_token_noise = config[Keys.TOKEN_PROBABILITY]
+    expected_token_noise: float = config[Keys.TOKEN_PROBABILITY]
     data = dataset.data["street_number"].copy()
     # Note: I changed this column from string_series to street number. It has several string formats
     # containing both numeric and alphabetically string characters.
@@ -1101,7 +1103,7 @@ def test_generate_ocr_errors(dataset, column, fuzzy_checker: FuzzyChecker):
     assert (data[missing_mask] == noised_data[missing_mask]).all()
 
     # Check expected noise level
-    token_probability = config[Keys.TOKEN_PROBABILITY]
+    token_probability: float = config[Keys.TOKEN_PROBABILITY]
     cell_probability = config[Keys.CELL_PROBABILITY]
     # We need to calculate the expected noise. We need to get the average number of tokens per string
     # that can be noised since not all tokens can be noised for OCR errors.

--- a/tests/unit/test_column_noise.py
+++ b/tests/unit/test_column_noise.py
@@ -989,8 +989,8 @@ def test_generate_phonetic_errors(dataset, column, fuzzy_checker: FuzzyChecker):
     assert (noised_data[missing_mask] == "").all()
 
     # Check expected noise level
-    cell_probability = config[Keys.CELL_PROBABILITY]
-    token_probability = config[Keys.TOKEN_PROBABILITY]
+    cell_probability: float = config[Keys.CELL_PROBABILITY]
+    token_probability: float = config[Keys.TOKEN_PROBABILITY]
     check_original = data[~missing_mask]
     check_noised = noised_data[~missing_mask]
     actual_noise = (check_original != check_noised).sum()
@@ -1212,8 +1212,8 @@ def test_make_typos(dataset, column, fuzzy_checker: FuzzyChecker):
     check_noised = noised_data.loc[not_missing_idx]
 
     # Check for expected noise level
-    cell_probability = config[Keys.CELL_PROBABILITY]
-    token_probability = config[Keys.TOKEN_PROBABILITY]
+    cell_probability: float = config[Keys.CELL_PROBABILITY]
+    token_probability: float = config[Keys.TOKEN_PROBABILITY]
     qwerty_tokens = pd.Series(load_qwerty_errors_data().index)
     data_series = (
         pd.Series(INTEGERS_LIST) if column == "numbers" else pd.Series(CHARACTERS_LIST)
@@ -1354,8 +1354,8 @@ def test_age_write_wrong_digits(dataset, fuzzy_checker: FuzzyChecker):
     check_original = data[~missing_mask]
     check_noised = noised_data[~missing_mask]
     expected_noise = (check_original != check_noised).sum()
-    cell_probability = config[Keys.CELL_PROBABILITY]
-    token_probability = config[Keys.TOKEN_PROBABILITY]
+    cell_probability: float = config[Keys.CELL_PROBABILITY]
+    token_probability: float = config[Keys.TOKEN_PROBABILITY]
     tokens_per_string = check_original.astype(str).str.len()
     avg_probability_any_token_noised = (
         1 - (1 - token_probability) ** tokens_per_string

--- a/tests/unit/test_row_noise.py
+++ b/tests/unit/test_row_noise.py
@@ -34,14 +34,14 @@ def dummy_data():
 
 
 def test_omit_row(dummy_data, fuzzy_checker: FuzzyChecker):
-    config: LayeredConfigTree = get_configuration()[DATASET_SCHEMAS.tax_w2_1099.name][Keys.ROW_NOISE][
-        NOISE_TYPES.omit_row.name
-    ]
+    config: LayeredConfigTree = get_configuration()[DATASET_SCHEMAS.tax_w2_1099.name][
+        Keys.ROW_NOISE
+    ][NOISE_TYPES.omit_row.name]
     dataset = Dataset(DATASET_SCHEMAS.tax_w2_1099, dummy_data, 0)
     NOISE_TYPES.omit_row(dataset, config)
     noised_data1 = dataset.data
 
-    expected_noise_1 = config[Keys.ROW_PROBABILITY]
+    expected_noise_1: float = config[Keys.ROW_PROBABILITY]
     fuzzy_checker.fuzzy_assert_proportion(
         name="test_omit_row",
         observed_numerator=len(noised_data1),
@@ -53,9 +53,9 @@ def test_omit_row(dummy_data, fuzzy_checker: FuzzyChecker):
 
 
 def test_do_not_respond(mocker, dummy_data, fuzzy_checker: FuzzyChecker):
-    config: LayeredConfigTree = get_configuration()[DATASET_SCHEMAS.census.name][Keys.ROW_NOISE][
-        NOISE_TYPES.do_not_respond.name
-    ]
+    config: LayeredConfigTree = get_configuration()[DATASET_SCHEMAS.census.name][
+        Keys.ROW_NOISE
+    ][NOISE_TYPES.do_not_respond.name]
     mocker.patch(
         "pseudopeople.noise_level._get_census_omission_noise_levels",
         side_effect=(lambda *_: config[Keys.ROW_PROBABILITY]),
@@ -85,7 +85,8 @@ def test_do_not_respond(mocker, dummy_data, fuzzy_checker: FuzzyChecker):
     assert (noised_census.dtypes == my_dummy_data.dtypes).all()
 
     # Check ACS data is scaled properly due to oversampling
-    expected_noise = 0.5 + config[Keys.ROW_PROBABILITY] / 2
+    row_probability: float = config[Keys.ROW_PROBABILITY]
+    expected_noise = 0.5 + row_probability / 2
     fuzzy_checker.fuzzy_assert_proportion(
         name="test_do_not_respond",
         observed_numerator=len(my_dummy_data) - len(noised_acs),
@@ -120,9 +121,9 @@ def test__get_census_omission_noise_levels(age, race_ethnicity, sex, expected_le
 
 def test_do_not_respond_missing_columns(dummy_data):
     """Test do_not_respond raises error when missing required columns."""
-    config: LayeredConfigTree = get_configuration()[DATASET_SCHEMAS.census.name][Keys.ROW_NOISE][
-        NOISE_TYPES.do_not_respond.name
-    ]
+    config: LayeredConfigTree = get_configuration()[DATASET_SCHEMAS.census.name][
+        Keys.ROW_NOISE
+    ][NOISE_TYPES.do_not_respond.name]
     census = Dataset(DATASET_SCHEMAS.census, dummy_data, 0)
     with pytest.raises(KeyError, match="race_ethnicity"):
         NOISE_TYPES.do_not_respond(census, config)


### PR DESCRIPTION
## mypy operator error

### Description
- *Category*: mypy
- *JIRA issue*: [MIC-5183](https://jira.ihme.washington.edu/browse/MIC-5183)

Fix mypy operator errors.

### Testing
Ran mypy with operator error enabled and confirmed all remaining issues came from problems with checking containment in LayeredConfigTree objects.