### PR TITLE
Albrja/mic-5575/drop support for python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.2.0 - 11/14/24**
+
+ - Drop support for Python 3.9
+
 **1.1.1 - 06/17/24**
 
  - Hotfix pin numpy below 2.0

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ pseudopeople is a Python package that generates realistic simulated data about a
 fictional United States population, designed for use in testing entity resolution
 (record linkage) methods or other data science algorithms at scale.
 
-**pseudopeople requires Python 3.8-3.11 to run**
+**pseudopeople requires Python 3.10-3.11 to run**
 
 You can install pseudopeople from PyPI with pip:
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from packaging.version import parse
 from setuptools import find_packages, setup
 
-min_version, max_version = ("3.9", "3.11")
+min_version, max_version = ("3.10", "3.11")
 
 min_version = parse(min_version)
 max_version = parse(max_version)


### PR DESCRIPTION
## Albrja/mic-5575/drop support for python 3.9

### Drop support for python 3.9
- *Category*: Feature
- *JIRA issue*: [MIC-5575](https://jira.ihme.washington.edu/browse/MIC-5575)

-drop support for python 3.9
