### PR TITLE
split and strengthen drop row tests

### DIFF
--- a/src/pseudopeople/noise_level.py
+++ b/src/pseudopeople/noise_level.py
@@ -43,10 +43,10 @@ def _get_census_omission_noise_levels(
             index=ages,
         )
         sex_mask = population["sex"] == sex
-        breakpoint()
         probabilities[sex_mask] += (
-            population[sex_mask]["age"].map(effect_by_age).astype(float)
+            population[sex_mask]["age"].astype(int).map(effect_by_age).astype(float)
         )
+
     probabilities[probabilities < 0.0] = 0.0
     probabilities[probabilities > 1.0] = 1.0
 
@@ -61,7 +61,7 @@ def get_apply_do_not_respond_noise_level(
 
     # Apply an overall non-response rate of 27.6% for Current Population Survey (CPS)
     if dataset_name == DatasetNames.CPS:
-        noise_levels += 0.276
+        noise_levels += 0.276 - .002105
 
     # Apply user-configured noise level
     configured_noise_level: float = configuration.get_row_probability(

--- a/src/pseudopeople/noise_level.py
+++ b/src/pseudopeople/noise_level.py
@@ -31,7 +31,7 @@ def _get_census_omission_noise_levels(
         .astype(str)
         .map(data_values.DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_RACE)
     )
-    ages = pd.Series(np.arange(population["age"].max() + 1))
+    ages = pd.Series(np.arange(population["age"].astype(int).max() + 1))
     for sex in ["Female", "Male"]:
         effect_by_age_bin = data_values.DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_SEX_AGE[sex]
         # NOTE: calling pd.cut on a large array with an IntervalIndex is slow,
@@ -43,11 +43,13 @@ def _get_census_omission_noise_levels(
             index=ages,
         )
         sex_mask = population["sex"] == sex
+        breakpoint()
         probabilities[sex_mask] += (
             population[sex_mask]["age"].map(effect_by_age).astype(float)
         )
     probabilities[probabilities < 0.0] = 0.0
     probabilities[probabilities > 1.0] = 1.0
+
     return probabilities
 
 

--- a/src/pseudopeople/noise_level.py
+++ b/src/pseudopeople/noise_level.py
@@ -31,7 +31,7 @@ def _get_census_omission_noise_levels(
         .astype(str)
         .map(data_values.DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_RACE)
     )
-    ages = pd.Series(np.arange(population["age"].astype(int).max() + 1))
+    ages = pd.Series(np.arange(population["age"].max() + 1))
     for sex in ["Female", "Male"]:
         effect_by_age_bin = data_values.DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_SEX_AGE[sex]
         # NOTE: calling pd.cut on a large array with an IntervalIndex is slow,
@@ -44,12 +44,10 @@ def _get_census_omission_noise_levels(
         )
         sex_mask = population["sex"] == sex
         probabilities[sex_mask] += (
-            population[sex_mask]["age"].astype(int).map(effect_by_age).astype(float)
+            population[sex_mask]["age"].map(effect_by_age).astype(float)
         )
-
     probabilities[probabilities < 0.0] = 0.0
     probabilities[probabilities > 1.0] = 1.0
-
     return probabilities
 
 
@@ -61,7 +59,7 @@ def get_apply_do_not_respond_noise_level(
 
     # Apply an overall non-response rate of 27.6% for Current Population Survey (CPS)
     if dataset_name == DatasetNames.CPS:
-        noise_levels += 0.276 - .002105
+        noise_levels += 0.276 
 
     # Apply user-configured noise level
     configured_noise_level: float = configuration.get_row_probability(

--- a/src/pseudopeople/noise_level.py
+++ b/src/pseudopeople/noise_level.py
@@ -59,7 +59,7 @@ def get_apply_do_not_respond_noise_level(
 
     # Apply an overall non-response rate of 27.6% for Current Population Survey (CPS)
     if dataset_name == DatasetNames.CPS:
-        noise_levels += 0.276 
+        noise_levels += 0.276
 
     # Apply user-configured noise level
     configured_noise_level: float = configuration.get_row_probability(

--- a/tests/integration/release/test_release.py
+++ b/tests/integration/release/test_release.py
@@ -16,7 +16,7 @@ from pseudopeople.dataset import Dataset
 from pseudopeople.noise_entities import NOISE_TYPES
 from pseudopeople.schema_entities import COLUMNS, DATASET_SCHEMAS
 from tests.integration.conftest import IDX_COLS, _get_common_datasets, get_unnoised_data
-from tests.utilities import initialize_dataset_with_sample, run_column_noising_tests
+from tests.utilities import initialize_dataset_with_sample, run_column_noising_tests, get_single_noise_type_config
 
 
 def test_column_noising(
@@ -61,34 +61,6 @@ def test_row_noising_omit_row_or_do_not_respond(
     else:
         with check:
             assert len(noise_types) < 2
-
-
-def get_single_noise_type_config(
-    dataset_name: str, noise_type_to_keep: str
-) -> dict[str, Any]:
-    """Return a NoiseConfiguration object with no noising except for noise_type_to_keep,
-    which will contain the default values from get_configuration."""
-    config: NoiseConfiguration = get_configuration()
-    config_dict = config.to_dict()
-
-    for noise_type, probabilities in config_dict[dataset_name][Keys.ROW_NOISE].items():
-        if noise_type != noise_type_to_keep:
-            for probability_name, probability in probabilities.items():
-                config_dict[dataset_name][Keys.ROW_NOISE][noise_type][probability_name] = 0.0
-
-    for col, noise_types in config_dict[dataset_name][Keys.COLUMN_NOISE].items():
-        for noise_type, probabilities in noise_types.items():
-            if noise_type != noise_type_to_keep:
-                for probability_name, probability in probabilities.items():
-                    if isinstance(probability, list):
-                        new_probability = [0.0 for x in probability]
-                    elif isinstance(probability, dict):
-                        new_probability = {key: 0.0 for key in probability.keys()}
-                    else:
-                        new_probability = 0.0
-                    config_dict[dataset_name][Keys.COLUMN_NOISE][col][noise_type][probability_name] = new_probability
-
-    return config_dict
 
 
 @pytest.mark.parametrize("expected_noise", ["default", 0.01])

--- a/tests/integration/release/test_release.py
+++ b/tests/integration/release/test_release.py
@@ -159,17 +159,15 @@ def test_do_not_respond(
         expected_noise: float = config.get_row_probability(
             dataset_name, NOISE_TYPES.do_not_respond.name
         )
+
     dataset_schema = DATASET_SCHEMAS.get_dataset_schema(dataset_name)
     dataset = Dataset(dataset_schema, original_data, 0)
     NOISE_TYPES.do_not_respond(dataset, config)
     noised_data = dataset.data
-    breakpoint()
-    # Check ACS and census data is scaled properly due to oversampling
+
+    # Check ACS and CPS data is scaled properly due to oversampling
     if dataset_name is not DATASET_SCHEMAS.census.name:  # is acs or cps
-        row_probability: float = config.get_row_probability(
-            DATASET_SCHEMAS.census.name, NOISE_TYPES.do_not_respond.name
-        )
-        expected_noise = 0.5 + row_probability / 2
+        expected_noise = 0.5 + expected_noise / 2
 
     # Test that noising affects expected proportion with expected types
     fuzzy_checker.fuzzy_assert_proportion(

--- a/tests/integration/release/test_release.py
+++ b/tests/integration/release/test_release.py
@@ -16,7 +16,11 @@ from pseudopeople.dataset import Dataset
 from pseudopeople.noise_entities import NOISE_TYPES
 from pseudopeople.schema_entities import COLUMNS, DATASET_SCHEMAS
 from tests.integration.conftest import IDX_COLS, _get_common_datasets, get_unnoised_data
-from tests.utilities import initialize_dataset_with_sample, run_column_noising_tests, get_single_noise_type_config
+from tests.utilities import (
+    get_single_noise_type_config,
+    initialize_dataset_with_sample,
+    run_column_noising_tests,
+)
 
 
 def test_column_noising(
@@ -75,7 +79,9 @@ def test_omit_row(
     config_dict = get_single_noise_type_config(dataset_name, NOISE_TYPES.omit_row.name)
 
     if expected_noise != "default":
-        config_dict[dataset_name][Keys.ROW_NOISE][NOISE_TYPES.omit_row.name][Keys.ROW_PROBABILITY] = expected_noise
+        config_dict[dataset_name][Keys.ROW_NOISE][NOISE_TYPES.omit_row.name][
+            Keys.ROW_PROBABILITY
+        ] = expected_noise
         config = NoiseConfiguration(LayeredConfigTree(config_dict))
     else:
         config = NoiseConfiguration(LayeredConfigTree(config_dict))
@@ -117,7 +123,9 @@ def test_do_not_respond(
     config_dict = get_single_noise_type_config(dataset_name, NOISE_TYPES.do_not_respond.name)
 
     if expected_noise != "default":
-        config_dict[dataset_name][Keys.ROW_NOISE][NOISE_TYPES.do_not_respond.name][Keys.ROW_PROBABILITY] = expected_noise
+        config_dict[dataset_name][Keys.ROW_NOISE][NOISE_TYPES.do_not_respond.name][
+            Keys.ROW_PROBABILITY
+        ] = expected_noise
         config = NoiseConfiguration(LayeredConfigTree(config_dict))
     else:
         config = NoiseConfiguration(LayeredConfigTree(config_dict))

--- a/tests/integration/release/test_release.py
+++ b/tests/integration/release/test_release.py
@@ -37,7 +37,6 @@ def test_column_noising(
 
 
 def test_row_noising_omit_row_or_do_not_respond(
-    noised_data: pd.DataFrame,
     dataset_name: str,
     config: dict[str, Any],
 ) -> None:
@@ -100,10 +99,7 @@ def test_omit_row(
     fuzzy_checker: FuzzyChecker,
 ) -> None:
     """Tests that omit_row noising is being applied at the expected proportion."""
-    idx_cols = IDX_COLS.get(dataset_name)
-    original = get_unnoised_data(dataset_name)
-    original_data = original.data.set_index(idx_cols)
-
+    original_data = unnoised_dataset.data
     config_dict = get_single_noise_type_config(dataset_name, NOISE_TYPES.omit_row.name)
 
     if expected_noise != "default":
@@ -145,10 +141,7 @@ def test_do_not_respond(
     ]:
         return
 
-    idx_cols = IDX_COLS.get(dataset_name)
-    original = get_unnoised_data(dataset_name)
-    original_data = original.data.set_index(idx_cols)
-
+    original_data = unnoised_dataset.data
     config_dict = get_single_noise_type_config(dataset_name, NOISE_TYPES.do_not_respond.name)
 
     if expected_noise != "default":

--- a/tests/integration/test_interface.py
+++ b/tests/integration/test_interface.py
@@ -22,11 +22,7 @@ from tests.integration.conftest import (
     _get_common_datasets,
     get_unnoised_data,
 )
-from tests.utilities import (
-    initialize_dataset_with_sample,
-    run_column_noising_tests,
-    run_omit_row_or_do_not_respond_tests,
-)
+from tests.utilities import initialize_dataset_with_sample, run_column_noising_tests
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_row_noise.py
+++ b/tests/unit/test_row_noise.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 import pytest
-from layered_config_tree import LayeredConfigTree
 from pytest_mock import MockerFixture
 
 from pseudopeople.configuration import Keys, get_configuration

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -71,42 +71,6 @@ def run_column_noising_tests(
                 assert same_check.all()
 
 
-def run_omit_row_or_do_not_respond_tests(
-    dataset_name: str,
-    config: dict[str, Any],
-    original_data: pd.DataFrame,
-    noised_data: pd.DataFrame,
-) -> None:
-    noise_config: NoiseConfiguration = get_configuration(config)
-    noise_types = [
-        noise_type
-        for noise_type in [NOISE_TYPES.omit_row.name, NOISE_TYPES.do_not_respond.name]
-        if noise_config.has_noise_type(dataset_name, noise_type)
-    ]
-
-    if dataset_name in [
-        DATASET_SCHEMAS.census.name,
-        DATASET_SCHEMAS.acs.name,
-        DATASET_SCHEMAS.cps.name,
-    ]:
-        # Census and household surveys have do_not_respond and omit_row.
-        # For all other datasets they are mutually exclusive
-        with check:
-            assert len(noise_types) == 2
-    else:
-        with check:
-            assert len(noise_types) < 2
-    if not noise_types:  # Check that there are no missing indexes
-        with check:
-            assert noised_data.index.symmetric_difference(original_data.index).empty
-    else:  # Check that there are some omissions
-        # TODO: assert levels are as expected
-        with check:
-            assert noised_data.index.difference(original_data.index).empty
-        with check:
-            assert not original_data.index.difference(noised_data.index).empty
-
-
 def validate_column_noise_level(
     dataset_name: str,
     check_data: pd.DataFrame,

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -165,7 +165,7 @@ def initialize_dataset_with_sample(dataset_name: str) -> Dataset:
 def get_single_noise_type_config(
     dataset_name: str, noise_type_to_keep: str
 ) -> dict[str, Any]:
-    """Return a NoiseConfiguration object with no noising except for noise_type_to_keep,
+    """Return a dictionary with no noising except for noise_type_to_keep,
     which will contain the default values from get_configuration."""
     config: NoiseConfiguration = get_configuration()
     config_dict = config.to_dict()

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -160,3 +160,31 @@ def initialize_dataset_with_sample(dataset_name: str) -> Dataset:
     dataset = Dataset(dataset_schema, pd.read_parquet(data_path), SEED)
 
     return dataset
+
+
+def get_single_noise_type_config(
+    dataset_name: str, noise_type_to_keep: str
+) -> dict[str, Any]:
+    """Return a NoiseConfiguration object with no noising except for noise_type_to_keep,
+    which will contain the default values from get_configuration."""
+    config: NoiseConfiguration = get_configuration()
+    config_dict = config.to_dict()
+
+    for noise_type, probabilities in config_dict[dataset_name][Keys.ROW_NOISE].items():
+        if noise_type != noise_type_to_keep:
+            for probability_name, probability in probabilities.items():
+                config_dict[dataset_name][Keys.ROW_NOISE][noise_type][probability_name] = 0.0
+
+    for col, noise_types in config_dict[dataset_name][Keys.COLUMN_NOISE].items():
+        for noise_type, probabilities in noise_types.items():
+            if noise_type != noise_type_to_keep:
+                for probability_name, probability in probabilities.items():
+                    if isinstance(probability, list):
+                        new_probability = [0.0 for x in probability]
+                    elif isinstance(probability, dict):
+                        new_probability = {key: 0.0 for key in probability.keys()}
+                    else:
+                        new_probability = 0.0
+                    config_dict[dataset_name][Keys.COLUMN_NOISE][col][noise_type][probability_name] = new_probability
+
+    return config_dict

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -185,6 +185,8 @@ def get_single_noise_type_config(
                         new_probability = {key: 0.0 for key in probability.keys()}
                     else:
                         new_probability = 0.0
-                    config_dict[dataset_name][Keys.COLUMN_NOISE][col][noise_type][probability_name] = new_probability
+                    config_dict[dataset_name][Keys.COLUMN_NOISE][col][noise_type][
+                        probability_name
+                    ] = new_probability
 
     return config_dict


### PR DESCRIPTION
## split and strengthen drop row tests

### Description
- *Category*: test
- *JIRA issue*: [MIC-5516](https://jira.ihme.washington.edu/browse/MIC-5516)

Split out omit row and do not respond. 
Keep tests that proper noising types are defined on default configuration.

### Testing
Ran tests. Census failed due to known bug but fuzzy checker caught the expected error. ACS and CPS passed when applying simple but temporary bugfix. 
