### PR TITLE
change dask default client

### DIFF
--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -16,3 +16,4 @@ py:exc DataSourceError
 # misc
 # TODO: remove when dropping support for Python 3.9
 py:class Path
+py:class dd.DataFrame

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,13 +17,6 @@ import sys
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 from pathlib import Path
 
-from docutils import nodes
-from docutils.nodes import Text
-from sphinx.addnodes import literal_emphasis, pending_xref
-from sphinx.application import Sphinx
-from sphinx.environment import BuildEnvironment
-from sphinx.ext.intersphinx import missing_reference
-
 import pseudopeople
 
 base_dir = Path(pseudopeople.__file__).parent

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ if __name__ == "__main__":
         "types-tqdm",
         "types-setuptools",
         "pyarrow-stubs",
+        "types-psutil",
     ]
 
     setup_requires = ["setuptools_scm"]

--- a/src/pseudopeople/dataset.py
+++ b/src/pseudopeople/dataset.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
-from pseudopeople.configuration import Keys
 from pseudopeople.configuration.noise_configuration import NoiseConfiguration
 from pseudopeople.constants.metadata import DATEFORMATS
 from pseudopeople.constants.noise_type_metadata import COPY_HOUSEHOLD_MEMBER_COLS

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 import pandas as pd
 from loguru import logger
@@ -25,6 +25,35 @@ from pseudopeople.utilities import (
     get_state_abbreviation,
 )
 
+if TYPE_CHECKING:
+    import dask.dataframe as dd
+
+
+@overload
+def _generate_dataset(
+    dataset_schema: DatasetSchema,
+    source: Path | str | None,
+    seed: int,
+    config: Path | str | dict[str, Any] | None,
+    filters: Sequence[DataFilter],
+    verbose: bool,
+    engine_name: Literal["pandas"],
+) -> pd.DataFrame:
+    ...
+
+
+@overload
+def _generate_dataset(
+    dataset_schema: DatasetSchema,
+    source: Path | str | None,
+    seed: int,
+    config: Path | str | dict[str, Any] | None,
+    filters: Sequence[DataFilter],
+    verbose: bool,
+    engine_name: Literal["dask"],
+) -> dd.DataFrame:
+    ...
+
 
 def _generate_dataset(
     dataset_schema: DatasetSchema,
@@ -34,7 +63,7 @@ def _generate_dataset(
     filters: Sequence[DataFilter],
     verbose: bool = False,
     engine_name: Literal["pandas", "dask"] = "pandas",
-) -> pd.DataFrame:
+) -> pd.DataFrame | dd.DataFrame:
     """
     Helper for generating noised datasets.
 
@@ -67,7 +96,7 @@ def _generate_dataset(
 
     engine = get_engine_from_string(engine_name)
 
-    noised_dataset: pd.DataFrame
+    noised_dataset: pd.DataFrame | dd.DataFrame
     if engine == PANDAS_ENGINE:
         # We process shards serially
         data_file_paths = get_dataset_filepaths(source, dataset_schema.name)
@@ -205,6 +234,32 @@ def _get_data_changelog_version(changelog: Path) -> Version:
     return version
 
 
+@overload
+def generate_decennial_census(
+    source: Path | str | None = None,
+    seed: int = 0,
+    config: Path | str | dict[str, Any] | None = None,
+    year: int | None = 2020,
+    state: str | None = None,
+    verbose: bool = False,
+    engine: Literal["pandas"] = "pandas",
+) -> pd.DataFrame:
+    ...
+
+
+@overload
+def generate_decennial_census(
+    source: Path | str | None,
+    seed: int,
+    config: Path | str | dict[str, Any] | None,
+    year: int | None,
+    state: str | None,
+    verbose: bool,
+    engine: Literal["dask"],
+) -> dd.DataFrame:
+    ...
+
+
 def generate_decennial_census(
     source: Path | str | None = None,
     seed: int = 0,
@@ -213,7 +268,7 @@ def generate_decennial_census(
     state: str | None = None,
     verbose: bool = False,
     engine: Literal["pandas", "dask"] = "pandas",
-) -> pd.DataFrame:
+) -> pd.DataFrame | dd.DataFrame:
     """
     Generates a pseudopeople decennial census dataset which represents
     simulated responses to the US Census Bureau's Census of Population
@@ -303,6 +358,32 @@ def generate_decennial_census(
     )
 
 
+@overload
+def generate_american_community_survey(
+    source: Path | str | None = None,
+    seed: int = 0,
+    config: Path | str | dict[str, Any] | None = None,
+    year: int | None = 2020,
+    state: str | None = None,
+    verbose: bool = False,
+    engine: Literal["pandas"] = "pandas",
+) -> pd.DataFrame:
+    ...
+
+
+@overload
+def generate_american_community_survey(
+    source: Path | str | None,
+    seed: int,
+    config: Path | str | dict[str, Any] | None,
+    year: int | None,
+    state: str | None,
+    verbose: bool,
+    engine: Literal["dask"],
+) -> dd.DataFrame:
+    ...
+
+
 def generate_american_community_survey(
     source: Path | str | None = None,
     seed: int = 0,
@@ -311,7 +392,7 @@ def generate_american_community_survey(
     state: str | None = None,
     verbose: bool = False,
     engine: Literal["pandas", "dask"] = "pandas",
-) -> pd.DataFrame:
+) -> pd.DataFrame | dd.DataFrame:
     """
     Generates a pseudopeople ACS dataset which represents simulated
     responses to the ACS survey.
@@ -416,6 +497,32 @@ def generate_american_community_survey(
     )
 
 
+@overload
+def generate_current_population_survey(
+    source: Path | str | None = None,
+    seed: int = 0,
+    config: Path | str | dict[str, Any] | None = None,
+    year: int | None = 2020,
+    state: str | None = None,
+    verbose: bool = False,
+    engine: Literal["pandas"] = "pandas",
+) -> pd.DataFrame:
+    ...
+
+
+@overload
+def generate_current_population_survey(
+    source: Path | str | None,
+    seed: int,
+    config: Path | str | dict[str, Any] | None,
+    year: int | None,
+    state: str | None,
+    verbose: bool,
+    engine: Literal["dask"],
+) -> dd.DataFrame:
+    ...
+
+
 def generate_current_population_survey(
     source: Path | str | None = None,
     seed: int = 0,
@@ -424,7 +531,7 @@ def generate_current_population_survey(
     state: str | None = None,
     verbose: bool = False,
     engine: Literal["pandas", "dask"] = "pandas",
-) -> pd.DataFrame:
+) -> pd.DataFrame | dd.DataFrame:
     """
     Generates a pseudopeople CPS dataset which represents simulated
     responses to the CPS survey.
@@ -530,6 +637,32 @@ def generate_current_population_survey(
     )
 
 
+@overload
+def generate_taxes_w2_and_1099(
+    source: Path | str | None = None,
+    seed: int = 0,
+    config: Path | str | dict[str, Any] | None = None,
+    year: int | None = 2020,
+    state: str | None = None,
+    verbose: bool = False,
+    engine: Literal["pandas"] = "pandas",
+) -> pd.DataFrame:
+    ...
+
+
+@overload
+def generate_taxes_w2_and_1099(
+    source: Path | str | None,
+    seed: int,
+    config: Path | str | dict[str, Any] | None,
+    year: int | None,
+    state: str | None,
+    verbose: bool,
+    engine: Literal["dask"],
+) -> dd.DataFrame:
+    ...
+
+
 def generate_taxes_w2_and_1099(
     source: Path | str | None = None,
     seed: int = 0,
@@ -538,7 +671,7 @@ def generate_taxes_w2_and_1099(
     state: str | None = None,
     verbose: bool = False,
     engine: Literal["pandas", "dask"] = "pandas",
-) -> pd.DataFrame:
+) -> pd.DataFrame | dd.DataFrame:
     """
     Generates a pseudopeople W2 and 1099 tax dataset which represents
     simulated tax form data.
@@ -628,6 +761,32 @@ def generate_taxes_w2_and_1099(
     )
 
 
+@overload
+def generate_women_infants_and_children(
+    source: Path | str | None = None,
+    seed: int = 0,
+    config: Path | str | dict[str, Any] | None = None,
+    year: int | None = 2020,
+    state: str | None = None,
+    verbose: bool = False,
+    engine: Literal["pandas"] = "pandas",
+) -> pd.DataFrame:
+    ...
+
+
+@overload
+def generate_women_infants_and_children(
+    source: Path | str | None,
+    seed: int,
+    config: Path | str | dict[str, Any] | None,
+    year: int | None,
+    state: str | None,
+    verbose: bool,
+    engine: Literal["dask"],
+) -> dd.DataFrame:
+    ...
+
+
 def generate_women_infants_and_children(
     source: Path | str | None = None,
     seed: int = 0,
@@ -636,7 +795,7 @@ def generate_women_infants_and_children(
     state: str | None = None,
     verbose: bool = False,
     engine: Literal["pandas", "dask"] = "pandas",
-) -> pd.DataFrame:
+) -> pd.DataFrame | dd.DataFrame:
     """
     Generates a pseudopeople WIC dataset which represents a simulated
     version of the administrative data that would be recorded by WIC.
@@ -731,6 +890,30 @@ def generate_women_infants_and_children(
     )
 
 
+@overload
+def generate_social_security(
+    source: Path | str | None = None,
+    seed: int = 0,
+    config: Path | str | dict[str, Any] | None = None,
+    year: int | None = 2020,
+    verbose: bool = False,
+    engine: Literal["pandas"] = "pandas",
+) -> pd.DataFrame:
+    ...
+
+
+@overload
+def generate_social_security(
+    source: Path | str | None,
+    seed: int,
+    config: Path | str | dict[str, Any] | None,
+    year: int | None,
+    verbose: bool,
+    engine: Literal["dask"],
+) -> dd.DataFrame:
+    ...
+
+
 def generate_social_security(
     source: Path | str | None = None,
     seed: int = 0,
@@ -738,7 +921,7 @@ def generate_social_security(
     year: int | None = 2020,
     verbose: bool = False,
     engine: Literal["pandas", "dask"] = "pandas",
-) -> pd.DataFrame:
+) -> pd.DataFrame | dd.DataFrame:
     """
     Generates a pseudopeople SSA dataset which represents simulated
     Social Security Administration (SSA) data.
@@ -819,6 +1002,32 @@ def generate_social_security(
     )
 
 
+@overload
+def generate_taxes_1040(
+    source: Path | str | None = None,
+    seed: int = 0,
+    config: Path | str | dict[str, Any] | None = None,
+    year: int | None = 2020,
+    state: str | None = None,
+    verbose: bool = False,
+    engine: Literal["pandas"] = "pandas",
+) -> pd.DataFrame:
+    ...
+
+
+@overload
+def generate_taxes_1040(
+    source: Path | str | None,
+    seed: int,
+    config: Path | str | dict[str, Any] | None,
+    year: int | None,
+    state: str | None,
+    verbose: bool,
+    engine: Literal["dask"],
+) -> dd.DataFrame:
+    ...
+
+
 def generate_taxes_1040(
     source: Path | str | None = None,
     seed: int = 0,
@@ -827,7 +1036,7 @@ def generate_taxes_1040(
     state: str | None = None,
     verbose: bool = False,
     engine: Literal["pandas", "dask"] = "pandas",
-) -> pd.DataFrame:
+) -> pd.DataFrame | dd.DataFrame:
     """
     Generates a pseudopeople 1040 tax dataset which represents simulated
     tax form data.

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -1159,6 +1159,7 @@ def set_up_dask_client() -> None:
 
         # extract the memory limit from the environment variable
         cluster = LocalCluster(  # type: ignore [no-untyped-call]
+            name="pseudopeople_dask_cluster",
             n_workers=CPU_COUNT,
             threads_per_worker=1,
         )

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -942,15 +942,15 @@ def set_up_dask_client() -> None:
     # Determine whether or not a Dask client is already running. If not,
     # create a new one.
     try:
-        client = get_client()
+        get_client()
     except ValueError:
         # No Dask client is running so we create one.
         from dask.distributed import LocalCluster
         from dask.system import CPU_COUNT
 
         # extract the memory limit from the environment variable
-        cluster = LocalCluster(
+        cluster = LocalCluster(  # type: ignore [no-untyped-call]
             n_workers=CPU_COUNT,
             threads_per_worker=1,
         )
-        client = cluster.get_client()
+        cluster.get_client()  # type: ignore [no-untyped-call]

--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -111,7 +111,7 @@ def test_set_up_dask_client_default() -> None:
 
     set_up_dask_client()
     client = get_client()
-    workers = client.scheduler_info()["workers"]
+    workers = client.scheduler_info()["workers"]  # type: ignore[no-untyped-call]
     assert len(workers) == CPU_COUNT
     assert all(worker["nthreads"] == 1 for worker in workers.values())
     if is_on_slurm():
@@ -134,13 +134,13 @@ def test_set_up_dask_client_default() -> None:
 def test_set_up_dask_client_custom() -> None:
     memory_limit = 1  # gb
     n_workers = 3
-    cluster = LocalCluster(
+    cluster = LocalCluster(  # type: ignore[no-untyped-call]
         name="custom",
         n_workers=n_workers,
         threads_per_worker=2,
         memory_limit=memory_limit * 1024**3,
     )
-    client = cluster.get_client()
+    client = cluster.get_client()  # type: ignore[no-untyped-call]
     set_up_dask_client()
     client = get_client()
     assert client.cluster.name == "custom"

--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -1,7 +1,12 @@
+import os
 from pathlib import Path
 
+import numpy as np
+import psutil
 import pytest
 from _pytest.tmpdir import TempPathFactory
+from dask.distributed import LocalCluster, get_client
+from dask.system import CPU_COUNT
 from packaging.version import parse
 from pytest_mock import MockerFixture
 
@@ -9,9 +14,11 @@ from pseudopeople.constants.metadata import DatasetNames
 from pseudopeople.exceptions import DataSourceError
 from pseudopeople.interface import (
     _get_data_changelog_version,
+    set_up_dask_client,
     validate_source_compatibility,
 )
 from pseudopeople.schema_entities import DATASET_SCHEMAS
+from tests.utilities import is_on_slurm
 
 CENSUS = DATASET_SCHEMAS.get_dataset_schema(DatasetNames.CENSUS)
 
@@ -94,3 +101,50 @@ def test_validate_source_compatibility_wrong_directory(tmp_path: Path) -> None:
     bad_path.mkdir()
     with pytest.raises(FileNotFoundError, match="Could not find 'decennial_census' in"):
         validate_source_compatibility(bad_path, CENSUS)
+
+
+def test_set_up_dask_client_default() -> None:
+
+    # There should be no dask client yet
+    with pytest.raises(ValueError):
+        client = get_client()
+
+    set_up_dask_client()
+    client = get_client()
+    workers = client.scheduler_info()["workers"]
+    assert len(workers) == CPU_COUNT
+    assert all(worker["nthreads"] == 1 for worker in workers.values())
+    if is_on_slurm():
+        try:
+            available_memory = float(os.environ["SLURM_MEM_PER_NODE"]) / 1024
+        except KeyError:
+            raise RuntimeError(
+                "You are on Slurm but SLURM_MEM_PER_NODE is not set. "
+                "It is likely that you are SSHed onto a node (perhaps using VSCode). "
+                "In this case, dask will assign the total memory of the node to each "
+                "worker instead of the allocated memory from the srun call. "
+                "Pseudopeople should only be used on Slurm directly on the node "
+                "assigned via an srun (both for pytests as well as actual work)."
+            )
+    else:
+        available_memory = psutil.virtual_memory().total / (1024 ** 3)
+    assert np.isclose(sum(worker["memory_limit"] / 1024**3 for worker in workers.values()), available_memory, rtol=0.01)
+
+
+def test_set_up_dask_client_custom() -> None:
+    memory_limit = 1  # gb
+    n_workers = 3
+    cluster = LocalCluster(
+        name="custom",
+        n_workers=n_workers,
+        threads_per_worker=2,
+        memory_limit=memory_limit * 1024**3,
+    )
+    client = cluster.get_client()
+    set_up_dask_client()
+    client = get_client()
+    assert client.cluster.name == "custom"
+    workers = client.scheduler_info()["workers"]
+    assert len(workers) == 3
+    assert all(worker["nthreads"] == 2 for worker in workers.values())
+    assert sum(worker["memory_limit"] / 1024**3 for worker in workers.values()) == memory_limit * n_workers

--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -111,6 +111,8 @@ def test_set_up_dask_client_default() -> None:
 
     set_up_dask_client()
     client = get_client()
+    assert isinstance(client.cluster, LocalCluster)
+    assert client.cluster.name == "pseudopeople_dask_cluster"
     workers = client.scheduler_info()["workers"]  # type: ignore[no-untyped-call]
     assert len(workers) == CPU_COUNT
     assert all(worker["nthreads"] == 1 for worker in workers.values())

--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -121,8 +121,8 @@ def test_set_up_dask_client_default() -> None:
             raise RuntimeError(
                 "You are on Slurm but SLURM_MEM_PER_NODE is not set. "
                 "It is likely that you are SSHed onto a node (perhaps using VSCode). "
-                "In this case, dask will assign the total memory of the node to each "
-                "worker instead of the allocated memory from the srun call. "
+                "In this case, dask will assign the total memory of the node to the "
+                "cluster instead of the allocated memory from the srun call. "
                 "Pseudopeople should only be used on Slurm directly on the node "
                 "assigned via an srun (both for pytests as well as actual work)."
             )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,3 +1,4 @@
+
 import numpy as np
 import pandas as pd
 import pytest

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import math
+import shutil
 from collections.abc import Callable
-from functools import partial
 from typing import Any
 
 import numpy as np
@@ -190,3 +190,15 @@ def get_single_noise_type_config(
                     ] = new_probability
 
     return config_dict
+
+
+def is_on_slurm() -> bool:
+    """Returns True if the current environment is a SLURM cluster.
+
+    Notes
+    -----
+    This function simply checks for the presence of the `sbatch` command to _infer_
+    if SLURM is installed. It does _not_ check if SLURM is currently active or
+    managing jobs.
+    """
+    return shutil.which("sbatch") is not None


### PR DESCRIPTION
## Change default Dask client

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5523

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

Dask by default uses a threaded scheduler which isn't helpful for these workloads.
This fixes it so that if first checks to see if a dask cluster is set up and, if so,
just uses that. If one isn't, it uses a `LocalCluster` with threads per node = 1.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.


*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [x] all tests pass (`pytest --runslow`)
