### PR TITLE
update do not respond fuzzy checker

### DIFF
--- a/src/pseudopeople/noise_level.py
+++ b/src/pseudopeople/noise_level.py
@@ -31,7 +31,7 @@ def _get_census_omission_noise_levels(
         .astype(str)
         .map(data_values.DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_RACE)
     )
-    ages = pd.Series(np.arange(population["age"].max() + 1))
+    ages = pd.Series(np.arange(population["age"].astype(int).max() + 1))
     for sex in ["Female", "Male"]:
         effect_by_age_bin = data_values.DO_NOT_RESPOND_ADDITIVE_PROBABILITY_BY_SEX_AGE[sex]
         # NOTE: calling pd.cut on a large array with an IntervalIndex is slow,
@@ -44,7 +44,7 @@ def _get_census_omission_noise_levels(
         )
         sex_mask = population["sex"] == sex
         probabilities[sex_mask] += (
-            population[sex_mask]["age"].map(effect_by_age).astype(float)
+            population[sex_mask]["age"].astype(int).map(effect_by_age).astype(float)
         )
     probabilities[probabilities < 0.0] = 0.0
     probabilities[probabilities > 1.0] = 1.0

--- a/tests/integration/release/test_release.py
+++ b/tests/integration/release/test_release.py
@@ -132,7 +132,7 @@ def test_do_not_respond(
         observed_numerator=len(original_data) - len(noised_data),
         observed_denominator=len(original_data),
         # 3% uncertainty on either side
-        target_proportion=(expected_noise *.97, expected_noise*1.03),
+        target_proportion=(expected_noise * 0.97, expected_noise * 1.03),
         name_additional=f"noised_data",
     )
     assert set(noised_data.columns) == set(original_data.columns)

--- a/tests/integration/release/test_release.py
+++ b/tests/integration/release/test_release.py
@@ -131,7 +131,8 @@ def test_do_not_respond(
         name="test_do_not_respond",
         observed_numerator=len(original_data) - len(noised_data),
         observed_denominator=len(original_data),
-        target_proportion=expected_noise,
+        # 3% uncertainty on either side
+        target_proportion=(expected_noise *.97, expected_noise*1.03),
         name_additional=f"noised_data",
     )
     assert set(noised_data.columns) == set(original_data.columns)


### PR DESCRIPTION
## update do not respond fuzzy checker

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-5893](https://jira.ihme.washington.edu/browse/MIC-5893)

Use a range instead of single value when fuzzy checking do not respond, expanding by 3% on both sides as described [here](https://github.com/ihmeuw/vivarium_research/pull/1600/files).

### Testing
Ran test on acs, cps, and census sample data and acs and cps for full scale data.
