### PR TITLE
set up dask client test fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,4 +18,4 @@ Updating the shared repo will take affect on the next pipeline invocation.
 The "_" denotes that all modules will be imported from the shared library.
 */ 
 @Library("vivarium_build_utils") _
-reusable_pipeline(scheduled_branches: ["main", "release-candidate/v.orange.rebased"], upstream_repos: ["layered_config_tree"])
+reusable_pipeline(scheduled_branches: ["main", "epic/full_scale_testing", "release-candidate/v.orange.rebased"], upstream_repos: ["layered_config_tree"])

--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -104,10 +104,16 @@ def test_validate_source_compatibility_wrong_directory(tmp_path: Path) -> None:
 
 
 def test_set_up_dask_client_default() -> None:
-
-    # There should be no dask client yet
-    with pytest.raises(ValueError):
+    # Shut down a client if it exists
+    try:
         client = get_client()
+        client.shutdown()
+    except ValueError:
+        pass
+    finally:
+        # There should be no dask client at this point
+        with pytest.raises(ValueError):
+            client = get_client()
 
     set_up_dask_client()
     client = get_client()


### PR DESCRIPTION
## set up dask client test fix

### Description
- *Category*: bugfix
- *JIRA issue*: hotfix

When we run pytest --runslow, there are tests that run dask and set up a client which persists in the next tests. We were making an assumption that there is no dask client in test_set_up_dask_client_default. This PR shuts down a client if one already exists.

### Testing
Ran pytest --runslow. 
