### PR TITLE
pin pyarrow <v20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
         "numpy<2.0.0",
         "pyyaml>=5.1",
         "vivarium>=1.2.0",
-        "pyarrow",
+        "pyarrow>=19.0.1,<20.0.0",
         "tqdm",
         "layered_config_tree>=1.0.1",
     ]


### PR DESCRIPTION
## Pin pyarrow>=19.0.0,<20.0.0

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: na

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> we pandas started pulling in the just-released pyarrow v20
as the default parquet engine. Interestingly, v20 is not marked
stable and there is no changelog or anything - we suspect it is a
mistake on apache's end. Regardless, we can't use it yet.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [x] all tests pass (`pytest --runslow`)
