### PR TITLE
don't fuzzy check empty shards in guardian duplication

### DIFF
--- a/tests/integration/release/test_release.py
+++ b/tests/integration/release/test_release.py
@@ -283,6 +283,10 @@ def test_full_release_noising(
 
                     fuzzy_check_kwargs = {}
                     if noise_type == NOISE_TYPES.duplicate_with_guardian:
+                        # don't perform checks if no simulants in shard were
+                        # eligible for noising
+                        if total_counts["denominator"] == 0:
+                            continue
                         fuzzy_check_kwargs = {
                             col: total_counts[col]
                             for col in total_counts.index

--- a/tests/integration/release/test_release.py
+++ b/tests/integration/release/test_release.py
@@ -283,10 +283,6 @@ def test_full_release_noising(
 
                     fuzzy_check_kwargs = {}
                     if noise_type == NOISE_TYPES.duplicate_with_guardian:
-                        # don't perform checks if no simulants in shard were
-                        # eligible for noising
-                        if total_counts["denominator"] == 0:
-                            continue
                         fuzzy_check_kwargs = {
                             col: total_counts[col]
                             for col in total_counts.index

--- a/tests/integration/release/utilities.py
+++ b/tests/integration/release/utilities.py
@@ -234,24 +234,26 @@ def fuzzy_check_duplicate_with_guardian(
             DATASET_SCHEMAS.census.name, probability_name
         )
     # Test that noising affects expected proportion with expected types
-    with check:
-        fuzzy_checker.fuzzy_assert_proportion(
-            name="test_duplicate_guardian",
-            observed_numerator=household_under_18_duplications,
-            observed_denominator=household_under_18_eligible,
-            target_proportion=expected_noise[Keys.ROW_PROBABILITY_IN_HOUSEHOLDS_UNDER_18],
-            name_additional="household_under_18_duplications",
-        )
-    with check:
-        fuzzy_checker.fuzzy_assert_proportion(
-            name="test_duplicate_guardian",
-            observed_numerator=college_under_24_duplications,
-            observed_denominator=college_under_24_eligible,
-            target_proportion=expected_noise[
-                Keys.ROW_PROBABILITY_IN_COLLEGE_GROUP_QUARTERS_UNDER_24
-            ],
-            name_additional="college_under_24_duplications",
-        )
+    if household_under_18_eligible != 0:
+        with check:
+            fuzzy_checker.fuzzy_assert_proportion(
+                name="test_duplicate_guardian",
+                observed_numerator=household_under_18_duplications,
+                observed_denominator=household_under_18_eligible,
+                target_proportion=expected_noise[Keys.ROW_PROBABILITY_IN_HOUSEHOLDS_UNDER_18],
+                name_additional="household_under_18_duplications",
+            )
+    if college_under_24_eligible != 0:
+        with check:
+            fuzzy_checker.fuzzy_assert_proportion(
+                name="test_duplicate_guardian",
+                observed_numerator=college_under_24_duplications,
+                observed_denominator=college_under_24_eligible,
+                target_proportion=expected_noise[
+                    Keys.ROW_PROBABILITY_IN_COLLEGE_GROUP_QUARTERS_UNDER_24
+                ],
+                name_additional="college_under_24_duplications",
+            )
 
 
 def fuzzy_check_do_not_respond_counts(

--- a/tests/integration/release/utilities.py
+++ b/tests/integration/release/utilities.py
@@ -206,14 +206,15 @@ def fuzzy_check_omit_row_counts(
 ) -> None:
     expected_noise = config.get_row_probability(dataset_name, NOISE_TYPES.omit_row.name)
     # Test that noising affects expected proportion with expected types
-    with check:
-        fuzzy_checker.fuzzy_assert_proportion(
-            name="test_omit_row",
-            observed_numerator=numerator,
-            observed_denominator=denominator,
-            target_proportion=expected_noise,
-            name_additional="noised_data",
-        )
+    if denominator != 0:
+        with check:
+            fuzzy_checker.fuzzy_assert_proportion(
+                name="test_omit_row",
+                observed_numerator=numerator,
+                observed_denominator=denominator,
+                target_proportion=expected_noise,
+                name_additional="noised_data",
+            )
 
 
 def fuzzy_check_duplicate_with_guardian(
@@ -270,15 +271,16 @@ def fuzzy_check_do_not_respond_counts(
     if dataset_name is not DATASET_SCHEMAS.census.name:  # is acs or cps
         expected_noise = 0.5 + expected_noise / 2
 
-    # Test that noising affects expected proportion with expected types
-    with check:
-        fuzzy_checker.fuzzy_assert_proportion(
-            name="test_do_not_respond",
-            observed_numerator=numerator,
-            observed_denominator=denominator,
-            target_proportion=expected_noise,
-            name_additional="noised_data",
-        )
+    if denominator != 0:
+        # Test that noising affects expected proportion with expected types
+        with check:
+            fuzzy_checker.fuzzy_assert_proportion(
+                name="test_do_not_respond",
+                observed_numerator=numerator,
+                observed_denominator=denominator,
+                target_proportion=expected_noise,
+                name_additional="noised_data",
+            )
 
 
 def run_guardian_duplication_tests(


### PR DESCRIPTION
## don't fuzzy check empty shards in guardian duplication

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-6178](https://jira.ihme.washington.edu/browse/MIC-6178)

Don't perform fuzzy checks if no simulants were eligible for noising in a shard.
