### PR TITLE
Fix pandas array read only error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.2.6 - 01/05/26**
+
+ - Bugfix: Fix pandas array read only error when loading test data
+
 **1.2.5 - 01/02/26**
 
  - Leverage vivarium_dependencies

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -109,6 +109,8 @@ def split_sample_data_dir_state_edit(tmpdir_factory, split_sample_data_dir):
             # We do not filter by state for SSA
             if dataset_name != DatasetNames.SSA:
                 # Add a state so we can filter for integration tests
+                # Make a copy to avoid read-only categorical array error
+                data = data.copy()
                 state_column = [column for column in data.columns if "state" in column]
                 data.loc[data.reset_index().index % 2 == 0, state_column] = STATE
                 data.to_parquet(outdir / data_path.name)
@@ -208,6 +210,8 @@ def noised_sample_data_taxes_1040(config):
 def sample_data_decennial_census_state_edit():
     data = _load_sample_data(DATASETS.census.name)
     # Set half of the entries to the state we'll filter on
+    # Make a copy to avoid read-only categorical array error
+    data = data.copy()
     data.loc[data.reset_index().index % 2 == 0, DATASETS.census.state_column_name] = STATE
     return data
 
@@ -216,6 +220,8 @@ def sample_data_decennial_census_state_edit():
 def sample_data_american_community_survey_state_edit():
     data = _load_sample_data(DATASETS.acs.name)
     # Set half of the entries to the state we'll filter on
+    # Make a copy to avoid read-only categorical array error
+    data = data.copy()
     data.loc[data.reset_index().index % 2 == 0, DATASETS.acs.state_column_name] = STATE
     return data
 
@@ -224,6 +230,8 @@ def sample_data_american_community_survey_state_edit():
 def sample_data_current_population_survey_state_edit():
     data = _load_sample_data(DATASETS.cps.name)
     # Set half of the entries to the state we'll filter on
+    # Make a copy to avoid read-only categorical array error
+    data = data.copy()
     data.loc[data.reset_index().index % 2 == 0, DATASETS.cps.state_column_name] = STATE
     return data
 
@@ -232,6 +240,8 @@ def sample_data_current_population_survey_state_edit():
 def sample_data_women_infants_and_children_state_edit():
     data = _load_sample_data(DATASETS.wic.name)
     # Set half of the entries to the state we'll filter on
+    # Make a copy to avoid read-only categorical array error
+    data = data.copy()
     data.loc[data.reset_index().index % 2 == 0, DATASETS.wic.state_column_name] = STATE
     return data
 
@@ -240,6 +250,8 @@ def sample_data_women_infants_and_children_state_edit():
 def sample_data_taxes_w2_and_1099_state_edit():
     data = _load_sample_data(DATASETS.tax_w2_1099.name)
     # Set half of the entries to the state we'll filter on
+    # Make a copy to avoid read-only categorical array error
+    data = data.copy()
     data.loc[
         data.reset_index().index % 2 == 0, DATASETS.tax_w2_1099.state_column_name
     ] = STATE


### PR DESCRIPTION
## Fix pandas array read only error

### Fix array error when loading test data
- *Category*: Bugfix
- *JIRA issue*: [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-XYZ)

-fix error when loading test data and trying to modify categorical array

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [ ] all tests pass (`pytest --runslow`)
