### PR TITLE
Albrja/mic-5839/Fail deploy if changelog date is wrong

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,16 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v3
+      - name: Validate Release Date
+        run: |
+          CHANGELOG_DATE=$(head -n 1 CHANGELOG.rst | grep -oP '\d{2}/\d{2}/\d{2}')          
+          TODAY=$(date +%m/%d/%y)          
+          if [ "$CHANGELOG_DATE" != "$TODAY" ]; then
+            echo "CHANGELOG date: $CHANGELOG_DATE"
+            echo "Today's date: $TODAY"
+            echo "Please update the CHANGELOG.rst with today's date before releasing."
+            exit 1
+          fi
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.2.6 - 01/06/26**
+
+ - Fail deployment if changelog date does not match current date
+
 **1.2.5 - 01/05/26**
 
  - Leverage vivarium_dependencies


### PR DESCRIPTION
## Albrja/mic-5839/Fail deploy if changelog date is wrong

### Fail deploy if changelog date is wrong
- *Category*: Release
- *JIRA issue*: [MIC-5839](https://jira.ihme.washington.edu/browse/MIC-5839)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.

*** REMINDER ***
CI WILL NOT RUN ANY TESTS MARKED AS SLOW (CURRENTLY INCLUDES INTEGRATION TESTS).
MANUALLY RUN SLOW TESTS LIKE `pytest --runslow` WITH EACH PR.
-->
- [ ] all tests pass (`pytest --runslow`)
