### PR TITLE
Speed up noising hot path and fix SettingWithCopyWarning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+**1.2.9 - 06/07/26**
+
+ - Performance: size the randomness IndexMap to the data instead of a 1,000,000 floor, and skip the empty-string-to-NaN replace on categorical columns when it is a no-op (output unchanged)
+ - Fix pandas SettingWithCopyWarning emitted during row and column noising
+
 **1.2.8 - 03/25/26**
 
  - Remove upstream_repos from Jenkinsfile

--- a/src/pseudopeople/interface.py
+++ b/src/pseudopeople/interface.py
@@ -225,15 +225,21 @@ def _clean_input_data(
     dataset: Dataset,
 ) -> pd.DataFrame:
     for col in dataset.columns:
-        # Coerce empty strings to nans
-        data[col.name] = data[col.name].replace("", np.nan)
-
-        if data[col.name].dtype.name == "category" and col.dtype_name == DtypeNames.OBJECT:
-            # We made some columns in the pseudopeople input categorical
-            # purely as a kind of DIY compression.
-            # TODO: Determine whether this is benefitting us after
-            # the switch to Parquet.
-            data[col.name] = to_string(data[col.name])
+        # Coerce empty strings to nans. Calling .replace on a categorical column is
+        # expensive (it validates/rebuilds the category index) and is a no-op unless
+        # "" is actually one of the categories, so skip it in that case.
+        column = data[col.name]
+        if column.dtype.name == "category":
+            if "" in column.cat.categories:
+                data[col.name] = column.replace("", np.nan)
+            if col.dtype_name == DtypeNames.OBJECT:
+                # We made some columns in the pseudopeople input categorical
+                # purely as a kind of DIY compression.
+                # TODO: Determine whether this is benefitting us after
+                # the switch to Parquet.
+                data[col.name] = to_string(data[col.name])
+        else:
+            data[col.name] = column.replace("", np.nan)
 
     return data
 
@@ -296,7 +302,9 @@ def _zfill_fast(col: pd.Series, desired_length: int) -> pd.Series:
 def _extract_columns(columns_to_keep, noised_dataset):
     """Helper function for test mocking purposes"""
     if columns_to_keep:
-        noised_dataset = noised_dataset[[c.name for c in columns_to_keep]]
+        # .copy() so downstream in-place dtype coercion does not operate on a
+        # column-subset view (avoids pandas SettingWithCopyWarning).
+        noised_dataset = noised_dataset[[c.name for c in columns_to_keep]].copy()
     return noised_dataset
 
 

--- a/src/pseudopeople/noise_functions.py
+++ b/src/pseudopeople/noise_functions.py
@@ -54,7 +54,9 @@ def omit_rows(
         randomness_stream,
         f"{dataset_name}_omit_choice",
     )
-    noised_data = dataset_data.loc[dataset_data.index.difference(to_noise_index)]
+    # .copy() so subsequent column noise mutates an owned frame rather than a
+    # slice view (avoids pandas SettingWithCopyWarning).
+    noised_data = dataset_data.loc[dataset_data.index.difference(to_noise_index)].copy()
 
     return noised_data
 
@@ -137,7 +139,9 @@ def apply_do_not_respond(
     to_noise_idx = get_index_to_noise(
         dataset_data, noise_levels, randomness_stream, f"do_not_respond_{dataset_name}"
     )
-    noised_data = dataset_data.loc[dataset_data.index.difference(to_noise_idx)]
+    # .copy() so subsequent column noise mutates an owned frame rather than a
+    # slice view (avoids pandas SettingWithCopyWarning).
+    noised_data = dataset_data.loc[dataset_data.index.difference(to_noise_idx)].copy()
 
     return noised_data
 

--- a/src/pseudopeople/utilities.py
+++ b/src/pseudopeople/utilities.py
@@ -16,7 +16,15 @@ from pseudopeople.dtypes import DtypeNames
 
 
 def get_randomness_stream(dataset_name: str, seed: Any, index: pd.Index) -> RandomnessStream:
-    map_size = max(1_000_000, max(index) * 2)
+    # pseudopeople builds a fresh stream per shard with no CRN key columns, so the
+    # IndexMap is just an identity lookup that needs to be large enough to index
+    # every value in ``index`` (the ``* 2`` leaves headroom for rows added by
+    # duplication noise). RandomnessStream.get_draw samples an array the size of
+    # the IndexMap on every draw, so the previous 1_000_000 floor generated ~1M
+    # random numbers per draw even for tiny shards. Sizing to the data avoids that
+    # waste; output is unchanged because numpy's RandomState yields the same stream
+    # prefix for any sufficiently large sample size.
+    map_size = max(index) * 2 + 2 if len(index) else 2
     return RandomnessStream(
         key=dataset_name,
         clock=lambda: pd.Timestamp("2020-04-01"),

--- a/tests/unit/test_noise_form.py
+++ b/tests/unit/test_noise_form.py
@@ -124,7 +124,9 @@ def test_noise_order(mocker, dummy_data, dataset):
     )
     for field in NOISE_TYPES._fields:
         mock_return = (
-            dummy_data[["event_type"]]
+            # .copy() to mirror the real row-noise functions, which return an owned
+            # frame rather than a slice view of the input.
+            dummy_data[["event_type"]].copy()
             if field
             in [
                 NOISE_TYPES.do_not_respond.name,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -8,6 +8,7 @@ from pseudopeople.dtypes import DtypeNames
 from pseudopeople.noise_functions import _corrupt_tokens
 from pseudopeople.utilities import (
     get_index_to_noise,
+    get_randomness_stream,
     to_string_as_integer,
     two_d_array_choice,
     vectorized_choice,
@@ -261,3 +262,31 @@ def test_two_d_array_choice(fuzzy_checker: FuzzyChecker):
                 target_proportion=1 / num_choices,
                 name_additional=f"team {team} for sport {sport}",
             )
+
+
+def test_get_randomness_stream_is_sized_to_the_data():
+    # The IndexMap is sized to the data (with headroom), not floored at 1,000,000,
+    # so get_draw does not generate ~1M random numbers per draw on small shards.
+    index = pd.RangeIndex(100)
+    stream = get_randomness_stream("decennial_census", 0, index)
+    assert len(stream.index_map) == max(index) * 2 + 2
+    assert len(stream.index_map) < 1_000_000
+
+
+@pytest.mark.parametrize("n", [1, 93, 9_287])
+def test_get_randomness_stream_draws_unchanged_by_sizing(n):
+    # Right-sizing the IndexMap must not change the random draws: numpy's
+    # RandomState yields the same stream prefix for any sufficiently large size,
+    # and the (no-CRN) IndexMap is an identity lookup.
+    index = pd.RangeIndex(n)
+    data_sized = get_randomness_stream("decennial_census", 0, index)
+    one_million = RandomnessStream(
+        key="decennial_census",
+        clock=lambda: pd.Timestamp("2020-04-01"),
+        seed=0,
+        index_map=IndexMap(size=max(1_000_000, max(index) * 2)),
+    )
+    pd.testing.assert_series_equal(
+        data_sized.get_draw(index, additional_key="x"),
+        one_million.get_draw(index, additional_key="x"),
+    )


### PR DESCRIPTION
## Title:   Speed up noising and fix SettingWithCopyWarning<!-- Ideally, <=50 chars. 50 chars is here..: -->

  - *Category*: refactor (performance; also fixes a SettingWithCopyWarning)
  - *JIRA issue*: none

  Three output-preserving cleanups in the per-shard noising hot path,
  motivated by profiling on a real state-sized input (where generation is
  dominated by per-shard fixed costs, not row volume):

  - `get_randomness_stream`: size the Vivarium `IndexMap` to the data
    (with headroom for duplication noise) instead of flooring it at
    1,000,000. `RandomnessStream.get_draw` samples an array the size of
    the `IndexMap` on *every* draw, so the floor generated ~1M random
    numbers per draw even for tiny shards.
  - `_clean_input_data`: skip the empty-string->NaN `.replace` on
    categorical columns when "" is not a category. On a categorical,
    `.replace` validates/rebuilds the category index and is otherwise a
    no-op.
  - Fix the pandas `SettingWithCopyWarning` emitted during row/column
    noising: the row-omission noise functions and the output column
    extractor now return owned frames rather than slice views.

  Guidance to reviewers: the `IndexMap` change does **not** change output.
  numpy's `RandomState` yields the same stream prefix for any sufficiently
  large size, and (with no CRN key columns) the map is an identity lookup,
  so the draws are unchanged — `test_get_randomness_stream_draws_unchanged
  _by_sizing` asserts the draws match the old 1,000,000-sized map. Output
  was also verified bit-identical end-to-end across census/W2/SSA/1040.
  Measured ~2.18x faster per-shard noising from the first two changes.

  ### Testing

  - Unit and integration suites both run with `SettingWithCopyWarning`
    raised as an error (`-W error::pandas.errors.SettingWithCopyWarning`)
    to confirm the warning is gone from both the pandas and dask paths:
    unit 182 passed, integration 165 passed / 7 skipped.
  - New regression tests: the `IndexMap` is data-sized (not 1M) and its
    draws are unchanged vs the old floor (n = 1, 93, 9,287).
  - [x] all tests pass (`pytest --runslow`)